### PR TITLE
Make disk alerts persistent

### DIFF
--- a/cookbooks/collectd/templates/default/collectd.conf.erb
+++ b/cookbooks/collectd/templates/default/collectd.conf.erb
@@ -231,7 +231,9 @@ LoadPlugin threshold
       WarningMax    <%= @disk_thresholds.warning_for('/') %>
       FailureMin    0.00
       FailureMax    <%= @disk_thresholds.failure_for('/') %>
-      DataSource "value"
+      DataSource    "value"
+      Persist       true
+      Hits          10
     </Type>
     </Plugin>
 
@@ -245,7 +247,9 @@ LoadPlugin threshold
       WarningMax    <%= @disk_thresholds.warning_for('/db') %>
       FailureMin    0.00
       FailureMax    <%= @disk_thresholds.failure_for('/db') %>
-      DataSource "value"
+      DataSource    "value"
+      Persist       true
+      Hits          10
     </Type>
     </Plugin>
   <% end %>
@@ -258,7 +262,9 @@ LoadPlugin threshold
       WarningMax    <%= @disk_thresholds.warning_for('/data') %>
       FailureMin    0.00
       FailureMax    <%= @disk_thresholds.failure_for('/data') %>
-      DataSource "value"
+      DataSource    "value"
+      Persist       true
+      Hits          10
     </Type>
     </Plugin>
 
@@ -270,7 +276,9 @@ LoadPlugin threshold
       WarningMax    <%= @disk_thresholds.warning_for('/mnt') %>
       FailureMin    0.00
       FailureMax    <%= @disk_thresholds.failure_for('/mnt') %>
-      DataSource "value"
+      DataSource    "value"
+      Persist       true
+      Hits          10
     </Type>
   </Plugin>
 


### PR DESCRIPTION
(opened on behalf of @crigor)

This sends a collectd notification every 5 or 6 minutes. AWSM will disregard alerts within 1 hour so essentially this will generate disk alerts every hour.

The current behavior sends 1 alert on state change (warning -> failure or okay -> failure). If you miss that one failure alert you'll never get notified again.

This affects warning too though. So if your disk is in the warning level you'll get an hourly alert and email.
