### PR TITLE
CC-1030 /var/lib/nginx/tmp permissions

### DIFF
--- a/cookbooks/nginx/recipes/configure.rb
+++ b/cookbooks/nginx/recipes/configure.rb
@@ -122,6 +122,12 @@ directory "/var/log/engineyard/nginx" do
   mode 0755
 end
 
+directory "/var/lib/nginx/tmp"
+  owner 'deploy'
+  group 'nginx'
+  mode 0755
+end
+
 logrotate "nginx" do
   files "/var/log/engineyard/nginx/*log"
   copy_then_truncate true


### PR DESCRIPTION
Description of your patch
-------------
Fixed /var/lib/nginx/tmp permissions on creation for uploads via nginx

Recommended Release Notes
-------------
Fix tmp permissions for nginx uploads


Estimated risk
-------------
Low

Components involved
-------------
Nginx

Description of testing done
-------------
Ran Chef with change without errors

QA Instructions
-------------
1. Build environment on stable stack
1. Ensure chef completes successfully and app deploys and runs as expected
1. Upgrade to target stack
1. Verify chef run completes successfully
1. Verify the correct permissions and owners on `/var/lib/nginx/tmp` with ls -lah  are 755 and deploy: nginx


1. Terminate and recreate environment on target stack
1. Verify chef run completes successfully
1. Verify the correct permissions and owners on `/var/lib/nginx/tmp` with ls -lah  are 755 and deploy: nginx

