### PR TITLE
CC-1038 PHP 5.6 Security Updates

### DIFF
--- a/cookbooks/php/attributes/php.rb
+++ b/cookbooks/php/attributes/php.rb
@@ -1,2 +1,2 @@
-default['php']['version'] = "5.6.21"
+default['php']['version'] = "5.6.25"
 default['php']['full_atom'] = "dev-lang/php"


### PR DESCRIPTION
Description of your patch
-------------
Updated PHP 5.6 to 5.6.25 for security fixes

Recommended Release Notes
-------------
Update PHP to 5.6.25.


Estimated risk
-------------
Low

Components involved
-------------
PHP

Description of testing done
-------------
Ran Chef with change without errors and  verified the php version with `php -v` lists `PHP 5.6.25-pl0-gentoo` at the beginning of the banner

QA Instructions
-------------
1. Build environment on stable stack
1. Ensure chef completes successfully and app deploys and runs as expected
1. Upgrade to target stack
1. Verify chef run completes successfully
1. Verify the php version with `php -v` lists `PHP 5.6.25-pl0-gentoo` at the beginning of the banner

1. Terminate and recreate environment on target stack
1. Verify chef run completes successfully
1. Verify the php version with `php -v` lists `PHP 5.6.25-pl0-gentoo` at the beginning of the banner

