### PR TITLE
CC-1037 Resolve new relic for php installation issue

### DIFF
--- a/cookbooks/newrelic/providers/default.rb
+++ b/cookbooks/newrelic/providers/default.rb
@@ -44,8 +44,8 @@ def install_php_rpm
     recursive true
   end
 
-  remote_file "/opt/php_rpm/newrelic-php5-#{node.dna['newrelic']['php_rpm_version']}-linux.tar.gz" do
-    source "http://download.newrelic.com/php_agent/archive/#{node.dna['newrelic']['php_rpm_version']}/newrelic-php5-#{node.dna['newrelic']['php_rpm_version']}-linux.tar.gz"
+  remote_file "/opt/php_rpm/newrelic-php5-#{node['newrelic']['php_rpm_version']}-linux.tar.gz" do
+    source "http://download.newrelic.com/php_agent/archive/#{node['newrelic']['php_rpm_version']}/newrelic-php5-#{node['newrelic']['php_rpm_version']}-linux.tar.gz"
     action :create_if_missing
   end
 
@@ -56,8 +56,8 @@ def install_php_rpm
     code <<-EOH
       export NR_INSTALL_SILENT='true'
       export NR_INSTALL_KEY="#{newrelic_license_key}"
-      gzip -dc newrelic-php5-#{node.dna['newrelic']['php_rpm_version']}-linux.tar.gz | tar xf -
-      cd newrelic-php5-#{node.dna['newrelic']['php_rpm_version']}-linux
+      gzip -dc newrelic-php5-#{node['newrelic']['php_rpm_version']}-linux.tar.gz | tar xf -
+      cd newrelic-php5-#{node['newrelic']['php_rpm_version']}-linux
       ./newrelic-install install
     EOH
     action :run


### PR DESCRIPTION
Description of your patch
-------------
Fixed node call for new relic php installation resulting in fixing php installation of new relic

Recommended Release Notes
-------------
Resolve an issue installing New Relic for PHP stacks


Estimated risk
-------------
Low

Components involved
-------------
PHP and New Relic

Description of testing done
-------------
Ran Chef with change without errors while new relic was installed

QA Instructions
-------------
1. Build environment on stable php stack
1. Add New Relic to the environment, chef will not complete
1. Upgrade to target stack
1. Verify chef run completes successfully
1. Verify newrelic-daemon is listed on instance as running by looking at output of `monit summary | grep newrelic`

1. Terminate and recreate environment on target stack
1. Verify chef run completes successfully
1. Verify newrelic-daemon is listed on instance as running by looking at output of `monit summary | grep newrelic`

