### PR TITLE
CC-1044 Libuv For Nodejs 6.4.0

### DIFF
--- a/cookbooks/node/attributes/node.rb
+++ b/cookbooks/node/attributes/node.rb
@@ -28,6 +28,9 @@ if (node.engineyard.metadata('openssl_ebuild_version','1.0.1') =~ /1\.0\.1/)
   ])
 end
 
+#Note Libuv is required for newer nodejs versions
+default['nodejs']['libuv']['version'] = '1.9.1'
+
 # Note: see cookbooks/node/recipes/common.rb to set the package for any new versions
 
 default['coffeescript']['version'] = node.engineyard.metadata('coffeescript_version','1.9.3')

--- a/cookbooks/node/recipes/common.rb
+++ b/cookbooks/node/recipes/common.rb
@@ -8,6 +8,10 @@ unmask_package "dev-libs/libuv" do
   unmaskfile "libuv"
 end
 
+enable_package 'dev-libs/libuv' do
+  version node['nodejs']['libuv']['version']
+end
+
 directory "/mnt/node/tmp" do
   action :delete
   recursive true

--- a/cookbooks/node/recipes/common.rb
+++ b/cookbooks/node/recipes/common.rb
@@ -3,6 +3,11 @@ get_package_name = {
 }
 get_package_name.default = 'net-libs/nodejs'
 
+unmask_package "dev-libs/libuv" do
+  version node['nodejs']['libuv']['version']
+  unmaskfile "libuv"
+end
+
 directory "/mnt/node/tmp" do
   action :delete
   recursive true


### PR DESCRIPTION
Description of your patch
-------------
Enable Libuv 1.9.1

Recommended Release Notes
-------------
Resolve an issue installing NodeJS 6.4.0


Estimated risk
-------------
Low

Components involved
-------------
Nodejs

Description of testing done
-------------
Ran Chef with change and verified that running `emerge -g =net-libs-6.4.0` installs without errors

QA Instructions
-------------
1. Build environment on stable stack
1. Running `emerge -g =net-libs-6.4.0` will not run on the instance
1. Upgrade to target stack
1. Verify chef run completes successfully
1. Verify `emerge -g =net-libs-6.4.0` runs correctly

1. Terminate and recreate environment on target stack
1. Verify chef run completes successfully
1. Verify `emerge -g =net-libs-6.4.0` runs correctly
