### PR TITLE
Fix sequelizejs to use framework_env variable.

### DIFF
--- a/cookbooks/sequelizejs/recipes/default.rb
+++ b/cookbooks/sequelizejs/recipes/default.rb
@@ -22,6 +22,7 @@ if ['solo', 'app_master', 'app', 'util'].include?(node['dna']['instance_role'])
       mode 0644
       source 'config.json.erb'
       variables({
+        :environment => node[:dna][:environment][:framework_env],
         :dialect => node[:sequelizejs][:dialect],
         :database => database_name,
         :username => node['dna']['engineyard']['environment']['ssh_username'],

--- a/cookbooks/sequelizejs/templates/default/config.json.erb
+++ b/cookbooks/sequelizejs/templates/default/config.json.erb
@@ -1,5 +1,5 @@
 {
-  "production": {
+  "<%= @environment %>": {
     "username": "<%= @username %>",
     "password": "<%= @password %>",
     "database": "<%= @database %>",


### PR DESCRIPTION
Previously, the sequelizejs recipe generates a config.json with a hardcoded framework env `production`. This causes issues if you use the recipe in environments with NODE_ENV not set to "production". This fix will get the environment from `node[:dna][:environment][:framework_env]` to generate the proper config.json.

I have tested this against the basic-chat app with NODE_ENV set to "development".
