### PR TITLE
Data 417

### DIFF
--- a/cookbooks/mysql/attributes/version.rb
+++ b/cookbooks/mysql/attributes/version.rb
@@ -1,4 +1,5 @@
 lock_major_version = %x{[[ -f "/db/.lock_db_version" ]] && grep -E -o '^[0-9]+\.[0-9]+' /db/.lock_db_version }
+full_version =  %x{[[ -f "/db/.lock_db_version" ]] && grep -E -o '^[0-9]+\.[0-9]+\.[0-9]+' /db/.lock_db_version }
 db_stack = lock_major_version == '' ? attribute.dna['engineyard']['environment']['db_stack_name'] :  "mysql#{lock_major_version.gsub(/\./, '_').strip}"
 
 default['latest_version_56'] = '5.6.29'
@@ -16,7 +17,7 @@ when 'mysql5_7', 'aurora5_7', 'mariadb10_1'
 
 end
 
-
+default['mysql']['full_version'] = full_version == '' ? node['mysql']['latest_version'] : full_version
 default['mysql']['virtual'] = major_version
 default['mysql']['short_version'] = major_version
 default['mysql']['logbase'] = "/db/mysql/#{major_version}/log/"

--- a/cookbooks/mysql/recipes/default.rb
+++ b/cookbooks/mysql/recipes/default.rb
@@ -35,6 +35,7 @@ managed_template "/etc/mysql/my.cnf" do
     :mysql_version => Gem::Version.new(node['mysql']['short_version']),
     :mysql_5_5 => Gem::Version.new('5.5'),
     :mysql_5_6 => Gem::Version.new('5.6'),
+    :mysql_full_version => Gem::Version.new(node['mysql']['full_version']),
     :logbase => node['mysql']['logbase'],
     :innodb_buff => innodb_buff,
     :replication_master => node.dna['instance_role'] == 'db_master',

--- a/cookbooks/mysql/recipes/default.rb
+++ b/cookbooks/mysql/recipes/default.rb
@@ -35,7 +35,7 @@ managed_template "/etc/mysql/my.cnf" do
     :mysql_version => Gem::Version.new(node['mysql']['short_version']),
     :mysql_5_5 => Gem::Version.new('5.5'),
     :mysql_5_6 => Gem::Version.new('5.6'),
-    :mysql_full_version => Gem::Version.new(node['mysql']['full_version']),
+    :mysql_full_version => node['mysql']['full_version'],
     :logbase => node['mysql']['logbase'],
     :innodb_buff => innodb_buff,
     :replication_master => node.dna['instance_role'] == 'db_master',

--- a/cookbooks/mysql/templates/default/my.conf.erb
+++ b/cookbooks/mysql/templates/default/my.conf.erb
@@ -178,6 +178,7 @@ query_cache_type		= 1
 [mysqldump]
 quick
 max_allowed_packet		= 128M
+hex-blob
 
 [mysql]
 # uncomment the next directive if you are not familiar with SQL

--- a/cookbooks/mysql/templates/default/my.conf.erb
+++ b/cookbooks/mysql/templates/default/my.conf.erb
@@ -178,7 +178,9 @@ query_cache_type		= 1
 [mysqldump]
 quick
 max_allowed_packet		= 128M
+<% if @mysql_full_version >= '5.6.21' %>
 hex-blob
+<% end %>
 
 [mysql]
 # uncomment the next directive if you are not familiar with SQL


### PR DESCRIPTION
Description of your patch
--------------

Adds the `hex-blob` option to the default my.cnf file under the `[mysqldump]` section to address MySQL bug http://bugs.mysql.com/bug.php?id=43544


Recommended Release Notes
--------------
Adds a mysqldump configuration option to improve the reliability of logical backups on MySQL 5.6.21+

Estimated risk
--------------

Low
- This does not impact the function of the database server and only affects how logical backups are processed by `mysqldump`

Components involved
--------------

$ git diff master --name-only
cookbooks/mysql/attributes/version.rb
cookbooks/mysql/recipes/default.rb
cookbooks/mysql/templates/default/my.conf.erb


Description of testing done
--------------

Created a cluster with the ToDo application using the current v5 stack.
Using the mysql client:
  use todo;
  create table t1 (c1 POINT);
  insert into t1 values(GeomFromText('POINT(1 1)'));

Ran  
  mysqldump -necqt --compact todo

Validated 
  the presence of binary characters `<?>` in the output
  INSERT INTO `t1` (`c1`) VALUES ('\0\0\0\0\0\0\0\0\0\0\0\0\0�?\0\0\0\0\0\0�?');

Upgraded to the new stack
Ran  
  mysqldump -necqt --compact todo

Validated
  The result was properly hex formatted
  INSERT INTO `t1` (`c1`) VALUES (0x000000000101000000000000000000F03F000000000000F03F);

QA Instructions
--------------

Recheck the testing scenario above with a 5.7 database stack, you may need to first enable the mysql5_7 feature on your testing account.