### PR TITLE
Cc 1047

### DIFF
--- a/cookbooks/mysql/attributes/version.rb
+++ b/cookbooks/mysql/attributes/version.rb
@@ -2,8 +2,8 @@ lock_major_version = %x{[[ -f "/db/.lock_db_version" ]] && grep -E -o '^[0-9]+\.
 full_version =  %x{[[ -f "/db/.lock_db_version" ]] && grep -E -o '^[0-9]+\.[0-9]+\.[0-9]+' /db/.lock_db_version }
 db_stack = lock_major_version == '' ? attribute.dna['engineyard']['environment']['db_stack_name'] :  "mysql#{lock_major_version.gsub(/\./, '_').strip}"
 
-default['latest_version_56'] = '5.6.29'
-default['latest_version_57'] = '5.7.13'
+default['latest_version_56'] = '5.6.32'
+default['latest_version_57'] = '5.7.14'
 major_version=''
 
 case db_stack

--- a/cookbooks/mysql/attributes/version.rb
+++ b/cookbooks/mysql/attributes/version.rb
@@ -1,4 +1,5 @@
 lock_major_version = %x{[[ -f "/db/.lock_db_version" ]] && grep -E -o '^[0-9]+\.[0-9]+' /db/.lock_db_version }
+full_version =  %x{[[ -f "/db/.lock_db_version" ]] && grep -E -o '^[0-9]+\.[0-9]+\.[0-9]+' /db/.lock_db_version }
 db_stack = lock_major_version == '' ? attribute.dna['engineyard']['environment']['db_stack_name'] :  "mysql#{lock_major_version.gsub(/\./, '_').strip}"
 
 default['latest_version_56'] = '5.6.29'
@@ -16,7 +17,7 @@ when 'mysql5_7', 'aurora5_7', 'mariadb10_1'
 
 end
 
-
+default['mysql']['full_version'] = full_version == '' ? node['mysql']['latest_version'] : full_version
 default['mysql']['virtual'] = major_version
 default['mysql']['short_version'] = major_version
 default['mysql']['logbase'] = "/db/mysql/#{major_version}/log/"

--- a/cookbooks/mysql/recipes/default.rb
+++ b/cookbooks/mysql/recipes/default.rb
@@ -35,6 +35,7 @@ managed_template "/etc/mysql/my.cnf" do
     :mysql_version => Gem::Version.new(node['mysql']['short_version']),
     :mysql_5_5 => Gem::Version.new('5.5'),
     :mysql_5_6 => Gem::Version.new('5.6'),
+    :mysql_full_version => Gem::Version.new(node['mysql']['full_version']),
     :logbase => node['mysql']['logbase'],
     :innodb_buff => innodb_buff,
     :replication_master => node.dna['instance_role'] == 'db_master',

--- a/cookbooks/mysql/recipes/default.rb
+++ b/cookbooks/mysql/recipes/default.rb
@@ -35,7 +35,7 @@ managed_template "/etc/mysql/my.cnf" do
     :mysql_version => Gem::Version.new(node['mysql']['short_version']),
     :mysql_5_5 => Gem::Version.new('5.5'),
     :mysql_5_6 => Gem::Version.new('5.6'),
-    :mysql_full_version => Gem::Version.new(node['mysql']['full_version']),
+    :mysql_full_version => node['mysql']['full_version'],
     :logbase => node['mysql']['logbase'],
     :innodb_buff => innodb_buff,
     :replication_master => node.dna['instance_role'] == 'db_master',

--- a/cookbooks/mysql/recipes/install.rb
+++ b/cookbooks/mysql/recipes/install.rb
@@ -4,7 +4,7 @@ lock_version_file = '/db/.lock_db_version'
 db_running = %x{mysql -N -e "select 1;" 2> /dev/null}.strip == '1'
 
 known_versions = {
-  'dev-db/percona-server' => ['5.6.28.76.1', '5.6.29.76.2-r1', '5.6.32-78.0', '5.7.13.6', '5.7.14-7']
+  'dev-db/percona-server' => ['5.6.28.76.1', '5.6.29.76.2-r1', '5.6.32.78.0', '5.7.13.6', '5.7.14.7']
 }
 
 execute "dropping lock version file" do

--- a/cookbooks/mysql/recipes/install.rb
+++ b/cookbooks/mysql/recipes/install.rb
@@ -4,7 +4,7 @@ lock_version_file = '/db/.lock_db_version'
 db_running = %x{mysql -N -e "select 1;" 2> /dev/null}.strip == '1'
 
 known_versions = {
-  'dev-db/percona-server' => ['5.6.28.76.1', '5.6.29.76.2-r1', '5.6.32.78.0', '5.7.13.6', '5.7.14.7']
+  'dev-db/percona-server' => ['5.6.28.76.1', '5.6.29.76.2-r1', '5.6.32.78.1', '5.7.13.6', '5.7.14.8']
 }
 
 execute "dropping lock version file" do

--- a/cookbooks/mysql/recipes/install.rb
+++ b/cookbooks/mysql/recipes/install.rb
@@ -4,7 +4,7 @@ lock_version_file = '/db/.lock_db_version'
 db_running = %x{mysql -N -e "select 1;" 2> /dev/null}.strip == '1'
 
 known_versions = {
-  'dev-db/percona-server' => ['5.6.28.76.1', '5.6.29.76.2-r1', '5.7.13.6']
+  'dev-db/percona-server' => ['5.6.28.76.1', '5.6.29.76.2-r1', '5.6.32-78.0', '5.7.13.6', '5.7.14-7']
 }
 
 execute "dropping lock version file" do

--- a/cookbooks/mysql/templates/default/my.conf.erb
+++ b/cookbooks/mysql/templates/default/my.conf.erb
@@ -178,6 +178,7 @@ query_cache_type		= 1
 [mysqldump]
 quick
 max_allowed_packet		= 128M
+hex-blob
 
 [mysql]
 # uncomment the next directive if you are not familiar with SQL

--- a/cookbooks/mysql/templates/default/my.conf.erb
+++ b/cookbooks/mysql/templates/default/my.conf.erb
@@ -178,7 +178,9 @@ query_cache_type		= 1
 [mysqldump]
 quick
 max_allowed_packet		= 128M
+<% if @mysql_full_version >= '5.6.21' %>
 hex-blob
+<% end %>
 
 [mysql]
 # uncomment the next directive if you are not familiar with SQL


### PR DESCRIPTION
Description of your patch
--------------

Updates Percona-Server to 5.6.32 and 5.7.14 to address CVE-2016-6662 and CVE-2016-6663.


Recommended Release Notes
--------------
Adds Percona-Server 5.6.32 and 5.7.14 to address CVE-2016-6662 and CVE-2016-6663. See our [Upgrade Procedures](https://support.cloud.engineyard.com/hc/en-us/articles/205408178-Database-Version-Upgrade-Policies) for additional details about applying this update.

Estimated risk
--------------

Low
- Customers need to take additional steps to apply this update or must have opted in to automatic updates.
- Recommended procedure for databases is to always test new releases in a non-Production environment before upgrading Production.

Components involved
--------------

$ git diff master --name-only
cookbooks/mysql/attributes/version.rb
cookbooks/mysql/recipes/install.rb

Description of testing done
--------------
Under the 16.06 stack

- Provisioned a cluster using the existing Stack with automatic version upgrades disabled (default)
- Ran:
  - `mysqld --version`
- Validated:
  - 5.6.29  (any version prior to 5.6.32 or 5.7.14 is expected)
- Deployed to tpol-2016 dev stack.
- Upgraded the environment,
- Ran: 
  - `mysqld --version`
- Validated
  - 5.6.29 (version should be the same as the prior check)
- Edit environment, remove the check next to "Prevent database version changes", saved change
- Clicked "Apply" for the environment on the dashboard
- Ran:
  - `mysqld --version`
- Validated:
  - 5.6.32
- Ran:
  - `/etc/init.d/mysql restart`
- Validated:
  - MySQL restarts successfully
- Ran:
  - `ls -lah /usr/lib/mysql/plugin/libmemcached.so`
- Validated:
  - The file was listed.

QA Instructions
--------------

Using the 16.06 stack enable the `mysql5_7` feature and boot a cluster running MySQL 5.7.
Repeat the testing above expecting 5.7.14 after the upgrade.

Using the 12.11 stack repeat the 5.6 validation steps above. 5.7 is not currently supported under the 12.11 stack

