### PR TITLE
CC-1048 NodeJS dashboard selection

### DIFF
--- a/cookbooks/node/attributes/node.rb
+++ b/cookbooks/node/attributes/node.rb
@@ -1,4 +1,17 @@
-default['nodejs']['version'] = node.engineyard.environment.metadata('nodejs_version','4.4.5')
+if attribute.dna[:engineyard][:environment][:components].find{|c| c['key'] == 'nodejs_6'}[:value]
+  stack_nodejs_version = '6.4.0'
+elsif attribute.dna[:engineyard][:environment][:components].find{|c| c['key'] == 'nodejs_5'}[:value]
+  stack_nodejs_version = '5.11.0'
+elsif attribute.dna[:engineyard][:environment][:components].find{|c| c['key'] == 'nodejs_4'}[:value]
+  stack_nodejs_version = '4.4.5'
+elsif attribute.dna[:engineyard][:environment][:components].find{|c| c['key'] == 'nodejs_012'}[:value]
+  stack_nodejs_version = '0.12.10'
+else
+  stack_nodejs_version = '4.4.5'
+end
+
+
+default['nodejs']['version'] = node.engineyard.environment.metadata('nodejs_version',"stack_nodejs_version")
 default['nodejs']['available_versions'] = [
   '0.12.6',  # net-libs/nodejs-0.12.6
   '0.12.7',  # net-libs/nodejs-0.12.7

--- a/cookbooks/node/attributes/node.rb
+++ b/cookbooks/node/attributes/node.rb
@@ -1,4 +1,4 @@
-fallback_nodejs_version = case attribute['dna']['engineyard']['environment']['components'].map(&:values).flatten.find(/^nodejs_/).first
+fallback_nodejs_version = case attribute['dna']['engineyard']['environment']['components'].find {|node| node['key'] == 'nodejs'}['value']
                            when 'nodejs_6'
                              '6.4.0'
                            when 'nodejs_5'

--- a/cookbooks/node/attributes/node.rb
+++ b/cookbooks/node/attributes/node.rb
@@ -9,7 +9,7 @@ elsif attribute['dna']['engineyard']['environment']['components'].find{|c| c['ke
 elsif attribute['dna']['engineyard']['environment']['components'].find{|c| c['key'] == 'nodejs_012'}
   default['nodejs']['version'] = '0.12.10'
 else
-  stack_nodejs_version = '4.4.5'
+  default['nodejs']['version'] = '4.4.5'
 end
 
 default['nodejs']['available_versions'] = [

--- a/cookbooks/node/attributes/node.rb
+++ b/cookbooks/node/attributes/node.rb
@@ -1,4 +1,5 @@
-fallback_nodejs_version = case attribute['dna']['engineyard']['environment']['components'].map(&:values).flatten.find(/nodejs/).first
+fallback_nodejs_version = case attribute['dna']['engineyard']['environment']
+  ['components'].map(&:values).flatten.find(/^nodejs_/).first
                            when 'nodejs_6'
                              '6.4.0'
                            when 'nodejs_5'

--- a/cookbooks/node/attributes/node.rb
+++ b/cookbooks/node/attributes/node.rb
@@ -4,7 +4,7 @@ elsif attribute['dna']['engineyard']['environment']['components'][0].first.inclu
   default['nodejs']['version'] = '6.4.0'
 elsif attribute['dna']['engineyard']['environment']['components'][0].first.include?("nodejs_5")
   default['nodejs']['version'] = '5.11.0'
-elsif attribute['dna']['engineyard']['environment']['components'][0].first.include?("nodejs_04")
+elsif attribute['dna']['engineyard']['environment']['components'][0].first.include?("nodejs_4")
   default['nodejs']['version'] = '4.4.5'
 else
   default['nodejs']['version'] = '4.4.5'

--- a/cookbooks/node/attributes/node.rb
+++ b/cookbooks/node/attributes/node.rb
@@ -1,4 +1,4 @@
-fallback_nodejs_version = case attribute['dna']['engineyard']['environment']['components'].find {|node| node['key'] == 'nodejs'}['value']
+fallback_nodejs_version = case attribute['dna']['engineyard']['environment']['components'].find {|node| node['key'] == 'nodejs'}['value'] || attribute['dna']['engineyard']['environment']['components'].map(&:values).flatten.find(/^nodejs_/).first
                            when 'nodejs_6'
                              '6.4.0'
                            when 'nodejs_5'

--- a/cookbooks/node/attributes/node.rb
+++ b/cookbooks/node/attributes/node.rb
@@ -1,14 +1,17 @@
-if attribute['dna']['engineyard']['environment']['components'][5].include?('nodejs_version')
-  default['nodejs']['version'] = node.engineyard.environment.metadata('nodejs_version')
-elsif attribute['dna']['engineyard']['environment']['components'][0].first.include?("nodejs_6")
-  default['nodejs']['version'] = '6.4.0'
-elsif attribute['dna']['engineyard']['environment']['components'][0].first.include?("nodejs_5")
-  default['nodejs']['version'] = '5.11.0'
-elsif attribute['dna']['engineyard']['environment']['components'][0].first.include?("nodejs_4")
-  default['nodejs']['version'] = '4.4.5'
-else
-  default['nodejs']['version'] = '4.4.5'
-end
+nodejs_runtime_version = if attribute['dna']['engineyard']['environment']['components'][5].include?('nodejs_version')
+                           node.engineyard.environment.metadata('nodejs_version')
+                         end
+
+nodejs_runtime_version ||= case attribute['dna']['engineyard']['environment']['components'].map(&:values).flatten.find(/nodejs/).first
+                           when 'nodejs_6'
+                             '6.4.0'
+                           when 'nodejs_5'
+                             '5.11.0'
+                           else
+                             '4.4.5'
+                           end
+
+default['nodejs']['version'] = nodejs_runtime_version
 
 default['nodejs']['available_versions'] = [
   '0.12.6',  # net-libs/nodejs-0.12.6

--- a/cookbooks/node/attributes/node.rb
+++ b/cookbooks/node/attributes/node.rb
@@ -1,17 +1,17 @@
-if attribute['dna']['engineyard']['environment']['components'].find{|c| c['key'] == 'nodejs_6'}
-  stack_nodejs_version = '6.4.0'
+if node.engineyard.environment.metadata('nodejs_version')
+  default['nodejs']['version'] = node.engineyard.environment.metadata('nodejs_version')
+elsif attribute['dna']['engineyard']['environment']['components'].find{|c| c['key'] == 'nodejs_6'}
+  default['nodejs']['version'] = '6.4.0'
 elsif attribute['dna']['engineyard']['environment']['components'].find{|c| c['key'] == 'nodejs_5'}
-  stack_nodejs_version = '5.11.0'
+  default['nodejs']['version'] = '5.11.0'
 elsif attribute['dna']['engineyard']['environment']['components'].find{|c| c['key'] == 'nodejs_4'}
-  stack_nodejs_version = '4.4.5'
+  default['nodejs']['version'] = '4.4.5'
 elsif attribute['dna']['engineyard']['environment']['components'].find{|c| c['key'] == 'nodejs_012'}
-  stack_nodejs_version = '0.12.10'
+  default['nodejs']['version'] = '0.12.10'
 else
   stack_nodejs_version = '4.4.5'
 end
 
-
-default['nodejs']['version'] = node.engineyard.environment.metadata('nodejs_version',"stack_nodejs_version")
 default['nodejs']['available_versions'] = [
   '0.12.6',  # net-libs/nodejs-0.12.6
   '0.12.7',  # net-libs/nodejs-0.12.7

--- a/cookbooks/node/attributes/node.rb
+++ b/cookbooks/node/attributes/node.rb
@@ -1,12 +1,12 @@
 if node.engineyard.environment.metadata('nodejs_version')
   default['nodejs']['version'] = node.engineyard.environment.metadata('nodejs_version')
-elsif attribute['dna']['engineyard']['environment']['components'].find{|c| c['key'] == 'nodejs_6'}
+elsif attribute['dna']['engineyard']['environment']['components'][0].first.include?("nodejs_6")
   default['nodejs']['version'] = '6.4.0'
-elsif attribute['dna']['engineyard']['environment']['components'].find{|c| c['key'] == 'nodejs_5'}
+elsif attribute['dna']['engineyard']['environment']['components'][0].first.include?("nodejs_5")
   default['nodejs']['version'] = '5.11.0'
-elsif attribute['dna']['engineyard']['environment']['components'].find{|c| c['key'] == 'nodejs_4'}
+elsif attribute['dna']['engineyard']['environment']['components'][0].first.include?("nodejs_04")
   default['nodejs']['version'] = '4.4.5'
-elsif attribute['dna']['engineyard']['environment']['components'].find{|c| c['key'] == 'nodejs_012'}
+elsif attribute['dna']['engineyard']['environment']['components'][0].first.include?("nodejs_012")
   default['nodejs']['version'] = '0.12.10'
 else
   default['nodejs']['version'] = '4.4.5'

--- a/cookbooks/node/attributes/node.rb
+++ b/cookbooks/node/attributes/node.rb
@@ -1,8 +1,4 @@
-nodejs_runtime_version = if attribute['dna']['engineyard']['environment']['components'][5].include?('nodejs_version')
-                           node.engineyard.environment.metadata('nodejs_version')
-                         end
-
-nodejs_runtime_version ||= case attribute['dna']['engineyard']['environment']['components'].map(&:values).flatten.find(/nodejs/).first
+fallback_nodejs_version = case attribute['dna']['engineyard']['environment']['components'].map(&:values).flatten.find(/nodejs/).first
                            when 'nodejs_6'
                              '6.4.0'
                            when 'nodejs_5'
@@ -11,7 +7,9 @@ nodejs_runtime_version ||= case attribute['dna']['engineyard']['environment']['c
                              '4.4.5'
                            end
 
-default['nodejs']['version'] = nodejs_runtime_version
+default['nodejs']['version'] = node.engineyard.environment.metadata(
+'nodejs_version', fallback_nodejs_version
+)
 
 default['nodejs']['available_versions'] = [
   '0.12.6',  # net-libs/nodejs-0.12.6

--- a/cookbooks/node/attributes/node.rb
+++ b/cookbooks/node/attributes/node.rb
@@ -1,4 +1,4 @@
-if node.engineyard.environment.metadata('nodejs_version')
+if attribute['dna']['engineyard']['environment']['components'][5].include?('nodejs_version')
   default['nodejs']['version'] = node.engineyard.environment.metadata('nodejs_version')
 elsif attribute['dna']['engineyard']['environment']['components'][0].first.include?("nodejs_6")
   default['nodejs']['version'] = '6.4.0'

--- a/cookbooks/node/attributes/node.rb
+++ b/cookbooks/node/attributes/node.rb
@@ -1,5 +1,4 @@
-fallback_nodejs_version = case attribute['dna']['engineyard']['environment']
-  ['components'].map(&:values).flatten.find(/^nodejs_/).first
+fallback_nodejs_version = case attribute['dna']['engineyard']['environment']['components'].map(&:values).flatten.find(/^nodejs_/).first
                            when 'nodejs_6'
                              '6.4.0'
                            when 'nodejs_5'
@@ -8,9 +7,7 @@ fallback_nodejs_version = case attribute['dna']['engineyard']['environment']
                              '4.4.5'
                            end
 
-default['nodejs']['version'] = node.engineyard.environment.metadata(
-'nodejs_version', fallback_nodejs_version
-)
+default['nodejs']['version'] = node.engineyard.environment.metadata('nodejs_version', fallback_nodejs_version)
 
 default['nodejs']['available_versions'] = [
   '0.12.6',  # net-libs/nodejs-0.12.6

--- a/cookbooks/node/attributes/node.rb
+++ b/cookbooks/node/attributes/node.rb
@@ -6,8 +6,6 @@ elsif attribute['dna']['engineyard']['environment']['components'][0].first.inclu
   default['nodejs']['version'] = '5.11.0'
 elsif attribute['dna']['engineyard']['environment']['components'][0].first.include?("nodejs_04")
   default['nodejs']['version'] = '4.4.5'
-elsif attribute['dna']['engineyard']['environment']['components'][0].first.include?("nodejs_012")
-  default['nodejs']['version'] = '0.12.10'
 else
   default['nodejs']['version'] = '4.4.5'
 end

--- a/cookbooks/node/attributes/node.rb
+++ b/cookbooks/node/attributes/node.rb
@@ -1,10 +1,10 @@
-if attribute.dna[:engineyard][:environment][:components].find{|c| c['key'] == 'nodejs_6'}[:value]
+if attribute['dna']['engineyard']['environment']['components'].find{|c| c['key'] == 'nodejs_6'}
   stack_nodejs_version = '6.4.0'
-elsif attribute.dna[:engineyard][:environment][:components].find{|c| c['key'] == 'nodejs_5'}[:value]
+elsif attribute['dna']['engineyard']['environment']['components'].find{|c| c['key'] == 'nodejs_5'}
   stack_nodejs_version = '5.11.0'
-elsif attribute.dna[:engineyard][:environment][:components].find{|c| c['key'] == 'nodejs_4'}[:value]
+elsif attribute['dna']['engineyard']['environment']['components'].find{|c| c['key'] == 'nodejs_4'}
   stack_nodejs_version = '4.4.5'
-elsif attribute.dna[:engineyard][:environment][:components].find{|c| c['key'] == 'nodejs_012'}[:value]
+elsif attribute['dna']['engineyard']['environment']['components'].find{|c| c['key'] == 'nodejs_012'}
   stack_nodejs_version = '0.12.10'
 else
   stack_nodejs_version = '4.4.5'

--- a/cookbooks/node/recipes/common.rb
+++ b/cookbooks/node/recipes/common.rb
@@ -1,5 +1,5 @@
 get_package_name = {
-  '4.4.5' => 'net-libs/nodejs',
+  node['nodejs']['version'] => 'net-libs/nodejs',
 }
 get_package_name.default = 'net-libs/nodejs'
 
@@ -36,102 +36,91 @@ execute "env-update" do
   command "env-update"
 end
 
-#bash 'add v8' do
-#  code 'echo "=dev-lang/v8-3.11.10.12 ~amd64" >>/etc/portage/package.keywords/local'
-#end
-
-#available_nodejs_versions = /Available versions:\s+(.*)$/.
-#  match(`eix -xn net-libs/nodejs`)[1].
-#  split.
-#  collect {|v| v =~ /(\(?[\d\.]+\)?)/; $1}.
-#  compact.
-#  sort {|x,y| Engineyard::Version.new(x) <=> Engineyard::Version.new(y)}.
-#  uniq
 
 available_nodejs_versions = node['nodejs']['available_versions'].sort {|x,y| Engineyard::Version.new(x) <=> Engineyard::Version.new(y)}
 
-nodejs_version_specs_for_apps = []
-# If there's more than one app, then the assumption will be that the system node.js should be
-# the highest version specified by the apps.
-node.engineyard.apps.each do |app|
-  package_json_path = File.join('/data/', app.name, 'current', 'package.json')
-  next unless FileTest.exist? package_json_path
-  package_data = JSON.parse(File.read(package_json_path))
-  nodejs_version_specs_for_apps << ( package_data['engines'] && package_data['engines']['node'] )
-end
-
-nodejs_version_specs_for_apps << node['nodejs']['version'] if nodejs_version_specs_for_apps.empty?
-
-nodejs_version_specs_for_apps = nodejs_version_specs_for_apps.collect do |spec|
-  case spec
-  when /\*/
-    '> 0.0'
-  when /([\d\.]+)\.x/
-    "~>#{$1}.0"
-  else
-    spec
-  end
-end.select do |spec|
-  # Trim out any specifications that aren't parseable
-  begin
-    Engineyard::Requirement.new(spec)
-  rescue
-    nil
-  end
-end.collect do |spec|
-  # If the version spec doesn't match any available version, then we'll transform it to something
-  # more likely to have a nominally acceptable match, instead of just ignoring it. This is more
-  # likely to result in the right thing being done than just pretending that the unfulfullable
-  # specification doesn't exist.
-  requirement = Engineyard::Requirement.new( spec )
-  if available_nodejs_versions.any? { |version| requirement === Engineyard::Version.new( version ) }
-    spec
-  else
-    spec =~ /([\d\.]+)/
-    flat_spec = $1
-    available_nodejs_versions.flatten.select do |version|
-      Engineyard::Version.new(version) > Engineyard::Version.new(flat_spec) ? version : nil
-    end.first
-  end
-end
-
-all_nodejs_version_specs_for_apps = Engineyard::Requirement.new( nodejs_version_specs_for_apps )
-
-globally_acceptable_nodejs_versions = available_nodejs_versions.select do |version|
-  all_nodejs_version_specs_for_apps === Engineyard::Version.new( version )
-end.sort {|x,y| Engineyard::Version.new(x) <=> Engineyard::Version.new(y)}
-
-if globally_acceptable_nodejs_versions.any?
-  nodejs_version_to_install_and_eselect = globally_acceptable_nodejs_versions.last
-else
-  greatest_good_nodejs_versions = Hash.new {|h,k| h[k] = 0}
-  nodejs_version_specs_for_apps.each do |version_spec|
-    requirement = Engineyard::Requirement.new( version_spec )
-    available_nodejs_versions.select do |version|
-      greatest_good_nodejs_versions[version] += 1 if requirement === Engineyard::Version.new( version )
-    end
-  end
-  most_popular_count = greatest_good_nodejs_versions.
-    values.
-    sort.
-    last
-  nodejs_version_to_install_and_eselect = greatest_good_nodejs_versions.
-    keys.
-    select {|k| greatest_good_nodejs_versions[k] == most_popular_count}.
-    sort {|x,y| Engineyard::Version.new(x) <=> Engineyard::Version.new(y)}.
-    last
-end
-
-# If the code can't figure out a good specific version to use based on the contents of the package.json
-# file or files, then we'll punt and just use the attributes/node.rb default.
-nodejs_version_to_install_and_eselect = nodejs_version_to_install_and_eselect || node['nodejs']['version']
-
-# Enable all versions of node we provide
-available_nodejs_versions.each do |nodejs_version|
-  enable_package get_package_name[nodejs_version] do
-    version nodejs_version
-  end
-end
+# nodejs_version_specs_for_apps = []
+# # If there's more than one app, then the assumption will be that the system node.js should be
+# # the highest version specified by the apps.
+# node.engineyard.apps.each do |app|
+#   package_json_path = File.join('/data/', app.name, 'current', 'package.json')
+#   next unless FileTest.exist? package_json_path
+#   package_data = JSON.parse(File.read(package_json_path))
+#   nodejs_version_specs_for_apps << ( package_data['engines'] && package_data['engines']['node'] )
+# end
+#
+# nodejs_version_specs_for_apps << node['nodejs']['version'] if nodejs_version_specs_for_apps.empty?
+#
+# nodejs_version_specs_for_apps = nodejs_version_specs_for_apps.collect do |spec|
+#   case spec
+#   when /\*/
+#     '> 0.0'
+#   when /([\d\.]+)\.x/
+#     "~>#{$1}.0"
+#   else
+#     spec
+#   end
+# end.select do |spec|
+#   # Trim out any specifications that aren't parseable
+#   begin
+#     Engineyard::Requirement.new(spec)
+#   rescue
+#     nil
+#   end
+# end.collect do |spec|
+#   # If the version spec doesn't match any available version, then we'll transform it to something
+#   # more likely to have a nominally acceptable match, instead of just ignoring it. This is more
+#   # likely to result in the right thing being done than just pretending that the unfulfullable
+#   # specification doesn't exist.
+#   requirement = Engineyard::Requirement.new( spec )
+#   if available_nodejs_versions.any? { |version| requirement === Engineyard::Version.new( version ) }
+#     spec
+#   else
+#     spec =~ /([\d\.]+)/
+#     flat_spec = $1
+#     available_nodejs_versions.flatten.select do |version|
+#       Engineyard::Version.new(version) > Engineyard::Version.new(flat_spec) ? version : nil
+#     end.first
+#   end
+# end
+#
+# all_nodejs_version_specs_for_apps = Engineyard::Requirement.new( nodejs_version_specs_for_apps )
+#
+# globally_acceptable_nodejs_versions = available_nodejs_versions.select do |version|
+#   all_nodejs_version_specs_for_apps === Engineyard::Version.new( version )
+# end.sort {|x,y| Engineyard::Version.new(x) <=> Engineyard::Version.new(y)}
+#
+# if globally_acceptable_nodejs_versions.any?
+#   nodejs_version_to_install_and_eselect = globally_acceptable_nodejs_versions.last
+# else
+#   greatest_good_nodejs_versions = Hash.new {|h,k| h[k] = 0}
+#   nodejs_version_specs_for_apps.each do |version_spec|
+#     requirement = Engineyard::Requirement.new( version_spec )
+#     available_nodejs_versions.select do |version|
+#       greatest_good_nodejs_versions[version] += 1 if requirement === Engineyard::Version.new( version )
+#     end
+#   end
+#   most_popular_count = greatest_good_nodejs_versions.
+#     values.
+#     sort.
+#     last
+#   nodejs_version_to_install_and_eselect = greatest_good_nodejs_versions.
+#     keys.
+#     select {|k| greatest_good_nodejs_versions[k] == most_popular_count}.
+#     sort {|x,y| Engineyard::Version.new(x) <=> Engineyard::Version.new(y)}.
+#     last
+# end
+#
+# # If the code can't figure out a good specific version to use based on the contents of the package.json
+# # file or files, then we'll punt and just use the attributes/node.rb default.
+ nodejs_version_to_install_and_eselect = node['nodejs']['version']
+#
+ # Enable all versions of node we provide
+ available_nodejs_versions.each do |nodejs_version|
+   enable_package get_package_name[nodejs_version] do
+     version nodejs_version
+   end
+# end
 
 # 0.12.x needs extra packages enabled
 if (available_nodejs_versions & %w(0.12.6 0.12.7 0.12.10)).length > 0
@@ -143,25 +132,20 @@ if (available_nodejs_versions & %w(0.12.6 0.12.7 0.12.10)).length > 0
   end
 end
 
-# Enable and install a system node
-unmask_package get_package_name[nodejs_version_to_install_and_eselect] do
-  #version "#{node.dna['nodejs']['version']}"
-  version nodejs_version_to_install_and_eselect
-  unmaskfile "nodejs"
-end
+# # Enable and install a system node
+ unmask_package get_package_name[nodejs_version_to_install_and_eselect] do
+   version nodejs_version_to_install_and_eselect
+   unmaskfile "nodejs"
+ end
 
-# Update the attributes
-node.normal['nodejs']['version'] = nodejs_version_to_install_and_eselect
-node.normal['nodejs']['available_versions'] = available_nodejs_versions
+# # Update the attributes
+# node['nodejs']['version'] = nodejs_version_to_install_and_eselect
+# node['nodejs']['available_versions'] = available_nodejs_versions
 
-#Commenting out due to portage issues. Believe this should be able to be Removed going forward.
-# package "app-admin/eselect-nodejs" do
-#   version "20120820"
-# end
 
-package get_package_name[nodejs_version_to_install_and_eselect] do
-  version nodejs_version_to_install_and_eselect
-end
+ package get_package_name[nodejs_version_to_install_and_eselect] do
+   version nodejs_version_to_install_and_eselect
+ end
 
 nodejs_version_to_eselect_trimmed = nodejs_version_to_install_and_eselect.split("-r").first
 eselect nodejs_version_to_eselect_trimmed do
@@ -208,8 +192,6 @@ end
   end
 end
 
-
-#TODO: REMOVE BEFORE NEW DISTRO RELEASE
 directory "/opt/nodejs" do
   action :create
 end

--- a/cookbooks/node/recipes/common.rb
+++ b/cookbooks/node/recipes/common.rb
@@ -139,8 +139,8 @@ end
  end
 
 # # Update the attributes
-# node['nodejs']['version'] = nodejs_version_to_install_and_eselect
-# node['nodejs']['available_versions'] = available_nodejs_versions
+ node.normal['nodejs']['version'] = nodejs_version_to_install_and_eselect
+ node.normal['nodejs']['available_versions'] = available_nodejs_versions
 
 
  package get_package_name[nodejs_version_to_install_and_eselect] do

--- a/cookbooks/node/recipes/common.rb
+++ b/cookbooks/node/recipes/common.rb
@@ -120,7 +120,7 @@ available_nodejs_versions = node['nodejs']['available_versions'].sort {|x,y| Eng
    enable_package get_package_name[nodejs_version] do
      version nodejs_version
    end
-# end
+ end
 
 # 0.12.x needs extra packages enabled
 if (available_nodejs_versions & %w(0.12.6 0.12.7 0.12.10)).length > 0

--- a/cookbooks/node/recipes/common.rb
+++ b/cookbooks/node/recipes/common.rb
@@ -1,5 +1,5 @@
 get_package_name = {
-  node['nodejs']['version'] => 'net-libs/nodejs',
+  '4.4.5' => 'net-libs/nodejs',
 }
 get_package_name.default = 'net-libs/nodejs'
 
@@ -35,86 +35,10 @@ end
 execute "env-update" do
   command "env-update"
 end
-
-
 available_nodejs_versions = node['nodejs']['available_versions'].sort {|x,y| Engineyard::Version.new(x) <=> Engineyard::Version.new(y)}
 
-# nodejs_version_specs_for_apps = []
-# # If there's more than one app, then the assumption will be that the system node.js should be
-# # the highest version specified by the apps.
-# node.engineyard.apps.each do |app|
-#   package_json_path = File.join('/data/', app.name, 'current', 'package.json')
-#   next unless FileTest.exist? package_json_path
-#   package_data = JSON.parse(File.read(package_json_path))
-#   nodejs_version_specs_for_apps << ( package_data['engines'] && package_data['engines']['node'] )
-# end
-#
-# nodejs_version_specs_for_apps << node['nodejs']['version'] if nodejs_version_specs_for_apps.empty?
-#
-# nodejs_version_specs_for_apps = nodejs_version_specs_for_apps.collect do |spec|
-#   case spec
-#   when /\*/
-#     '> 0.0'
-#   when /([\d\.]+)\.x/
-#     "~>#{$1}.0"
-#   else
-#     spec
-#   end
-# end.select do |spec|
-#   # Trim out any specifications that aren't parseable
-#   begin
-#     Engineyard::Requirement.new(spec)
-#   rescue
-#     nil
-#   end
-# end.collect do |spec|
-#   # If the version spec doesn't match any available version, then we'll transform it to something
-#   # more likely to have a nominally acceptable match, instead of just ignoring it. This is more
-#   # likely to result in the right thing being done than just pretending that the unfulfullable
-#   # specification doesn't exist.
-#   requirement = Engineyard::Requirement.new( spec )
-#   if available_nodejs_versions.any? { |version| requirement === Engineyard::Version.new( version ) }
-#     spec
-#   else
-#     spec =~ /([\d\.]+)/
-#     flat_spec = $1
-#     available_nodejs_versions.flatten.select do |version|
-#       Engineyard::Version.new(version) > Engineyard::Version.new(flat_spec) ? version : nil
-#     end.first
-#   end
-# end
-#
-# all_nodejs_version_specs_for_apps = Engineyard::Requirement.new( nodejs_version_specs_for_apps )
-#
-# globally_acceptable_nodejs_versions = available_nodejs_versions.select do |version|
-#   all_nodejs_version_specs_for_apps === Engineyard::Version.new( version )
-# end.sort {|x,y| Engineyard::Version.new(x) <=> Engineyard::Version.new(y)}
-#
-# if globally_acceptable_nodejs_versions.any?
-#   nodejs_version_to_install_and_eselect = globally_acceptable_nodejs_versions.last
-# else
-#   greatest_good_nodejs_versions = Hash.new {|h,k| h[k] = 0}
-#   nodejs_version_specs_for_apps.each do |version_spec|
-#     requirement = Engineyard::Requirement.new( version_spec )
-#     available_nodejs_versions.select do |version|
-#       greatest_good_nodejs_versions[version] += 1 if requirement === Engineyard::Version.new( version )
-#     end
-#   end
-#   most_popular_count = greatest_good_nodejs_versions.
-#     values.
-#     sort.
-#     last
-#   nodejs_version_to_install_and_eselect = greatest_good_nodejs_versions.
-#     keys.
-#     select {|k| greatest_good_nodejs_versions[k] == most_popular_count}.
-#     sort {|x,y| Engineyard::Version.new(x) <=> Engineyard::Version.new(y)}.
-#     last
-# end
-#
-# # If the code can't figure out a good specific version to use based on the contents of the package.json
-# # file or files, then we'll punt and just use the attributes/node.rb default.
- nodejs_version_to_install_and_eselect = node['nodejs']['version']
-#
+nodejs_version_to_install_and_eselect = node['nodejs']['version']
+
  # Enable all versions of node we provide
  available_nodejs_versions.each do |nodejs_version|
    enable_package get_package_name[nodejs_version] do


### PR DESCRIPTION
Description of your patch
-------------
Enable The Non-Ruby Version Selection Feature to work for selecting NodeJS. This removes the previous aggregation of apps on the instance to figure out what version should be being run and uses the nodejs version selection.

Recommended Release Notes
-------------
This release allows Nodejs versions to be selected for Nodejs, Ruby, PHP Environments and ensures that the "nodejs_version" metadata on a per environment basis for Stable V5. When upgrading please have support enable the `Non-Ruby Version Selection Feature` to your account. 

Estimated risk
-------------
High

Components involved
-------------
Nodejs

Description of testing done
-------------
Ran Chef with change and verified that running `node -v` returned 4.4.5, 5.11.0, 6.4.0 and if another version was selected returned the default 4.4.5 version of nodejs

QA Instructions
-------------
1. Build environment on stable stack
1. Enable the non-ruby version feature flag on your account
1. Verify chef run completes successfully
1. Select a version of nodejs in edit environment and verify it does not change based on any changes to that screen
1. Upgrade to target stack
1. Verify chef run completes successfully
1. Select Nodejs 4 in edit environment. Save the change
1. Verify chef run completes successfully
1. Verify `node -v` returns 4.4.5
1. Select Nodejs 5 in edit environment. Save the change
1. Verify chef run completes successfully
1. Verify `node -v` returns 5.11.0
1. Select Nodejs 5 in edit environment. Save the change
1. Verify chef run completes successfully
1.  Verify `node -v` returns 6.4.0
1. Select Any Nodejs in the drop down that is not 4, 5, 6. Save the change
1. Verify chef run completes successfully
1. Verify `node -v` returns 4.4.5

1. Terminate and recreate environment on target stack
1. Verify chef run completes successfully
1. Select Nodejs 4 in edit environment. Save the change
1. Verify chef run completes successfully
1. Verify `node -v` returns 4.4.5
1. Select Nodejs 5 in edit environment. Save the change
1. Verify chef run completes successfully
1. Verify `node -v` returns 5.11.0
1. Select Nodejs 5 in edit environment. Save the change
1. Verify chef run completes successfully
1.  Verify `node -v` returns 6.4.0
1. Select Any Nodejs in the drop down that is not 4, 5, 6. Save the change
1. Verify chef run completes successfully
1. Verify `node -v` returns 4.4.5
