### PR TITLE
add haproxy restart for .pem template

### DIFF
--- a/cookbooks/nginx/recipes/default.rb
+++ b/cookbooks/nginx/recipes/default.rb
@@ -446,6 +446,7 @@ php_webroot = node.engineyard.environment.apps.first['components'].find {|compon
         :chain => app[:vhosts][1][:chain],
         :key => app[:vhosts][1][:key]
       )
+      notifies :restart, 'service[haproxy]', :delayed
     end
 
     # CC-260: Same issue as previous; using compile-time if rather than run-time only_if directive


### PR DESCRIPTION
https://tickets.engineyard.com/issue/CC-1051

When a customer updates their SSL Certificate, then clicks Apply on the environment dashboard, the SSL Certificate is updated in the server (/etc/nginx/ssl/<cert_file>) but HAProxy continues to serve the old certificate. HAProxy needs to be reloaded for it to start serving the updated certificate.

We should automatically reload HAProxy on Apply if the SSL certificate of the environment has changed.