### PR TITLE
Elasticsearch 2.4.0

### DIFF
--- a/cookbooks/elasticsearch/README.md
+++ b/cookbooks/elasticsearch/README.md
@@ -1,0 +1,7 @@
+# Elasticsearch
+
+This recipe is used to run on Elasticsearch the stable-v5 stack.
+
+The elasticsearch recipe is managed by Engine Yard. You should not copy this recipe to your repository but instead copy custom-delayed_job4. Please check the [custom-elasticsearch readme](../../examples/elasticsearch/cookbooks/custom-elasticsearch) for the complete instructions.
+
+We accept contributions for changes that can be used by all customers.

--- a/cookbooks/elasticsearch/attributes/default.rb
+++ b/cookbooks/elasticsearch/attributes/default.rb
@@ -1,0 +1,38 @@
+default['elasticsearch'].tap do |elasticsearch|
+  # Run Elasticsearch on util instances named elasticsearch_*
+  # This is the default
+  elasticsearch['is_elasticsearch_instance'] = ( node['dna']['instance_role'] == 'util' && node['dna']['name'].include?('elasticsearch_') )
+
+  # Run Elasticsearch on a solo or app_master instance
+  # Not recommended for production environments
+  #elasticsearch['is_elasticsearch_instance'] = ( ['solo', 'app_master'].include?(node['dna']['instance_role']) )
+
+  # Set this to true if you're running more than one elasticsearch instance
+  # Set to false if you're running on a solo or app_master
+  elasticsearch['configure_cluster'] = true
+
+  # Elasticsearch version to install
+  elasticsearch['version'] = '2.4.0'
+
+  # Gentoo Java package name to use
+  elasticsearch['java_package_name'] = 'dev-java/icedtea-bin'
+
+  # Which version of the java package to use
+  elasticsearch['java_version'] = '3.0.1'
+  
+  # After installing the Java version we also need to eselect it
+  # The version below tells chef what java package to specify in eselect
+  elasticsearch['java_eselect_version'] = 'icedtea-bin-8'
+
+  # Elasticsearch cluster name
+  elasticsearch['clustername'] = node['dna']['environment']['name']
+
+  # Where to store the ES index
+  elasticsearch['home'] = '/data/elasticsearch'
+
+  # Elasticsearch configuration parameters
+  elasticsearch['heap_size'] = 1000
+  elasticsearch['fdulimit'] = nil
+  elasticsearch['defaultreplicas'] = 1
+  elasticsearch['defaultshards'] = 6
+end

--- a/cookbooks/elasticsearch/definitions/plugin.rb
+++ b/cookbooks/elasticsearch/definitions/plugin.rb
@@ -1,0 +1,23 @@
+define :es_plugin, :name => nil do
+  name = params['name']
+
+  case params['action'].to_sym
+  when :install
+    Chef::Log.info "attempting to install ElasticSearch plugin #{name}"
+
+    execute "plugin install #{name}" do
+      cwd "/usr/lib/elasticsearch-#{node['elasticsearch_version']}"
+      command "/usr/lib/elasticsearch-#{node['elasticsearch_version']}/bin/plugin -install #{name}"
+      not_if { File.directory?("/usr/lib/elasticsearch-#{node['elasticsearch_version']}/plugins/#{name}") }
+    end
+
+  when :remove
+    Chef::Log.info "attempting to remove ElasticSearch plugin #{name}"
+
+    execute "plugin remove #{name}" do
+      cwd "/usr/lib/elasticsearch-#{node['elasticsearch_version']}"
+      command "/usr/lib/elasticsearch-#{node['elasticsearch_version']}/bin/plugin -remove #{name}"
+      not_if { File.directory?("/usr/lib/elasticsearch-#{node['elasticsearch_version']}/plugins/#{name}") }
+    end
+  end
+end

--- a/cookbooks/elasticsearch/files/default/elasticsearch.logrotate
+++ b/cookbooks/elasticsearch/files/default/elasticsearch.logrotate
@@ -1,0 +1,12 @@
+/var/log/elasticsearch/*.log {
+    rotate 30
+    size 100M
+    compress
+    missingok
+    notifempty
+    sharedscripts
+    extension gz
+    postrotate
+      [ ! -f /var/run/elasticsearch/elasticsearch.pid ] || kill -USR1 `cat /var/run/elasticsearch/elasticsearch.pid`
+    endscript
+}

--- a/cookbooks/elasticsearch/metadata.rb
+++ b/cookbooks/elasticsearch/metadata.rb
@@ -1,0 +1,8 @@
+name 'elasticsearch'
+description 'Configuration & deployment of Elasticsearch on Engine Yard'
+long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
+maintainer 'Engine Yard'
+maintainer_email 'support@engineyard.com'
+version '0.0.1'
+issues_url 'https://github.com/engineyard/ey-cookbooks-stable-v5/issues'
+source_url 'https://github.com/engineyard/ey-cookbooks-stable-v5'

--- a/cookbooks/elasticsearch/recipes/configure_cluster.rb
+++ b/cookbooks/elasticsearch/recipes/configure_cluster.rb
@@ -1,0 +1,30 @@
+ES = node['elasticsearch']
+
+if node['dna']['utility_instances'].empty?
+  Chef::Log.info "No utility instances found"
+else
+  elasticsearch_instances = []
+  elasticsearch_expected = 0
+  node['dna']['utility_instances'].each do |elasticsearch|
+    if elasticsearch['name'].include?("elasticsearch_")
+      elasticsearch_expected = elasticsearch_expected + 1 unless node['dna']['fqdn'] == elasticsearch['hostname']
+      elasticsearch_instances << "#{elasticsearch['hostname']}:9300" unless node['dna']['fqdn'] == elasticsearch['hostname']
+    end
+  end
+
+  template "/usr/lib/elasticsearch-#{ES['version']}/config/elasticsearch.yml" do
+    source "elasticsearch.yml.erb"
+    owner "elasticsearch"
+    group "nogroup"
+    variables(
+      :elasticsearch_instances => elasticsearch_instances.join('", "'),
+      :elasticsearch_defaultreplicas => ES['defaultreplicas'],
+      :elasticsearch_expected => elasticsearch_expected,
+      :elasticsearch_defaultshards => ES['defaultshards'],
+      :elasticsearch_clustername => ES['clustername'],
+      :elasticsearch_host => node['fqdn']
+    )
+    mode 0600
+    backup 0
+  end
+end

--- a/cookbooks/elasticsearch/recipes/default.rb
+++ b/cookbooks/elasticsearch/recipes/default.rb
@@ -1,0 +1,13 @@
+#
+# Cookbook Name:: elasticsearch
+# Recipe:: default
+#
+# Credit goes to GoTime for their original recipe ( http://cookbooks.opscode.com/cookbooks/elasticsearch )
+
+ES = node['elasticsearch']
+
+include_recipe 'elasticsearch::download'
+include_recipe 'elasticsearch::install'
+if ES['is_elasticsearch_instance'] && ES['configure_cluster']
+  include_recipe 'elasticsearch::configure_cluster'
+end

--- a/cookbooks/elasticsearch/recipes/download.rb
+++ b/cookbooks/elasticsearch/recipes/download.rb
@@ -1,0 +1,11 @@
+ES = node['elasticsearch']
+download_url = "https://download.elastic.co/elasticsearch/release/org/elasticsearch/distribution/zip/elasticsearch/#{ES['version']}/elasticsearch-#{ES['version']}.zip"
+
+if ES['is_elasticsearch_instance']
+  Chef::Log.info "Downloading Elasticsearch v#{ES['version']}"
+  remote_file "#{Chef::Config[:file_cache_path]}/elasticsearch-#{ES['version']}.zip" do
+    source download_url
+    mode "0644"
+    action :create_if_missing
+  end
+end

--- a/cookbooks/elasticsearch/recipes/install.rb
+++ b/cookbooks/elasticsearch/recipes/install.rb
@@ -1,0 +1,179 @@
+ES = node['elasticsearch']
+
+if ES['is_elasticsearch_instance']
+  user "elasticsearch" do
+    uid 61021
+    gid "nogroup"
+  end
+
+  # Update JAVA as the Java on the AMI can sometimes crash
+  #
+  Chef::Log.info "Updating Java JDK"
+  enable_package ES['java_package_name'] do
+    version ES['java_version']
+    unmask true
+  end
+
+  # Forcing 'install' because if lower version packages are installed
+  # then 'upgrade' installs the desired version every time it runs.
+  package ES['java_package_name'] do
+    version ES['java_version']
+    action :install
+  end
+
+  execute "Set the default Java version to #{ES['java_version']}" do
+    command "eselect java-vm set system #{ES['java_eselect_version']}"
+    action :run
+  end
+
+  directory "/usr/lib/elasticsearch-#{ES['version']}" do
+    owner "elasticsearch"
+    group "nogroup"
+    mode 0755
+  end
+
+  ["/var/log/elasticsearch", "/var/lib/elasticsearch", "/var/run/elasticsearch"].each do |dir|
+    directory dir do
+      owner "elasticsearch"
+      group "nogroup"
+      mode 0755
+    end
+  end
+
+  bash "unzip elasticsearch" do
+    cwd Chef::Config[:file_cache_path]
+    code %(unzip #{Chef::Config[:file_cache_path]}/elasticsearch-#{ES['version']}.zip)
+    not_if { File.directory? "#{Chef::Config[:file_cache_path]}/elasticsearch-#{ES['version']}" }
+  end
+
+  bash "copy elasticsearch root" do
+    user "elasticsearch"
+    cwd Chef::Config[:file_cache_path]
+    code %(cp -r #{Chef::Config[:file_cache_path]}/elasticsearch-#{ES['version']}/* /usr/lib/elasticsearch-#{ES['version']})
+    not_if { File.exists? "/usr/lib/elasticsearch-#{ES['version']}/lib" }
+  end
+
+  directory "/usr/lib/elasticsearch-#{ES['version']}/plugins" do
+    owner "elasticsearch"
+    group "nogroup"
+    mode 0755
+  end
+
+  link "/usr/lib/elasticsearch" do
+    to "/usr/lib/elasticsearch-#{ES['version']}"
+    owner "elasticsearch"
+    group "nogroup"
+    mode 0755
+  end
+
+  directory ES['home'] do
+    owner "elasticsearch"
+    group "nogroup"
+    mode 0755
+  end
+
+  # Fix file permissions on data dir in case we're upgrading from ES 1.x
+  execute "set-permissions-data-dir" do
+    command "chown -R elasticsearch:nogroup #{ES['home']}/*"
+    user "root"
+    action :run
+    only_if "[[ -f #{ES['home']}/* ]]"
+    not_if "stat -c %U #{ES['home']}/* |grep elasticsearch"
+  end
+
+  # Fix file permissions on log dir in case we're upgrading from ES 1.x
+  execute "set-permissions-log-dir" do
+    command "chown -R elasticsearch:nogroup /var/log/elasticsearch/*"
+    user "root"
+    action :run
+    only_if "ls -1 /var/log/elasticsearch/ | wc -l"
+    only_if "stat -c %U /var/log/elasticsearch/*log* |grep -v elasticsearch"
+  end
+
+  directory "/usr/lib/elasticsearch-#{ES['version']}/data" do
+    owner "elasticsearch"
+    group "nogroup"
+    mode 0755
+    action :create
+    recursive true
+  end
+
+  if File.new("/proc/mounts").readlines.join.match(/\/usr\/lib[0-9]*\/elasticsearch-#{ES['version']}\/data/)
+    Chef::Log.info("Elastic search bind already complete")
+  else
+    mount "/usr/lib/elasticsearch-#{ES['version']}/data" do
+      device ES['home']
+      fstype "none"
+      options "bind,rw"
+      action :mount
+    end
+  end
+
+  template "/usr/lib/elasticsearch-#{ES['version']}/config/logging.yml" do
+    source "logging.yml.erb"
+    mode 0644
+  end
+
+  directory "/usr/share/elasticsearch" do
+    group "elasticsearch"
+    group "nogroup"
+    mode 0755
+  end
+
+  template "/usr/share/elasticsearch/elasticsearch.in.sh" do
+    source "elasticsearch.in.sh.erb"
+    mode 0644
+    backup 0
+    variables(
+      :elasticsearch_version => ES['version']
+    )
+  end
+
+
+  # Add log rotation for the elasticsearch logs
+  cookbook_file "/etc/logrotate.d/elasticsearch" do
+    source "elasticsearch.logrotate"
+    owner "root"
+    group "root"
+    mode "0644"
+    backup 0
+  end
+
+  template "/etc/monit.d/elasticsearch_#{ES['clustername']}.monitrc" do
+    source "elasticsearch.monitrc.erb"
+    owner "elasticsearch"
+    group "nogroup"
+    backup 0
+    mode 0644
+    variables(:owner => "elasticsearch")
+  end
+
+  # Tell monit to just reload, if elasticsearch is not running start it.  If it is monit will do nothing.
+  execute "monit reload" do
+    command "monit reload"
+  end
+end
+
+owner_name = node['dna']['users'].first['username']
+# This portion of the recipe should run on all instances in your environment.  We are going to drop elasticsearch.yml for you so you can parse it and provide the instances to your application.
+if ['solo','app_master','app','util'].include?(node['instance_role'])
+  elasticsearch_hosts = []
+  node['dna']['utility_instances'].each do |elasticsearch|
+    if elasticsearch['name'].include?("elasticsearch_")
+      elasticsearch_hosts << "#{elasticsearch['hostname']}:9200"
+    end
+
+    node['dna']['applications'].each do |app_name, data|
+      template "/data/#{app_name}/shared/config/elasticsearch.yml" do
+        owner owner_name
+        group owner_name
+        mode 0660
+        source "es.yml.erb"
+        backup 0
+        variables(:yaml_file => {
+          node['dna']['environment']['framework_env'] => {
+            :hosts => elasticsearch_hosts} })
+      end
+    end
+  end
+end

--- a/cookbooks/elasticsearch/templates/default/elasticsearch.in.sh.erb
+++ b/cookbooks/elasticsearch/templates/default/elasticsearch.in.sh.erb
@@ -1,0 +1,54 @@
+ES_CLASSPATH=$ES_HOME/lib/elasticsearch-<%= @elasticsearch_version %>.jar:$ES_HOME/lib/*
+
+if [ "x$ES_MIN_MEM" = "x" ]; then
+    ES_MIN_MEM=256m
+fi
+if [ "x$ES_MAX_MEM" = "x" ]; then
+  ES_MAX_MEM=1300m
+fi
+
+# min and max heap sizes should be set to the same value to avoid
+# stop-the-world GC pauses during resize, and so that we can lock the
+# heap in memory on startup to prevent any of it from being swapped
+# out.
+JAVA_OPTS="$JAVA_OPTS -Xms${ES_MIN_MEM}"
+JAVA_OPTS="$JAVA_OPTS -Xmx${ES_MAX_MEM}"
+
+# reduce the per-thread stack size
+# 256k is the minimum stack size for newer versions of Elasticsearch
+# see https://groups.google.com/forum/#!topic/elasticsearch/cfihFvFg08Q
+JAVA_OPTS="$JAVA_OPTS -Xss256k"
+
+JAVA_OPTS="$JAVA_OPTS -Djline.enabled=true"
+
+# Enable aggressive optimizations in the JVM
+#    - Disabled by default as it might cause the JVM to crash
+# JAVA_OPTS="$JAVA_OPTS -XX:+AggressiveOpts"
+
+# Enable reference compression, reducing memory overhead on 64bit JVMs
+#    - Disabled by default as it is not stable for Sun JVM before 6u19
+#JAVA_OPTS="$JAVA_OPTS -XX:+UseCompressedOops"
+
+# This stops an annoying warning
+JAVA_OPTS="$JAVA_OPTS -server"
+JAVA_OPTS="$JAVA_OPTS -XX:+UseParNewGC"
+JAVA_OPTS="$JAVA_OPTS -XX:+UseConcMarkSweepGC"
+JAVA_OPTS="$JAVA_OPTS -XX:+CMSParallelRemarkEnabled"
+JAVA_OPTS="$JAVA_OPTS -XX:SurvivorRatio=8"
+JAVA_OPTS="$JAVA_OPTS -XX:MaxTenuringThreshold=1"
+JAVA_OPTS="$JAVA_OPTS -XX:CMSInitiatingOccupancyFraction=75"
+JAVA_OPTS="$JAVA_OPTS -XX:+UseCMSInitiatingOccupancyOnly"
+
+# GC logging options -- uncomment to enable
+# JAVA_OPTS="$JAVA_OPTS -XX:+PrintGCDetails"
+# JAVA_OPTS="$JAVA_OPTS -XX:+PrintGCTimeStamps"
+# JAVA_OPTS="$JAVA_OPTS -XX:+PrintClassHistogram"
+# JAVA_OPTS="$JAVA_OPTS -XX:+PrintTenuringDistribution"
+# JAVA_OPTS="$JAVA_OPTS -XX:+PrintGCApplicationStoppedTime"
+# JAVA_OPTS="$JAVA_OPTS -Xloggc:/var/log/elasticsearch/gc.log"
+
+# Causes the JVM to dump its heap on OutOfMemory.
+JAVA_OPTS="$JAVA_OPTS -XX:+HeapDumpOnOutOfMemoryError"
+# The path to the heap dump location, note directory must exists and have enough
+# space for a full heap dump.
+#JAVA_OPTS="$JAVA_OPTS -XX:HeapDumpPath=$ES_HOME/logs/heapdump.hprof"

--- a/cookbooks/elasticsearch/templates/default/elasticsearch.monitrc.erb
+++ b/cookbooks/elasticsearch/templates/default/elasticsearch.monitrc.erb
@@ -1,0 +1,10 @@
+check process elasticsearch
+with pidfile /var/run/elasticsearch/elasticsearch.pid
+  start program = "/usr/lib/elasticsearch/bin/elasticsearch -d -p /var/run/elasticsearch/elasticsearch.pid" as uid <%= @owner %> with timeout 90 seconds
+  stop program = "/bin/bash -c '/bin/kill `cat /var/run/elasticsearch/elasticsearch.pid`'" with timeout 90 seconds
+  group elasticsearch
+  if failed
+    port 9200
+    protocol http
+    request "/"
+  then restart

--- a/cookbooks/elasticsearch/templates/default/elasticsearch.yml.erb
+++ b/cookbooks/elasticsearch/templates/default/elasticsearch.yml.erb
@@ -1,0 +1,24 @@
+path:
+  work: /var/lib/elasticsearch/work
+  logs: /var/log/elasticsearch
+  data: /data/elasticsearch
+
+
+cluster:
+  name: <%= @elasticsearch_clustername %>
+
+network:
+  bind_host: [127.0.0.1, <%= @elasticsearch_host %>]
+  publish_host: <%= @elasticsearch_host %>
+
+discovery:
+  zen:
+    minimum_master_nodes: 1
+    ping.timeout: 3s
+    ping.multicast.enabled: false
+    ping.unicast.hosts: ["<%= @elasticsearch_instances %>"]
+
+gateway:
+  recover_after_nodes: 1
+  recover_after_time: 5m
+  expected_nodes: <%= @elasticsearch_expected %>

--- a/cookbooks/elasticsearch/templates/default/es.yml.erb
+++ b/cookbooks/elasticsearch/templates/default/es.yml.erb
@@ -1,0 +1,2 @@
+<% require 'yaml' -%>
+<%=@yaml_file.to_yaml%>

--- a/cookbooks/elasticsearch/templates/default/logging.yml.erb
+++ b/cookbooks/elasticsearch/templates/default/logging.yml.erb
@@ -1,0 +1,21 @@
+rootLogger: INFO, console, file
+logger:
+  jgroups: WARN
+  # log action execution errors for easier debugging
+  action : INFO
+
+appender:
+  console:
+    type: console
+    layout:
+      type: consolePattern
+      conversionPattern: "[%d{ABSOLUTE}][%-5p][%-25c] %m%n"
+
+  file:
+    type: dailyRollingFile
+    file: /var/log/elasticsearch/${cluster.name}.log
+    datePattern: "'.'yyyy-MM-dd"
+    layout:
+      type: pattern
+      conversionPattern: "[%d{ABSOLUTE}][%-5p][%-25c] %m%n"
+      

--- a/examples/elasticsearch/README.md
+++ b/examples/elasticsearch/README.md
@@ -1,0 +1,6 @@
+# Elasticsearch
+
+This example contains a complete cookbooks/ that you can use on the stable-v5 stack.
+
+See https://github.com/engineyard/ey-cookbooks-stable-v5/tree/next-release/examples/elasticsearch/cookbooks/custom-elasticsearch for complete instructions.
+

--- a/examples/elasticsearch/cookbooks/custom-elasticsearch/README.md
+++ b/examples/elasticsearch/cookbooks/custom-elasticsearch/README.md
@@ -1,0 +1,121 @@
+Elasticsearch Cookbook for AppCloud
+---------------
+
+You know, for Search
+
+So, we build a web site or an application and want to add search to it, and then it hits us: getting search working is hard. We want our search solution to be fast, we want a painless setup and a completely free search schema, we want to be able to index data simply using JSON over HTTP, we want our search server to be always available, we want to be able to start with one machine and scale to hundreds, we want real-time search, we want simple multi-tenancy, and we want a solution that is built for the cloud.
+
+"This should be easier", we declared, "and cool, bonsai cool".
+
+[elasticsearch][2] aims to solve all these problems and more. It is an Open Source (Apache 2), Distributed, RESTful, Search Engine built on top of [Lucene][1].
+
+NOTE: This recipe installs Elasticsearch 2.4.0 and requires Java 7 or later. It will only work on the Gentoo 12.11 stack; the Java 7 ebuild is not available on Gentoo 2009. We do not recommend running older versions of Elasticsearch - versions prior to 1.2 have a remote code execution vulnerability, see http://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2014-3120
+
+Known Issues
+--------
+- A prior version of this recipe would create duplicate bind mounts under `/proc/mounts`. These weren't known to create any specific problems so this was added as a cleanup rather than a bugfix. In order to remove the extra mounts you need to run `sudo umount /usr/lib64/elasticsearch-#{version}/data` for each extra mount.
+
+Dependencies
+--------
+
+  * Your application should use gems(s) such as [tire][4],[rubberband][3],[elastic_searchable][5].
+
+Using it
+--------
+
+There are several ways to use this recipe, depending on your environment.
+
+  * On a solo environment
+  * On a small cluster: run Elasticsearch on app_master
+
+  Uncomment this line in attributes/default.rb:
+
+    ```
+      #'is_elasticsearch_instance' => ( node['dna']['instance_role'] == 'util' && node['dna']['name'].include?('elasticsearch_') ),
+    ```
+
+  * On a cluster with dedicated util instances for Elasticsearch
+
+  Name the Elasticsearch instances elasticsearch_0, elasticsearch_1, etc.
+
+
+  Uncomment this line in attributes/default.rb:
+
+  ```
+    'is_elasticsearch_instance' => ( ['solo', 'app_master'].include?(node['dna']['instance_role']) ),
+  ```
+
+  And set `configure_cluster` to true:
+
+  ```
+  'configure_cluster'       => true,
+  ```
+
+
+Verify
+-------
+
+On your instance, run:
+
+    curl localhost:9200
+
+Results should be simlar to:
+
+```
+{
+  "name" : "Bloodlust",
+  "cluster_name" : "elasticsearch",
+  "version" : {
+    "number" : "2.4.0",
+    "build_hash" : "ce9f0c7394dee074091dd1bc4e9469251181fc55",
+    "build_timestamp" : "2016-08-29T09:14:17Z",
+    "build_snapshot" : false,
+    "lucene_version" : "5.5.2"
+  },
+  "tagline" : "You Know, for Search"
+}
+```
+
+Plugins
+--------
+
+Rudamentary plugin support is there in a definition.  You will need to update the template for configuration options for said plugin; if you wish to improve this functionality please submit a pull request.
+
+Examples:
+
+``es_plugin "cloud-aws" do``
+``action :install``
+``end``
+
+``es_plugin "transport-memcached" do``
+``action :remove``
+``end``
+
+
+Caveats
+--------
+
+plugin support is still not complete/automated.  CouchDB and Memcached plugins may be worth investigating, pull requests to improve this.
+
+Backups
+--------
+
+Non-automated, regular snapshot should work.  If you have a large cluster this may complicate things, please consult the [elasticsearch][2] documentation regarding that.
+
+Upgrading
+--------
+
+If you have a small index and can easily rebuild it, the simplest way to upgrade from a previous version is to completely delete `/data/elasticsearch` and then re-run the recipe with the newer version. To do an in-place upgrade while keeping the index, please consult the [Elasticsearch documentation](https://www.elastic.co/guide/en/elasticsearch/reference/current/setup-upgrade.html).
+
+Warranty
+--------
+
+This cookbook is provided as is, there is no offer of support for this
+recipe by Engine Yard in any capacity.  If you find bugs, please open an
+issue and submit a pull request.
+
+[1]: http://lucene.apache.org/
+[2]: http://www.elasticsearch.org/
+[3]: https://github.com/grantr/rubberband
+[4]: https://github.com/karmi/tire
+[5]: https://github.com/wireframe/elastic_searchable/

--- a/examples/elasticsearch/cookbooks/custom-elasticsearch/attribues/default.rb
+++ b/examples/elasticsearch/cookbooks/custom-elasticsearch/attribues/default.rb
@@ -1,0 +1,14 @@
+# Modify the variables below to change how Elasticsearch will be installed
+# See cookbooks/elasticsearch/attributes/default.rb for the complete list of configurable variables
+
+# Run Elasticsearch on util instances named elasticsearch_*
+# This is the default
+#elasticsearch['is_elasticsearch_instance'] = ( node['dna']['instance_role'] == 'util' && node['dna']['name'].include?('elasticsearch_') )
+
+# Run Elasticsearch on a solo or app_master instance
+# Not recommended for production environments
+#elasticsearch['is_elasticsearch_instance'] = ( ['solo', 'app_master'].include?(node['dna']['instance_role']) )
+
+# Set this to true if you're running more than one elasticsearch instance
+# Set to false if you're running on a solo or app_master
+#elasticsearch['configure_cluster'] = false

--- a/examples/elasticsearch/cookbooks/custom-elasticsearch/attribues/default.rb
+++ b/examples/elasticsearch/cookbooks/custom-elasticsearch/attribues/default.rb
@@ -1,14 +1,16 @@
 # Modify the variables below to change how Elasticsearch will be installed
 # See cookbooks/elasticsearch/attributes/default.rb for the complete list of configurable variables
 
-# Run Elasticsearch on util instances named elasticsearch_*
-# This is the default
-#elasticsearch['is_elasticsearch_instance'] = ( node['dna']['instance_role'] == 'util' && node['dna']['name'].include?('elasticsearch_') )
+default['elasticsearch'].tap do |elasticsearch|
+  # Run Elasticsearch on util instances named elasticsearch_*
+  # This is the default
+  elasticsearch['is_elasticsearch_instance'] = ( node['dna']['instance_role'] == 'util' && node['dna']['name'].include?('elasticsearch_') )
 
-# Run Elasticsearch on a solo or app_master instance
-# Not recommended for production environments
-#elasticsearch['is_elasticsearch_instance'] = ( ['solo', 'app_master'].include?(node['dna']['instance_role']) )
+  # Run Elasticsearch on a solo or app_master instance
+  # Not recommended for production environments
+  #elasticsearch['is_elasticsearch_instance'] = ( ['solo', 'app_master'].include?(node['dna']['instance_role']) )
 
-# Set this to true if you're running more than one elasticsearch instance
-# Set to false if you're running on a solo or app_master
-#elasticsearch['configure_cluster'] = false
+  # Set this to true if you're running more than one elasticsearch instance
+  # Set to false if you're running on a solo or app_master
+  elasticsearch['configure_cluster'] = true
+end

--- a/examples/elasticsearch/cookbooks/custom-elasticsearch/metadata.rb
+++ b/examples/elasticsearch/cookbooks/custom-elasticsearch/metadata.rb
@@ -1,0 +1,10 @@
+name 'custom-elasticsearch'
+description 'Configuration & deployment of Elasticsearch on Engine Yard'
+long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
+maintainer 'Engine Yard'
+maintainer_email 'support@engineyard.com'
+version '0.0.1'
+issues_url 'https://github.com/engineyard/ey-cookbooks-stable-v5/issues'
+source_url 'https://github.com/engineyard/ey-cookbooks-stable-v5'
+
+depends 'elasticsearch'

--- a/examples/elasticsearch/cookbooks/custom-elasticsearch/recipes/default.rb
+++ b/examples/elasticsearch/cookbooks/custom-elasticsearch/recipes/default.rb
@@ -1,0 +1,1 @@
+include_recipe 'elasticsearch'

--- a/examples/elasticsearch/cookbooks/ey-custom/metadata.rb
+++ b/examples/elasticsearch/cookbooks/ey-custom/metadata.rb
@@ -1,0 +1,3 @@
+name 'ey-custom'
+
+depends 'custom-elasticsearch'

--- a/examples/elasticsearch/cookbooks/ey-custom/recipes/after-main.rb
+++ b/examples/elasticsearch/cookbooks/ey-custom/recipes/after-main.rb
@@ -1,0 +1,1 @@
+include_recipe 'custom-elasticsearch'


### PR DESCRIPTION
* V4 recipe has been cleaned up. Code duplication between `recipes/default.rb` and `recipes/non_util.rb` has been removed.
* The code for S3 support aren't being called and appears to be unused was removed
* The monit health check URL has been changed to `/` from `/_cat/health` in the V4 recipe. The newer monit on V5 is more sensitive and is reporting false positives on `/_cat/health`
* `/usr/lib/elasticsearch/bin/elasticsearch` needs to be started with the `-d` option, otherwise the newer monit will think the process has turned zombie and will terminate it.