### PR TITLE
CC-1056 CC-1055 Remove non-eselect and update nodejs versions

### DIFF
--- a/cookbooks/node/attributes/node.rb
+++ b/cookbooks/node/attributes/node.rb
@@ -1,29 +1,19 @@
 default['nodejs']['version'] = node.engineyard.environment.metadata('nodejs_version','4.4.5')
 default['nodejs']['available_versions'] = [
-  '0.12.6',  # net-libs/nodejs-0.12.6
-  '0.12.7',  # net-libs/nodejs-0.12.7
-  '0.12.10',  # net-libs/nodejs-0.12.10
-  '4.4.0', # net-libs/nodejs-4.4.0
-  '4.4.1', # net-libs/nodejs-4.4.1
   '4.4.5', # net-libs/nodejs-4.4.5
-  '5.9.1', # net-libs/nodejs-5.9.1
-  '5.10.1', # net-libs/nodejs-5.10.1
+  '4.6.0', # net-libs/nodejs-4.6.0
   '5.11.0', # net-libs/nodejs-5.11.0
-  '6.4.0' # net-libs/nodejs-6.4.0
+  '6.4.0', # net-libs/nodejs-6.4.0
+  '6.7.0' # net-libs/nodejs-6.7.0
 ]
 
 if (node.engineyard.metadata('openssl_ebuild_version','1.0.1') =~ /1\.0\.1/)
   default['nodejs']['available_versions'].concat ([
-    '0.12.6',  # net-libs/nodejs-0.12.6
-    '0.12.7',  # net-libs/nodejs-0.12.7
-    '0.12.10',  # net-libs/nodejs-0.12.10
-    '4.4.0', # net-libs/nodejs-4.4.0
-    '4.4.1', # net-libs/nodejs-4.4.1
     '4.4.5', # net-libs/nodejs-4.4.5
-    '5.9.1', # net-libs/nodejs-5.9.1
-    '5.10.1', # net-libs/nodejs-5.10.1
+    '4.6.0', # net-libs/nodejs-4.6.0
     '5.11.0', # net-libs/nodejs-5.11.0
-    '6.4.0' # net-libs/nodejs-6.4.0
+    '6.4.0', # net-libs/nodejs-6.4.0
+    '6.7.0' # net-libs/nodejs-6.7.0
 
   ])
 end


### PR DESCRIPTION
Description of your patch
-------------
Removed non-eselectable nodejs versions from available nodejs file and added updated 6.7.0 and 4.6.0 to available versions

Recommended Release Notes
-------------
Updates nodejs available versions to only list valid eselectable targets and updates available versions.

Estimated risk
-------------
Low

Components involved
-------------
Nodejs

Description of testing done
-------------
Ran Chef with change and verified that main chef completes

QA Instructions
-------------
1. Build environment on stable stack
1. Verify chef completes
1. Upgrade to new stack and verify chef completes
1. Build environment on new stack and verify chef completes