### PR TITLE
CC-1062 Install rack 1.6.4 before installing Unicorn

### DIFF
--- a/cookbooks/unicorn/recipes/install.rb
+++ b/cookbooks/unicorn/recipes/install.rb
@@ -2,6 +2,12 @@ ey_cloud_report "unicorn" do
   message "processing unicorn - install"
 end
 
+gem_package 'rack' do
+  version "1.6.4"
+  action :install
+end
+
+
 gem_package 'unicorn' do
   version "4.1.1"
   action :install


### PR DESCRIPTION
## Description of your patch

rack 2.0.1 was released last June 30. It requires Ruby 2.2.2.

For environments using the Unicorn stack, our main chef installs Unicorn 4.1.1 which has "rack >= 0" as a production dependency. This ends up installing rack 2.0.1 which breaks on pre-Ruby 2.2.2 environments.

This fix installs rack 1.6.4 before installing Unicorn 4.1.1. Before rack 2.0.1 was released, Unicorn 4.1.1 already installs rack 1.6.4, so there is no change from the behaviour we had before June 30.

Related YT: https://tickets.engineyard.com/issue/CC-1010
## Recommended Release Notes

Installs rack 1.6.4 before installing Unicorn, to get around rack 2.0.1's dependency on Ruby 2.2.
## Estimated risk

Minimal. Applications that use rack 1.6.4 will behave just like before. I tested against an application with Unicorn 5.1.0 and rack 2.0.1 on the Gemfile - the app was succesfully loaded by Unicorn.
## Components involved

main chef Cookbooks
## Description of testing done

Boot a solo environment, Ruby 2.1, Unicorn, verify that main chef runs cleanly
Deploy
Upgrade the environment to Ruby 2.2, click Apply, verify that main chef runs cleanly
Deploy
Update the Gemfile to use Unicorn 5.1.0 and Rack 2.0.1 then Deploy
## QA Instructions

See testing done above
