### PR TITLE
fixes for collectd and rrdtool

### DIFF
--- a/cookbooks/collectd/files/default/collectd_nanny
+++ b/cookbooks/collectd/files/default/collectd_nanny
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+if (( $# > 1 )) || { (( $# != 0 )) && [[ $1 != 'daily' ]] ;}
+then
+  echo 1>&2 Usage: $0 [daily]
+  exit 127
+fi
+
+if [[ $1 == 'daily' ]]
+then
+  #echo "Resetting collectd based on daily schedule"
+  # inittab will reset automatically
+  killall -9 collectd
+  #echo "done!"
+else
+  #echo "Cancelling child processes running longer than 1 hour..."
+  ps -eo pid,ppid,etime,cmd|grep '/usr/sbin/[c]ollectd'|awk '{print $1" "$2" "$3}' | while read -r p
+  do
+    unset pid
+    unset days
+    pid=$(echo "$p"|awk '{print $1}')
+    ppid=$(echo "$p"|awk '{print $2}')
+    datepart=$(echo "$p"|awk '{print $3}')
+    days=$(echo "$datepart"|awk -F- '{print $1}')
+    hours=$(echo "$datepart"|awk -F: '{print $1}')
+    if [[ "$hours" == *-* ]]
+    then
+      hours=$(echo "$hours"|awk -F- '{print $2}')
+      hours=$(echo $hours+$days*24 | bc)
+    fi
+    #echo "$pid $ppid $datepart $days Hours: $hours"
+    if [[ "$ppid" == 1 ]]
+    then
+      msg="Not killing pid '$pid', it is the parent."
+      #echo "$msg"
+    elif [[ "$hours" =~ ^[0-9]+$ ]] && [[ "$hours" -gt 1 ]]
+    then
+      #echo "Killing pid '$pid' live for '$hours' hours."
+      kill -9 "$pid"
+    fi
+  done
+  #echo "done!"
+fi

--- a/cookbooks/collectd/recipes/default.rb
+++ b/cookbooks/collectd/recipes/default.rb
@@ -50,7 +50,7 @@ cron 'hourly collectd check' do
   day '*'
   month '*'
   weekday '*'
-  command 'collectd_nanny'
+  command '/engineyard/bin/collectd_nanny'
 end
 
 cron 'daily collectd check' do
@@ -59,7 +59,7 @@ cron 'daily collectd check' do
   day '*'
   month '*'
   weekday '*'
-  command 'collectd_nanny daily'
+  command '/engineyard/bin/collectd_nanny daily'
 end
 
 has_db = ['solo','db_master','db_slave'].include?(node.dna['instance_role'])

--- a/cookbooks/collectd/recipes/default.rb
+++ b/cookbooks/collectd/recipes/default.rb
@@ -11,6 +11,12 @@ ey_cloud_report "collectd" do
   message 'processing performance monitoring'
 end
 
+# Update rrdtool-binding to latest available
+# - updates net-analyzer/rrdtool as well
+package 'dev-ruby/rrdtool-bindings' do
+  action :upgrade
+end
+
 include_recipe 'collectd::httpd'
 
 template "/engineyard/bin/ey-alert.rb" do
@@ -29,6 +35,31 @@ end
 
 package 'app-admin/collectd' do
  version node['collectd']['version']
+end
+
+cookbook_file "/engineyard/bin/collectd_nanny" do
+  owner 'root'
+  group 'root'
+  mode 0755
+  source 'collectd_nanny'
+end
+
+cron 'hourly collectd check' do
+  minute '5'
+  hour '0-2,4-23'
+  day '*'
+  month '*'
+  weekday '*'
+  command 'collectd_nanny'
+end
+
+cron 'daily collectd check' do
+  minute '5'
+  hour '3'
+  day '*'
+  month '*'
+  weekday '*'
+  command 'collectd_nanny daily'
 end
 
 has_db = ['solo','db_master','db_slave'].include?(node.dna['instance_role'])

--- a/cookbooks/collectd/recipes/httpd.rb
+++ b/cookbooks/collectd/recipes/httpd.rb
@@ -72,7 +72,7 @@ end
 # Setup HTTP auth so AWSM can get at the graphs
 execute "install-http-auth" do
   command %Q{
-    htpasswd -cb /etc/collectd-httpd/collectd-httpd.users  engineyard #{node.dna['haproxy']['password']}
+    htpasswd -cb /etc/collectd-httpd/collectd-httpd.users  engineyard #{node.engineyard.environment['stats_password']}
   }
 end
 


### PR DESCRIPTION
## Description of your patch

Adds collectd_nanny script to terminate stuck workers, and restart collectd daily.
Upgrades rrdtool to allow for performance graphs on the cloud dashboard.
Corrects configuration for stats to pull password from correct location in the metadata
## Recommended Release Notes

Fixes missing performance graphs on the cloud dashboard.
Adds functionality to improve stability of collectd monitoring.
## Estimated risk

Low
- Fixes existing broken content
- Adds script that resets collectd daily
## Components involved

$ git diff next-release --name-only
cookbooks/collectd/files/default/collectd_nanny
cookbooks/collectd/recipes/default.rb
cookbooks/collectd/recipes/httpd.rb
## Description of testing done

Under the 16.06 stack
- Provisioned a cluster using the existing Stack with automatic version upgrades disabled (default)
- In the dashboard accessed the "Performance graphs" URL and selected one of the graphs
- Validated:
  - the graph did not appear
- On one of the instances Ran:
  - `crontab -l |grep collectd`
- Validated:
  - the command returns 0 rows
- In the dashboard accessed the "Performance graphs" URL and selected one of the graphs
- Validated:
  - the graphs now appear
- On one of the instances Ran:
  - `crontab -l |grep collectd`
- Validated:
  - the command returns 4 rows

```
  # Chef Name: hourly collectd check
  5 0-2,4-23 * * * collectd_nanny
  # Chef Name: daily collectd check
  5 3 * * * collectd_nanny daily
```
## QA Instructions

Using the 16.06 stack boot one of each instance role (app, app_master, db_master, db_slave, util, solo). Verify the cron schedule exists for each role, spot check graphs for each and verify all graphs checked are visible.

Recheck the instances after 3:05 AM system time has passed and run `ps -ef|grep '/usr/sbin/[c]ollectd'` and confirm that the timestamp for collectd is more recent than 3:04 AM.
