### PR TITLE
Postgres extensions support

### DIFF
--- a/cookbooks/postgresql/README.md
+++ b/cookbooks/postgresql/README.md
@@ -9,3 +9,27 @@ dependencies
 - ebs - manages the attachment and formatting of EBS volumes, and physical backup scheduling
 - ey-lib - provides internal stack functionality
 - ey-backup - establishes logical backup scheduling
+
+Extensions
+==========
+
+Postgres core extensions can be specified for a database by either:
+
+1. Creating /db/postgresql/extensions.json with the following format:
+
+{
+  'dbname': ['ext_name', ...],
+  ....
+}
+
+2. Using the pg_extension custom resource directly in a cookbook:
+
+pg_extension 'resource block name' do
+  ext_name [String, Array] # required, either a single extension name or multiple in an array
+  db_name [String, Array] # required, either a single db name or multiple in an array
+  schema_name String # optional, name of schema to install extension(s) to, must be present in all db specified in db_name
+  version String # optional, version of extension to install, only applicable if single ext_name is given
+  old_version # optional, for replacing old style non-extension contrib package
+end
+
+See PostgreSQL CREATE EXTENSION docs for full explanation of schema_name, version, and old_version

--- a/cookbooks/postgresql/attributes/extension_details.rb
+++ b/cookbooks/postgresql/attributes/extension_details.rb
@@ -1,0 +1,30 @@
+# Here you can set a few key attributes for individual extensions. Each key
+# has a default so an extension entry is only needed if one or more of the 
+# defaults need to be overriden.
+#
+# Valid keys w/ their defualts:
+#
+# min_pg_version: 9.4 - minimum Postgres version needed
+# max_pg_version: nil
+# use_load: nil -- this is mostly for auto_explain which needs LOAD
+#    statement instead of CREATE EXTENSION
+
+default[:pg_extensions_file] = '/db/postgresql/extensions.json'
+
+default[:pg_ext_details] = {
+  'auto_explain' => {
+    use_load: true
+  },
+  'test_parser' => {
+    max_version: 9.4
+  },
+  'test_shm_mq' => {
+    max_version: 9.4
+  }
+}
+
+# postgis version details
+default[:postgis_version] = '2.2.2'
+default[:proj_version] = "4.8.0"
+default[:geos_version] = "3.5.0-r2"
+default[:gdal_version] = "1.11.1"

--- a/cookbooks/postgresql/libraries/helpers.rb
+++ b/cookbooks/postgresql/libraries/helpers.rb
@@ -19,6 +19,18 @@ module PostgreSQL
     def binary_pg_version
       %x{psql -U postgres --version | grep PostgreSQL | awk '{print $NF}'}.strip
     end
+
+    def add_shared_preload_library(lib)
+      custom_conf = "/db/postgresql/#{node[:postgresql][:short_version]}/custom.conf"
+      body = File.read(custom_conf)
+      return if body[/shared_preload_libraries.*#{lib}/]
+      if body[/shared_preload_libraries/]
+        body.gsub!(/^(shared_preload_libraries.*'?)(.*?)('.*)$/, '\1\2,' + lib + '\3')
+        File.write(custom_conf, body)
+      else
+        %x{echo "shared_preload_libraries = '#{lib}'" >> #{custom_conf}}
+      end
+    end
   end
 end
 

--- a/cookbooks/postgresql/recipes/auto_explain.rb
+++ b/cookbooks/postgresql/recipes/auto_explain.rb
@@ -1,0 +1,31 @@
+custom_conf = "/db/postgresql/#{node[:postgresql][:short_version]}/custom.conf"
+
+body = ''
+ruby_block 'add auto_explain to custom.conf' do
+  block do
+    body = ::File.read(custom_conf)
+    body += <<-EOF
+
+auto_explain.log_min_duration = '3s'
+auto_explain.log_analyze = 'false'
+auto_explain.log_verbose = 'false'
+auto_explain.log_buffers = 'false'
+auto_explain.log_format = 'text'
+auto_explain.log_nested_statements = 'false'
+EOF
+    File.write(custom_conf, body)
+    add_shared_preload_library('auto_explain')
+  end
+  not_if "[ -e #{custom_conf} ] && grep auto_explain #{custom_conf}"
+end
+
+# file "configure auto_explain" do
+#   action :create
+#   path custom_conf
+#   content lazy { body }
+#   not_if "[ -e #{custom_conf} ] && grep auto_explain #{custom_conf}"
+# end
+
+execute "reload postgres service" do
+  command "/etc/init.d/postgresql-#{node[:postgresql][:short_version]} reload"
+end

--- a/cookbooks/postgresql/recipes/pg_stat_statements.rb
+++ b/cookbooks/postgresql/recipes/pg_stat_statements.rb
@@ -1,0 +1,18 @@
+custom_conf = "/db/postgresql/#{node[:postgresql][:short_version]}/custom.conf"
+
+body = ''
+ruby_block 'add pg_stat_statements to custom.conf' do
+  block do
+    body = File.read(custom_conf)
+    body += <<-EOF
+
+pg_stat_statements.max = 10000
+pg_stat_statements.track = all
+EOF
+    File.write(custom_conf, body)
+    add_shared_preload_library('pg_stat_statements')
+  end
+  not_if "[ -e #{custom_conf} ] && grep pg_stat_statements #{custom_conf}"
+end
+
+Chef::Log.info("The pg_stat_statements extension has been created but a server restart is needed to load the module for it to work.")

--- a/cookbooks/postgresql/recipes/postgis_build.rb
+++ b/cookbooks/postgresql/recipes/postgis_build.rb
@@ -1,0 +1,23 @@
+package_use "sci-libs/geos" do
+  flags "-ruby"
+end
+
+enable_package "sci-libs/gdal" do
+  version node[:gdal_version]
+end
+
+enable_package "sci-libs/geos" do
+  version node[:geos_version]
+end
+enable_package "sci-libs/proj" do
+  version node[:proj_version]
+end
+
+enable_package "dev-db/postgis" do
+  version node[:postgis_version]
+end
+
+package "dev-db/postgis" do
+  version node[:postgis_version]
+  action :install
+end

--- a/cookbooks/postgresql/recipes/server_configure.rb
+++ b/cookbooks/postgresql/recipes/server_configure.rb
@@ -301,3 +301,13 @@ node.engineyard.apps.each do |app|
     owner username
   end
 end
+
+if ::File.exist?(node[:pg_extensions_file])
+  exts = JSON.parse(::File.read(node[:pg_extensions_file]))
+  exts.each do |db_name, exts|
+    pg_extension "loading extensions #{exts} to database #{db_name}" do
+      ext_name exts
+      db_name db_name
+    end
+  end
+end

--- a/cookbooks/postgresql/resources/pg_extension.rb
+++ b/cookbooks/postgresql/resources/pg_extension.rb
@@ -1,0 +1,67 @@
+resource_name :pg_extension
+
+property :ext_name, [String, Array], required: true
+property :db_name, [String, Array], required: true
+property :schema_name, String
+property :version, String
+property :old_version, String
+property :use_load, [TrueClass, FalseClass], default: false # use LOAD instead of CREATE EXTENSION
+
+action :install do
+  ext_names = ext_name.kind_of?(String) ? [ext_name] : ext_name
+  db_names = db_name.kind_of?(String) ? [db_name] : db_name
+  postgres_version = node[:postgresql][:short_version]
+  
+  if node[:dna][:instance_role][/^(db|solo)/]
+    ext_names.each do |ext_name|
+      ext_details = node[:pg_ext_details][ext_name] || {}
+      
+      # Postgis needs some package work
+      include_recipe 'postgresql::postgis_build' if ext_name[/^postgis/]
+      
+      db_names.each do |db_name|
+        # bail with a log message if the extension isn't supported for the active Postgres major version
+        if (!ext_details[:min_pg_version].nil? and postgres_version < ext_details[:min_pg_version]) || (!ext_details[:max_pg_version].nil? and postgres_version > ext_details[:max_pg_version])
+          Chef::Log.info "PostgreSQL extension #{ext_name} is only supported on versions #{ext_details[:min_pg_version]} #{!ext_details[:max_pg_version].nil? ? "to " + ext_details[:max_pg_version].to_s : "and higher"}. Currently installed version: #{postgres_version}."
+          break
+        end
+        
+        # the main extension/library install bit
+        if node[:dna][:instance_role][/db_master|solo/]
+          Chef::Log.info "Installing PostgreSQL extension #{ext_name} to database #{db_name}."
+          do_load = ext_details[:use_load].nil? ? use_load || false : ext_details[:use_load] || use_load
+          if do_load
+            cmd = 'LOAD'
+            quoted_ext_name = "'#{ext_name}'"
+          else
+            cmd = 'CREATE EXTENSION IF NOT EXISTS'
+            quoted_ext_name = ext_name
+          end
+          execute "Postgresql loading #{use_load ? 'library': 'extension'} #{ext_name}" do
+            command %Q(psql -U postgres -d #{db_name} -c "#{cmd} #{quoted_ext_name} #{"SCHEMA #{schema_name}" if !schema_name.nil? } #{"VERSION #{version}" if !version.nil?} #{"FROM #{old_version}" if !old_version.nil?};")
+          end
+      
+          # and a couple follow up commands for Postgis
+          if ext_name[/postgis/]
+            execute "Updating to correct postgis minor version" do
+              # this is essentially a no-op if already on this version.
+              command %Q(psql -U postgres -d #{db_name} -c 'ALTER EXTENSION postgis UPDATE TO "#{node[:postgis_version]}";')
+            end
+      
+            execute "Grant permissions to the #{node.engineyard.environment.ssh_username} user on the geometry_columns schema" do
+              command %Q(psql -U postgres -d #{db_name} -c "GRANT all on geometry_columns to #{node.engineyard.environment.ssh_username}")
+            end
+      
+            execute "Grant permissions to the #{node.engineyard.environment.ssh_username} user on the spatial_ref_sys schema" do
+              command %Q(psql -U postgres -d #{db_name} -c "GRANT all on spatial_ref_sys to #{node.engineyard.environment.ssh_username}")
+            end
+          end
+        end
+      
+        # these needs some configuration
+        include_recipe 'postgresql::auto_explain' if ext_name == 'auto_explain'
+        include_recipe 'postgresql::pg_stat_statements' if ext_name == 'pg_stat_statements'
+      end
+    end
+  end
+end


### PR DESCRIPTION
- pg_extension custom resource
- Specify core extensions to install via /db/postgresql/extensions.json

QA steps:
1. Boot Postgres env on QA stack with this branch already merged that has a db_slave.
2. Log into the db_master and run the following commands:

`createdb -O deploy foo`
`createdb -O deploy bar`
1. On both the db_master and db_slave create a file called `/db/postgresql/extensions.json` with this as it's contents:

```
{
  "foo": ["isn, postgis"],
  "bar": ["pg_buffercachem, pg_stat_statements"]
}
```
1. Run an Apply on the environment.
2. On both the db_master and db_slave run the following commands and verify that the relevant two extensions are listed for each db:

`psql -c '\dx' foo`
`psql -c '\dx' bar`
