### PR TITLE
add 2 hour timeout on postgres starts and EBS volume resizes

### DIFF
--- a/cookbooks/ebs/recipes/default.rb
+++ b/cookbooks/ebs/recipes/default.rb
@@ -46,6 +46,7 @@ if (`grep '/db ' /etc/fstab` == "")
 
       bash "grow-db-ebs" do
         code "resize2fs #{node['db_volume'].device}"
+        timeout 7200
         only_if { node['db_volume'].found? }
       end
       break

--- a/cookbooks/postgresql/recipes/server_configure.rb
+++ b/cookbooks/postgresql/recipes/server_configure.rb
@@ -251,6 +251,7 @@ end
 
 service "postgresql-#{postgres_version}" do
   action [:enable, :start]
+  timeout 7200
 end
 
 cookbook_file "/engineyard/bin/load_postgres_db.sh" do


### PR DESCRIPTION
## Description of your patch

Adds a 2 hour timeout to Postgres startups and EBS volume resizes. On very large volumes these processes can exceed the 3600 second (1 hour) default timeout of chef.
## Recommended Release Notes

Improve the reliability of chef when starting up Postgres on newly created servers.
Improve the reliability of chef when booting instances with volumes larger than 2TB.
## Estimated risk

Low
- This setting is already in place for MySQL, this just expands it to two additional resources that need it.
## Components involved

$ git diff master --name-only
cookbooks/ebs/recipes/default.rb
cookbooks/postgresql9/recipes/server_configure.rb
## Description of testing done

Under the 16.06 stack
- Provisioned a Postgres database cluster using the updated stack, in edit environment make sure not to enable ext4
- Added a replica database with a 3TB volume:
- Validated result:
  - The instance started successfully.
## QA Instructions

Verify against the 12.11 stack as above. Validate the EBS portion using a mysql cluster

_Note_ These conditions are notoriously difficult to recreate since volume performance when first starting up can be a factor of the data distribution for the underlying volume. The main thing we are looking for here is that these changes don't cause anything to fail or behave more negatively than they already do (currently these time out after one hour).
