### PR TITLE
Adjust collectd health check script to prevent syslog entries at minutes 1-9 of each hour

### DIFF
--- a/cookbooks/collectd/files/default/check_health_for
+++ b/cookbooks/collectd/files/default/check_health_for
@@ -51,7 +51,8 @@ function alert() {
 function check_interval {
     if [[ ! $(( $(date +"%-M") % ${INTERVAL} )) -eq 0 ]] || [[ $(date +"%-M") -eq 0 ]]
     then
-      exit
+      echo "PUTVAL $(hostname) interval=$(( $INTERVAL * 60)) U:$(date)" > /tmp/check_health_for.tmp
+      exit 
     fi
 }
 

--- a/cookbooks/collectd/files/default/check_health_for
+++ b/cookbooks/collectd/files/default/check_health_for
@@ -49,7 +49,7 @@ function alert() {
 # This function is not appropriate for checks that need to run every minute or need to run
 #  at the top of the hour (0 minutes). This was necessary since 0 % {anything} is 0
 function check_interval {
-    if [[ ! $(( $(date +"%M") % ${INTERVAL} )) -eq 0 ]] || [[ $(date +"%M") -eq 0 ]]
+    if [[ ! $(( $(date +"%-M") % ${INTERVAL} )) -eq 0 ]] || [[ $(date +"%-M") -eq 0 ]]
     then
       exit 0
     fi

--- a/cookbooks/collectd/files/default/check_health_for
+++ b/cookbooks/collectd/files/default/check_health_for
@@ -51,7 +51,7 @@ function alert() {
 function check_interval {
     if [[ ! $(( $(date +"%-M") % ${INTERVAL} )) -eq 0 ]] || [[ $(date +"%-M") -eq 0 ]]
     then
-      exit 0
+      exit
     fi
 }
 


### PR DESCRIPTION
## Description of your patch
- Modify collectd health check to eliminate the error "value too great for base" at 08 and 09 minutes after the hour. (CC-929)
- v5 only, modify interval check to output to a file to prevent collectd log messages "...check_health_for' has closed STDERR" (CC-1071)
## Recommended Release Notes
- Reduces warnings created by interval controls of collectd `check_health_for`
## Estimated risk

Minimal, monitoring is in place that would alert to any disruptions.
## Components involved

git diff --name-only next-release
cookbooks/collectd/files/default/check_health_for
## Description of testing done

Deployed a 16.06 current stack with Postgres and validated that the presence of messages like the following in `/var/log/syslog`

`less /var/log/syslog |grep check_health |grep 'value too great'`

```
[2015-10-26 04:08:07] exec plugin: exec_read_one: error = /engineyard/bin/check_health_for: line 48: 08: value too great for base (error token is "08")
[2015-10-26 04:09:37] exec plugin: exec_read_one: error = /engineyard/bin/check_health_for: line 48: 09: value too great for base (error token is "09")
```

For 16.06 only verified entries like the following

`less /var/log/syslog |grep check_health |grep 'STDERR'`

```
[2016-10-25 07:28:49] exec plugin: Program `/engineyard/bin/check_health_for' has closed STDERR.
[2016-10-25 07:36:19] exec plugin: Program `/engineyard/bin/check_health_for' has closed STDERR.
[2016-10-25 07:36:19] exec plugin: Program `/engineyard/bin/check_health_for' has closed STDERR.
[2016-10-25 07:37:19] exec plugin: Program `/engineyard/bin/check_health_for' has closed STDERR.
[2016-10-25 07:38:19] exec plugin: Program `/engineyard/bin/check_health_for' has closed STDERR.
[2016-10-25 07:38:49] exec plugin: Program `/engineyard/bin/check_health_for' has closed STDERR.
[2016-10-25 07:44:19] exec plugin: Program `/engineyard/bin/check_health_for' has closed STDERR.
[2016-10-25 07:47:19] exec plugin: Program `/engineyard/bin/check_health_for' has closed STDERR.
[2016-10-25 07:49:49] exec plugin: Program `/engineyard/bin/check_health_for' has closed STDERR.
```

Upgraded the environment and waited 2 hours:

Reran the command `less /var/log/syslog |grep check_health |grep 'value too great'`
Verified: no new entries since the upgrade

For 16.06 only 

Reran the command `less /var/log/syslog |grep check_health |grep 'STDERR'`
Verified: no new entries since the upgrade
## QA Instructions

On a variety of instance types (application master, utility, database) using the updated stack

Validate against 2009 and 12.11
