### PR TITLE
Create /root/.psqlrc for better prompt and 2000 line .psql_history file

### DIFF
--- a/cookbooks/postgresql/files/default/psqlrc
+++ b/cookbooks/postgresql/files/default/psqlrc
@@ -1,0 +1,11 @@
+\set QUIET 1
+\set PROMPT1 '%n@%M %/ %R%#%x '
+\set PROMPT2 '%n@%M %/ %R%# '
+\pset null '(null)'
+\set timing
+
+\set HISTSIZE 2000
+\set HISTCONTROL ignoredups
+
+\set ON_ERROR_ROLLBACK interactive
+\set QUIET 0

--- a/cookbooks/postgresql/recipes/client_config.rb
+++ b/cookbooks/postgresql/recipes/client_config.rb
@@ -18,3 +18,11 @@ update_file "add_PGUSER_to_root_bash_login" do
   body "export PGUSER='postgres'"
   not_if "grep 'PGUSER' /root/.bash_login"
 end
+
+cookbook_file "/root/.psqlrc" do
+  source 'psqlrc'
+  owner 'root'
+  group 'root'
+  mode '0600'
+  action :create_if_missing
+end


### PR DESCRIPTION
Description of your patch
-------------

Create /root/.psqlrc for better prompt and 2000 line .psql_history file

Recommended Release Notes
-------------

Create /root/.psqlrc for better prompt and 2000 line .psql_history file

Estimated risk
-------------

Low

Components involved
-------------

$ git diff --name-only next-release 
cookbooks/postgresql/files/default/psqlrc
cookbooks/postgresql/recipes/client_config.rb

Description of testing done
-------------


1. Boot Postgres env on QA stack with this branch already merged that has a db_slave.
2. Log into and out of psql (just run `psql` then type `\q` to exit.)
3. Verify that both `/root/.psqlrc` and `/root/.psql_history` exist:

`ls /root/.psqlrc`
`ls /root/.psql_history`

4. Verify that that the .psqlrc looks like this:

```
ip-172-31-22-46 ~ # cat .psqlrc 
\set QUIET 1
\set PROMPT1 '%n@%M %/ %R%#%x '
\set PROMPT2 '%n@%M %/ %R%# '
\pset null '(null)'
\set timing

\set HISTSIZE 2000
\set HISTCONTROL ignoredups

\set ON_ERROR_ROLLBACK interactive
\set QUIET 0
```

QA Instructions
-------------

Same as testing above.