### PR TITLE
CC-1073 Install SSMTP

### DIFF
--- a/cookbooks/ssmtp/recipes/default.rb
+++ b/cookbooks/ssmtp/recipes/default.rb
@@ -8,8 +8,7 @@
 
 package "mail-mta/ssmtp" do
   action :upgrade
-  version "2.62-r7"
-  not_if { "eix -I -C -c mail-mta | grep -v ssmtp | grep mail-mta" }
+  version "2.64-r2"
 end
 
 execute "fix the permissions" do


### PR DESCRIPTION
## Description of your patch

This patch installs ssmtp properly

Related YT: https://tickets.engineyard.com/issue/CC-1073
## Recommended Release Notes

Resolves an issue with ssmtp not being installed properly
## Estimated risk

Minimal. 
## Components involved

main chef Cookbooks
## Description of testing done
1. Boot an environment on v5
2. Verify chef finishes
3. Verify `eix ssmtp` doesn't have an installed version
4. Upgrade to target stack
5. Verify chef finishes
6. Verify `eix ssmtp` has 2.64-r2 installed
## QA Instructions

See testing done above
