### PR TITLE
defaults sync_binlog to 0 for all MySQL versions

### DIFF
--- a/cookbooks/mysql/templates/default/my.conf.erb
+++ b/cookbooks/mysql/templates/default/my.conf.erb
@@ -75,6 +75,7 @@ log-bin-index	= <%= @datadir %>/master-bin.index
 log-slave-updates = 1
 binlog-format  = MIXED
 <% end %>
+sync_binlog = 0
 
 # END master/slave configuration
 


### PR DESCRIPTION
## Description of your patch

Sets a default value of `sync_binlog=0` for MySQL databases to improve performance under MySQL 5.7. MySQL versions < 5.7 default to 0, 5.7 defaults this to 1 which creates issues for database performance.
## Recommended Release Notes

Default `sync_binlog` to 0 for MySQL 5.7 to improve binary logging performance.
## Estimated risk

Low
- This setting is the value used by prior instances of MySQL
- This setting really only changes things for MySQL 5.7 which is behind a feature flag anyway.
## Components involved

$ git diff next-release --name-only
cookbooks/mysql/templates/default/my.conf.erb
## Description of testing done

Under the 12.11 stack
- Provisioned a cluster using the existing Stack running MySQL 5.7
- Ran:
  - `mysql -NB -e "show global variables like 'sync_binlog'"`
- Validated result:
  
  ```
  sync_binlog   1
  ```
- Deployed to tpol-2016 dev stack.
- Upgraded the environment.
- Restarted mysql with `/etc/init.d/mysql restart`
- Ran: 
  - `mysql -NB -e "show global variables like 'sync_binlog'"`
- Validated result:
  
  ```
  sync_binlog   0
  ```
## QA Instructions

Repeat test above.

Boot a cluster running MySQL 5.6 and validate the cluster boots without error. 
- Run:
  - `mysql -NB -e "show global variables like 'sync_binlog'"`
- Validate result:
  
  ```
  sync_binlog   0
  ```
