### PR TITLE
CC-1060 Passenger 5 not install on utils

### DIFF
--- a/cookbooks/ey-lib/libraries/ey-application.rb
+++ b/cookbooks/ey-lib/libraries/ey-application.rb
@@ -99,7 +99,7 @@ class Chef
       def app_server_recipes
         ['nginx', 'trinidad', 'thin', 'puma', 'passenger', 'passenger3', 'passenger4',
           'passenger::apache', 'passenger::nginx', 'mongrel',
-          'unicorn', 'node::standard', 'node::tcp']
+          'unicorn', 'node::standard', 'node::tcp', 'passenger5']
       end
 
       class Vhost


### PR DESCRIPTION
## Description of your patch

This patch resolves an issue with Passenger 5 and utility instances.

Related YT: https://tickets.engineyard.com/issue/CC-1060
## Recommended Release Notes

Resolves an issue with Passenger 5 and utility instances
## Estimated risk

Minimal. 
## Components involved

main chef Cookbooks
## Description of testing done
1. Boot an environment with Passenger 5 and a utility instance
2. Verify chef fails on the utility instance
3. Upgrade to target stack
4. Verify chef completes on the utility instance
## QA Instructions

See testing done above
