### PR TITLE
CC-1074 Fix NewRelic server monitoring

### DIFF
--- a/cookbooks/newrelic/providers/default.rb
+++ b/cookbooks/newrelic/providers/default.rb
@@ -139,12 +139,12 @@ end
 
 def install_server_monitoring
   enable_package "sys-apps/newrelic-sysmond" do
-    version node.dna['newrelic']['sysmond_version']
+    version node['newrelic']['sysmond_version']
   end
 
   package "sys-apps/newrelic-sysmond" do
     action :upgrade
-    version node.dna['newrelic']['sysmond_version']
+    version node['newrelic']['sysmond_version']
     notifies :run, 'execute[restart nrsysmond]', :delayed
   end
 
@@ -166,11 +166,28 @@ def install_server_monitoring
     variables(:hostname => new_resource.hostname)
   end
 
+  template "/etc/init.d/newrelic-sysmond" do
+    owner "root"
+    group "root"
+    mode 0755
+    backup 0
+    source "newrelic-sysmond.init.erb"
+    variables(:hostname => new_resource.hostname)
+  end
+
+  
   directory "/var/log/newrelic" do
     action :create
     recursive true
     owner 'root'
     group 'root'
+  end
+
+  directory "/var/run/newrelic" do
+    action :create
+    recursive true
+    owner 'newrelic'
+    group 'newrelic'
   end
 
  execute "monit reload" do

--- a/cookbooks/newrelic/templates/default/newrelic-sysmond.init.erb
+++ b/cookbooks/newrelic/templates/default/newrelic-sysmond.init.erb
@@ -1,0 +1,31 @@
+#!/sbin/runscript
+# Copyright 1999-2012 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Header: /var/cvsroot/gentoo-x86/sys-apps/newrelic-sysmond/files/newrelic-sysmond.rc,v 1.2 2012/07/18 16:27:27 hollow Exp $
+
+depend() {
+        use net
+	}
+
+# Fix for YT-ND-112
+start_pre() {
+        checkpath -d -o newrelic:newrelic -m 0775 /var/run/newrelic
+	}
+
+start() {
+        ebegin "Starting NewRelic System Monitor"
+	start-stop-daemon --start \
+	                  --user newrelic \
+	                  --exec /usr/sbin/nrsysmond -- \
+	                  -c /etc/newrelic/nrsysmond.cfg \
+	                  -p /var/run/newrelic/nrsysmond.pid \
+	                  -n '<%= @hostname %>'
+        eend $?
+}
+
+stop() {
+        ebegin "Stopping NewRelic System Monitor"
+        start-stop-daemon --stop --pidfile /var/run/newrelic/nrsysmond.pid
+        eend $?
+}
+			

--- a/cookbooks/newrelic/templates/default/nrsysmond.monitrc.erb
+++ b/cookbooks/newrelic/templates/default/nrsysmond.monitrc.erb
@@ -1,7 +1,7 @@
 check process nrsysmond
-  with pidfile /var/run/nrsysmond.pid
-  start program = "/bin/bash -c '/usr/sbin/nrsysmond -p /var/run/nrsysmond.pid -c /etc/newrelic/nrsysmond.cfg<% if @hostname %> -n <%= @hostname %><% end %>'"
-  stop program = "/bin/bash -c '/bin/kill `cat /var/run/nrsysmond.pid`'"
+  with pidfile /var/run/newrelic/nrsysmond.pid
+  start program = "/etc/init.d/newrelic-sysmond start"
+  stop program = "/etc/init.d/newrelic-sysmond stop"
   if mem > 255.0 MB for 2 cycles then restart
   if cpu > 100% for 2 cycles then restart
   group newrelic


### PR DESCRIPTION
## Description of your patch

This patch: 
- Fixes NewRelic server monitoring.
- Makes monit use start-stop-daemon for its actions when dealing with nrsysmond.
- Set hostname for reporting with a meaningful name.

Related YT: https://tickets.engineyard.com/issue/CC-1074
## Recommended Release Notes

Fixes issues with NewRelic server monitoring.
Configures a meaningful hostname for reporting to NewRelic.
## Estimated risk

Minimal. 
## Components involved

main chef Cookbooks.
## Description of testing done
1. Boot an environment with any stack.
2. Enable NewRelic on the environment.
3. Verify que nothing is reported on the 'servers' section of NewRelic.
4. Upgrade to target stack.
5. Verify that information is recorded/displayed by NewRelic under with a server name in the form of '<amazon_id> - role - name' (name is only present if the instance has one). 
## QA Instructions

See testing done above.
