### PR TITLE
Use pkill to stop node's process group

### DIFF
--- a/cookbooks/node/templates/default/node.god.erb
+++ b/cookbooks/node/templates/default/node.god.erb
@@ -24,7 +24,7 @@ God.watch do |w|
   w.log = "/var/log/engineyard/apps/#{app_name}/node.log"
 
   w.start = "#{shared_dir}/bin/start"
-  w.stop = "/bin/kill -SIGINT -`cat /var/run/god/node-#{app_name}.pid`"
+  w.stop = "/usr/bin/pkill -SIGTERM -g `cat /var/run/god/node-#{app_name}.pid`"
   w.restart = "#{shared_dir}/bin/restart" if File.exist?("#{shared_dir}/bin/restart")
 
   w.transition(:up, :restart) do |on|


### PR DESCRIPTION
## Description of your patch

This patch changes the way node processes are stopped, resulting in a more targeted 'kill' which terminates only the desired processes and nothing else.

Related YT: https://tickets.engineyard.com/issue/ENG-1108
## Recommended Release Notes

Fixes issues when stopping NodeJS applications upon a deploy.
## Estimated risk

Medium. 
## Components involved

main chef Cookbooks.
## Description of testing done
See QA instructions.

## QA Instructions
1. Boot an environment with a NodeJS stack and a NodeJS test app.
2. Check that file `/etc/god/<app_name>/node.rb` contains the line:

```
w.stop = "/bin/kill -SIGINT -`cat /var/run/god/node-#{app_name}.pid`"
```

3. Upgrade to target stack.
4. Check that file `/etc/god/<app_name>/node.rb` contains the line:

```
w.stop = "/usr/bin/pkill -SIGINT -g `cat /var/run/god/node-#{app_name}.pid`"
```

5. Deploy the application several times, checking that:
  - Deploy shouldn't fail
  - Pid of the node daemon changes every time, checking via `pgrep node` and `cat /var/run/god/node-<app_name>.pid`

