### PR TITLE
CC-1051: Reload HAProxy for app.pem template.

### DIFF
--- a/cookbooks/nginx/recipes/default.rb
+++ b/cookbooks/nginx/recipes/default.rb
@@ -24,6 +24,10 @@ include_recipe 'nginx::install'
 
 tlsv12_available  = node.openssl.version =~ /1\.0\.1/
 
+execute "reload-haproxy" do
+  command 'if /etc/init.d/haproxy status ; then /etc/init.d/haproxy reload; else /etc/init.d/haproxy restart; fi'
+  action :nothing
+end
 
 service "nginx" do
   action :nothing
@@ -446,6 +450,7 @@ php_webroot = node.engineyard.environment.apps.first['components'].find {|compon
         :chain => app[:vhosts][1][:chain],
         :key => app[:vhosts][1][:key]
       )
+      notifies :run, resources(:execute => 'reload-haproxy'), :delayed
     end
 
     # CC-260: Same issue as previous; using compile-time if rather than run-time only_if directive


### PR DESCRIPTION
Description
-------------

Reload HAProxy when SSL certificate is updated. An older pull request #25 used restart, and that was reverted in #35. This new patch performs a `/etc/init.d/haproxy reload`.

Recommended Release Notes
-------------

Reloads HAProxy when SSL certificate is updated.

How to Test
-------------

* Create 2 self-signed certificates in https://cloud.engineyard.com/ssl_certificates. One can be named after the app master's hostname. The other can be named anything.
* Create a new environment using the latest stable-v5 stack.
* Assign any of the two SSL certificates to the environment. Click Apply.
* Check /etc/nginx/ssl/appname.pem. Take note of its timestamp. Also note the start time of the HAProxy process: `ps -ef | grep haproxy`.
* Try assigning the other SSL certificate to the environment, click Apply, and you should see that the appname.pem changes (see timestamp). Without the patch, the start time of the HAProxy process doesn't change as it's not reloaded. If you check the site on the browser and look at the certificate details, the hostname will still refer to the old certificate.
* When you switch to the other SSL certificate and click Apply, if the patch is already applied, the start time of the HAProxy process should be updated. Also, load the site on your browser, and check the certificate details for the hostname. With the patch, the hostname should change as expected.
