### PR TITLE
Cc 1049

### DIFF
--- a/cookbooks/php/README.md
+++ b/cookbooks/php/README.md
@@ -5,7 +5,7 @@ This PHP recipe is used to install, configure, and eselect the specified version
 
 
 ## Changing the installed version
-If you would like to change the version of PHP installed with this recipe this can be accomplished by updateing the attributes/php.rb file.  At present modifying the version specified after the else clause on line 9 of attributes/php.rb will change the default version installed.  A change made here will update both the cli and fpm php versions.
+When applicable the most strait forward way to change the PHP major version is to select the appropriate version via the dashboard.  This recipe will default to that selection first.  If you would like to change the minor version of PHP installed with this recipe this can be accomplished by updating the attributes/php.rb file.  A change made here will update both the cli and fpm php versions.
 
 ## Changing the php.ini configuration
-This recipe uses files/default/php.ini to configure the command line (/etc/php/cli-php{VERSION}/php.ini) and the php-fpm (/etc/php/fpm-php{VERSION}/php.ini) configuration files.  files/default/php.ini can be modified as desired to accomidate alternate values.
+This recipe uses files/default/php.ini to configure the command line (/etc/php/cli-php{VERSION}/php.ini) and the php-fpm (/etc/php/fpm-php{VERSION}/php.ini) configuration files.  files/default/php.ini can be modified as desired to accommodate alternate values.

--- a/cookbooks/php/README.md
+++ b/cookbooks/php/README.md
@@ -1,4 +1,11 @@
 PHP
 ====
 
-PHP recipe to update the version update attributes/php.rb
+This PHP recipe is used to install, configure, and eselect the specified version of PHP as well as default php.ini files. 
+
+
+## Changing the installed version
+If you would like to change the version of PHP installed with this recipe this can be accomplished by updateing the attributes/php.rb file.  At present modifying the version specified after the else clause on line 9 of attributes/php.rb will change the default version installed.  A change made here will update both the cli and fpm php versions.
+
+## Changing the php.ini configuration
+This recipe uses files/default/php.ini to configure the command line (/etc/php/cli-php{VERSION}/php.ini) and the php-fpm (/etc/php/fpm-php{VERSION}/php.ini) configuration files.  files/default/php.ini can be modified as desired to accomidate alternate values.

--- a/cookbooks/php/attributes/php.rb
+++ b/cookbooks/php/attributes/php.rb
@@ -6,8 +6,8 @@ default['php']['version'] = case attribute['dna']['engineyard']['environment']['
   when 'php_7'
     '7.0.11'
   else
-   #'7.0.11'
-   '5.6.25'	
+   '7.0.11'
+   #'5.6.25'	
 end
  
 default['php']['minor_version'] =  default['php']['version'].split(".").first(2).join(".")

--- a/cookbooks/php/attributes/php.rb
+++ b/cookbooks/php/attributes/php.rb
@@ -6,8 +6,8 @@ default['php']['version'] = case attribute['dna']['engineyard']['environment']['
   when 'php_7'
     '7.0.11'
   else
-   '7.0.11'
-   #'5.6.25'	
+   #'7.0.11'
+   '5.6.25'	
 end
  
 default['php']['minor_version'] =  default['php']['version'].split(".").first(2).join(".")

--- a/cookbooks/php/attributes/php.rb
+++ b/cookbooks/php/attributes/php.rb
@@ -1,2 +1,13 @@
-default['php']['version'] = "5.6.25"
 default['php']['full_atom'] = "dev-lang/php"
+
+default['php']['version'] = case attribute['dna']['engineyard']['environment']['components'].map(&:values).flatten.find(/^php_/).first
+  when 'php_56'
+    '5.6.25'
+  when 'php_7'
+    '7.0.11'
+  else
+   #'7.0.11'
+   '5.6.25'	
+end
+ 
+default['php']['minor_version'] =  default['php']['version'].split(".").first(2).join(".")

--- a/cookbooks/php/recipes/composer.rb
+++ b/cookbooks/php/recipes/composer.rb
@@ -1,5 +1,5 @@
 # Report to Cloud dashboard
-ey_cloud_report "processing php" do
+ey_cloud_report "processing php composer.rb" do
   message "processing php - composer"
 end
 

--- a/cookbooks/php/recipes/configure.rb
+++ b/cookbooks/php/recipes/configure.rb
@@ -1,4 +1,4 @@
-cookbook_file "/etc/php/cli-php5.6/php.ini" do
+cookbook_file "/etc/php/cli-php#{node["php"]["minor_version"]}/php.ini" do
   source "php.ini"
   owner "root"
   group "root"

--- a/cookbooks/php/recipes/install.rb
+++ b/cookbooks/php/recipes/install.rb
@@ -15,7 +15,7 @@ end
 
 execute 'eslect php cli version' do
   command "eselect php set cli php#{node["php"]["minor_version"]}"
-#  not_if ( "eselect php list cli | grep \* | grep #{node['php']['minor_version']}" )
+  not_if "php -v | grep PHP | grep #{node['php']['version']}"
 end
 
 

--- a/cookbooks/php/recipes/install.rb
+++ b/cookbooks/php/recipes/install.rb
@@ -13,6 +13,13 @@ package node['php']['full_atom'] do
   action :install
 end
 
+execute 'eslect php cli version' do
+  command "eselect php set cli php#{node["php"]["minor_version"]}"
+#  not_if ( "eselect php list cli | grep \* | grep #{node['php']['minor_version']}" )
+end
+
+
+
 # Install required extensions
 # enable_package "dev-php/pecl-memcache" do
 #   version "3.0.8-r1"


### PR DESCRIPTION
**Description of your patch**

This patch adds the ability to select PHP versions.  If the non-ruby-version selection flag is in place this will respect 5.6 (5.6.25) and 7.0 (7.0.11) as valid choices, otherwise the fallback version of 5.6.25 is used which is in line with the current default

Related YT: https://tickets.engineyard.com/issue/CC-1049

**Recommended Release Notes**

Adds the ability to select PHP versions

**Estimated risk**

Minimal.

**Components involved**

main chef Cookbooks

**Description of testing done**

Booted a fresh environment without the nonruby-version selection flag enabled
Confirmed that 5.6.25 was installed for php and php-fpm
Modified the fallback version around line 9 of cookbooks/php/attributes/php.rb to use 7.0.11
Uploaded and ran chef, Confirmed that 7.0.11 was used for php and php-fpm versions
Enabled the nonruby version selection feature flag
Booted an environment that was configured to use 5.6 via the dashboard and applied recipes
Ran chef and confirmed 5.6.25 was installed for php and php-fpm
Modified the fallback version around line 9 of cookbooks/php/attributes/php.rb to use 7.0.11 and selected php 5.3 (not supported) via the dashboard interface and ran chef
Confirmed that 7.0.11 was used for php and php-fpm versions
Set dashboard specified version to 5.6
Applied and confirmed 5.6 was in use


**QA Instructions**

See testing done above