### PR TITLE
Modified /engineyard/bin/sidekiq to pass worker ID to support reliable fetch

### DIFF
--- a/cookbooks/sidekiq/files/default/sidekiq
+++ b/cookbooks/sidekiq/files/default/sidekiq
@@ -66,7 +66,7 @@ start ()
   fi
 
   # start sidekiq
-  sudo -u "${app_user}" -E -H "${sidekiq}" -d -C "${conf_file}" -e "${rails_env}" -r "${app_root}" -P "${pid_file}" -L "${log_file}" &
+  sudo -u "${app_user}" -E -H "${sidekiq}" -d -C "${conf_file}" -e "${rails_env}" -r "${app_root}" -P "${pid_file}" -L "${log_file}" -i ${worker_id} &
   exit $?
 }
 


### PR DESCRIPTION
[To use Reliable Fetch (a feature of Sidekiq Pro) you're required to pass a worker ID to each worker](https://github.com/mperham/sidekiq/wiki/Reliability#using-reliable_fetch)