### PR TITLE
Allowed configuring workers independently

### DIFF
--- a/cookbooks/sidekiq/attributes/default.rb
+++ b/cookbooks/sidekiq/attributes/default.rb
@@ -4,25 +4,30 @@
 #
 
 default['sidekiq'].tap do |sidekiq|
-  
+
   # Sidekiq will be installed on to application/solo instances,
   # unless a utility name is set, in which case, Sidekiq will
   # only be installed on to a utility instance that matches
   # the name
   sidekiq['is_sidekiq_instance'] = true
-  
+
   # Number of workers (not threads)
-  sidekiq['workers'] = 1
-  
-  # Concurrency
-  sidekiq['concurrency'] = 25
-  
-  # Queues
-  sidekiq['queues'] = {
-    # :queue_name => priority
-    :default => 1
-  }
-  
+  # and configuration for each worker.
+  sidekiq['workers'] = [{
+
+    # Concurrency (threads)
+    'concurrency' => 25,
+
+    # Queues
+    # { :queue_name => priority }
+    'queues' => {
+      :default      => 1
+    },
+
+    # Memory Limit in MB (for Monit)
+    'memory_limit' => 400
+  }]
+
   # Verbose
   sidekiq['verbose'] = false
 end

--- a/cookbooks/sidekiq/recipes/cleanup.rb
+++ b/cookbooks/sidekiq/recipes/cleanup.rb
@@ -24,7 +24,7 @@ if node['sidekiq']['is_sidekiq_instance']
     end
 
     # yml files
-    node['sidekiq']['workers'].times do |count|
+    node['sidekiq']['workers'].each_with_index do |_, count|
       file "/data/#{app_name}/shared/config/sidekiq_#{count}.yml" do
         action :delete
       end

--- a/cookbooks/sidekiq/recipes/setup.rb
+++ b/cookbooks/sidekiq/recipes/setup.rb
@@ -23,21 +23,20 @@ if node['sidekiq']['is_sidekiq_instance']
       command "monit reload && sleep 10 && monit restart all -g #{app_name}_sidekiq"
       action :nothing
     end
-    
+
     # monit
-    template "/etc/monit.d/sidekiq_#{app_name}.monitrc" do 
-      mode 0644 
-      source "sidekiq.monitrc.erb" 
+    template "/etc/monit.d/sidekiq_#{app_name}.monitrc" do
+      mode 0644
+      source "sidekiq.monitrc.erb"
       backup false
-      variables({ 
-        :app_name => app_name, 
+      variables({
+        :app_name => app_name,
         :workers => node['sidekiq']['workers'],
-        :rails_env => node.dna['environment']['framework_env'],
-        :memory_limit => 400 # MB
+        :rails_env => node.dna['environment']['framework_env']
       })
       notifies :run, "execute[restart-sidekiq-for-#{app_name}]"
     end
-    
+
     # database.yml
     execute "update-database-yml-pg-pool-for-#{app_name}" do
       db_yaml_file = "/data/#{app_name}/shared/config/database.yml"
@@ -48,16 +47,16 @@ if node['sidekiq']['is_sidekiq_instance']
     end
 
     # yml files
-    node['sidekiq']['workers'].times do |count|
+    node['sidekiq']['workers'].each_with_index do |config, count|
       template "/data/#{app_name}/shared/config/sidekiq_#{count}.yml" do
         owner node['owner_name']
         group node['owner_name']
         mode 0644
         source "sidekiq.yml.erb"
         backup false
-        variables(node['sidekiq'])
+        variables(node['sidekiq'].merge(config))
         notifies :run, "execute[restart-sidekiq-for-#{app_name}]"
       end
     end
-  end 
+  end
 end

--- a/cookbooks/sidekiq/templates/default/sidekiq.monitrc.erb
+++ b/cookbooks/sidekiq/templates/default/sidekiq.monitrc.erb
@@ -1,9 +1,11 @@
-<% @workers.times do |count| %>
+<% @workers.each_with_index do |config, count| %>
 # sidekiq worker <%= count %>
 check process sidekiq_<%= @app_name %>_<%= count %>
   with pidfile /var/run/engineyard/sidekiq/<%= @app_name %>/sidekiq_<%= count %>.pid
   start program = "/engineyard/bin/sidekiq <%= @app_name %> start <%= @rails_env %> <%= count %>" with timeout 90 seconds
   stop program = "/engineyard/bin/sidekiq <%= @app_name %> stop <%= @rails_env %> <%= count %>" with timeout 90 seconds
-  if totalmem is greater than <%= @memory_limit %> MB for 3 cycles then restart 
+  <% if config['memory_limit'] %>
+  if totalmem is greater than <%= config['memory_limit'] %> MB for 3 cycles then restart
+  <% end %>
   group <%= @app_name %>_sidekiq
 <% end %>


### PR DESCRIPTION
Unlike #62 and #63, this is a breaking change. It changes the attribute `sidekiq['workers']` from an integer to an array of hashes.

This allows configuring sidekiq workers independently — so that different workers can service different queues, operate with different levels of concurrency or with different memory limits.