### PR TITLE
Fixed permissions for folder containing NR logs

### DIFF
--- a/cookbooks/newrelic/providers/default.rb
+++ b/cookbooks/newrelic/providers/default.rb
@@ -179,8 +179,8 @@ def install_server_monitoring
   directory "/var/log/newrelic" do
     action :create
     recursive true
-    owner 'root'
-    group 'root'
+    owner 'newrelic'
+    group 'newrelic'
   end
 
   directory "/var/run/newrelic" do


### PR DESCRIPTION
This should address an issue present in PR #55 