### PR TITLE
reverts changes associated with CC-1071

### DIFF
--- a/cookbooks/collectd/files/default/check_health_for
+++ b/cookbooks/collectd/files/default/check_health_for
@@ -51,7 +51,6 @@ function alert() {
 function check_interval {
     if [[ ! $(( $(date +"%-M") % ${INTERVAL} )) -eq 0 ]] || [[ $(date +"%-M") -eq 0 ]]
     then
-      echo "PUTVAL $(hostname) interval=$(( $INTERVAL * 60)) U:$(date)" > /tmp/check_health_for.tmp
       exit 
     fi
 }


### PR DESCRIPTION
## Description of your patch
- Modify collectd health check to eliminate the error "value too great for base" at 08 and 09 minutes after the hour. (CC-929)
## Recommended Release Notes
- Reduces warnings created by interval controls of collectd `check_health_for`
## Estimated risk

Minimal, monitoring is in place that would alert to any disruptions.
## Components involved

git diff --name-only next-release
cookbooks/collectd/files/default/check_health_for
## Description of testing done

Deployed a 16.06 current stack with Postgres and validated that the presence of messages like the following in `/var/log/syslog`

`less /var/log/syslog |grep check_health |grep 'value too great'`

```
[2015-10-26 04:08:07] exec plugin: exec_read_one: error = /engineyard/bin/check_health_for: line 48: 08: value too great for base (error token is "08")
[2015-10-26 04:09:37] exec plugin: exec_read_one: error = /engineyard/bin/check_health_for: line 48: 09: value too great for base (error token is "09")
```

Upgraded the environment and waited 2 hours:

Reran the command `less /var/log/syslog |grep check_health |grep 'value too great'`
Verified: no new entries since the upgrade

## QA Instructions

On a variety of instance types (application master, utility, database) using the updated stack

