### PR TITLE
Typo fix: use 2 digits for PHP7 version

### DIFF
--- a/cookbooks/php/attributes/php.rb
+++ b/cookbooks/php/attributes/php.rb
@@ -3,7 +3,7 @@ default['php']['full_atom'] = "dev-lang/php"
 default['php']['version'] = case attribute['dna']['engineyard']['environment']['components'].map(&:values).flatten.find(/^php_/).first
   when 'php_56'
     '5.6.25'
-  when 'php_7'
+  when 'php_70'
     '7.0.11'
   else
    #'7.0.11'


### PR DESCRIPTION
## Description of your patch

This is a minor patch to get the PR https://github.com/engineyard/ey-cookbooks-stable-v5/pull/61 to work.

dna.json uses `php_70`, not `php_7`.

```
        "components": [
          {
            "key": "php_70"
          },
```

Related YT: https://tickets.engineyard.com/issue/CC-1049

## Recommended Release Notes

Adds the ability to select PHP versions, including PHP 7. This is currently behind a feature flag. Please open a Support Ticket to enable it.

## Estimated risk

Minimal.

## Components involved

main chef Cookbooks

## Description of testing done

Enable nonruby-version-select flag
Create a new PHP environment
Pick PHP 7.0
Boot
Edit `/etc/chef/recipes/cookbooks/php/attributes/php.rb` - replace 'php_7' with 'php_70'
Run chef with 

```
PATH=/usr/local/ey_resin/bin:$PATH /home/ey/bin/chef-solo -j /etc/chef/dna.json -c /etc/chef/solo.rb
```
 
## QA instructions

A) Scenarios: Booting a new environment, adding an instance to the environment
Enable nonruby-version-select flag
Create a new gentoo-2016-qa-1.0.32 cluster
Pick PHP 7.0
Boot
Verify that the application was is PHP 7.0
Add a new app instance
Verify that the app instance is running PHP 7.0

B) Scenario: Upgrading an environment
Disable nonruby-version-select
Create a new gentoo-2016-v5.3.0 cluster
Pick PHP 5.6
Verify that the application is running PHP 5.6
Enable nonruby-version-select
Verify that you see PHP 7.0 in the choices
Pick PHP 7.0
Boot
Verify that the application is running PHP 7.0