### PR TITLE
Add labels to New Relic server monitoring and PHP 7.0 support

### DIFF
--- a/cookbooks/newrelic/providers/default.rb
+++ b/cookbooks/newrelic/providers/default.rb
@@ -41,16 +41,16 @@ def install_php_rpm
     '/usr/lib64/php5.6/lib/extensions/no-debug-non-zts-20131226'
   when '7.0'
     '/usr/lib64/php7.0/lib/extensions/no-debug-non-zts-20151012'
-  else
-    '/tmp'
   end
 
-  directory extensions_dir do
-    owner 'root'
-    group 'root'
-    mode 0755
-    action :create
-    recursive true
+  if extensions_dir
+    directory extensions_dir do
+      owner 'root'
+      group 'root'
+      mode 0755
+      action :create
+      recursive true
+    end
   end
 
   directory "/opt/php_rpm" do

--- a/cookbooks/newrelic/providers/default.rb
+++ b/cookbooks/newrelic/providers/default.rb
@@ -36,6 +36,23 @@ end
 
 
 def install_php_rpm
+  extensions_dir = case node['php']['minor_version']
+  when '5.6'
+    '/usr/lib64/php5.6/lib/extensions/no-debug-non-zts-20131226'
+  when '7.0'
+    '/usr/lib64/php7.0/lib/extensions/no-debug-non-zts-20151012'
+  else
+    '/tmp'
+  end
+
+  directory extensions_dir do
+    owner 'root'
+    group 'root'
+    mode 0755
+    action :create
+    recursive true
+  end
+
   directory "/opt/php_rpm" do
     owner 'root'
     group 'root'

--- a/cookbooks/newrelic/providers/default.rb
+++ b/cookbooks/newrelic/providers/default.rb
@@ -115,11 +115,12 @@ def configure_php_rpm
     group "root"
     mode 0644
     source "newrelic-daemon.monitrc.erb"
+    notifies :run, 'execute[monit reload]', :immediately
   end
 
   # cookbooks/php/libraries/php_helpers.rb
   #restart_fpm
-  ['app_master', 'app', 'solo'].include?(node['dna']['instance_role']) do
+  if ['app_master', 'app', 'solo'].include?(node['dna']['instance_role'])
     execute 'monit restart all -g php-fpm' do
       action :run
     end
@@ -131,7 +132,6 @@ def configure_php_rpm
 
   execute "monit reload" do
     action :nothing
-    subscribes :run, 'template[/etc/monit.d/newrelic-daemon.monitrc]', :immediately
     notifies :run, 'execute[restart newrelic-daemon]', :delayed
   end
 
@@ -172,6 +172,7 @@ def install_server_monitoring
     backup 0
     source "nrsysmond.monitrc.erb"
     variables(:hostname => new_resource.hostname)
+    notifies :run, 'execute[monit reload]', :immediately
   end
 
   template "/etc/init.d/newrelic-sysmond" do
@@ -180,6 +181,7 @@ def install_server_monitoring
     mode 0755
     backup 0
     source "newrelic-sysmond.init.erb"
+    notifies :run, 'execute[restart nrsysmond]', :delayed
   end
 
   
@@ -199,7 +201,6 @@ def install_server_monitoring
 
   execute "monit reload" do
     action :nothing
-    subscribes :run, 'template[/etc/monit.d/nrsysmond.monitrc]', :immediately
     notifies :run, 'execute[restart nrsysmond]', :delayed
   end
 

--- a/cookbooks/newrelic/recipes/default.rb
+++ b/cookbooks/newrelic/recipes/default.rb
@@ -8,10 +8,13 @@ end
 # Setting a meningful hostname to easy identification in New Relic dashboard
 id = node.dna['engineyard']['this']
 role = node.dna['instance_role'].gsub('_', ' ')
-name = node['name']
+name = node.dna['name']
+environment = node.dna['environment']['name']
 
 descriptive_hostname = "#{id} - #{role}"
 descriptive_hostname << " (#{name})" if name
+
+labels = "Server:#{id};Role:#{role};Environment:#{environment}"
 
 
 if newrelic_enabled?
@@ -34,6 +37,7 @@ if newrelic_enabled?
   # Use the newrelic resource to install server monitoring
   newrelic "sysmond" do
     hostname descriptive_hostname
+    labels labels
   end
 
 end

--- a/cookbooks/newrelic/resources/default.rb
+++ b/cookbooks/newrelic/resources/default.rb
@@ -14,3 +14,4 @@ attribute :run_type, :name_attribute => true, :kind_of => String
 attribute :app_name, :kind_of => String
 attribute :app_type, :kind_of => String
 attribute :hostname, :kind_of => String
+attribute :labels, :kind_of => String

--- a/cookbooks/newrelic/templates/default/newrelic-sysmond.init.erb
+++ b/cookbooks/newrelic/templates/default/newrelic-sysmond.init.erb
@@ -18,8 +18,7 @@ start() {
 	                  --user newrelic \
 	                  --exec /usr/sbin/nrsysmond -- \
 	                  -c /etc/newrelic/nrsysmond.cfg \
-	                  -p /var/run/newrelic/nrsysmond.pid \
-	                  -n '<%= @hostname %>'
+	                  -p /var/run/newrelic/nrsysmond.pid
         eend $?
 }
 

--- a/cookbooks/newrelic/templates/default/newrelic.cfg.erb
+++ b/cookbooks/newrelic/templates/default/newrelic.cfg.erb
@@ -121,3 +121,5 @@ ssl=true
 # Default: 30
 #
 #timeout=30
+
+labels="<%= @labels %>"

--- a/cookbooks/newrelic/templates/default/nrsysmond.cfg.erb
+++ b/cookbooks/newrelic/templates/default/nrsysmond.cfg.erb
@@ -121,3 +121,5 @@ ssl=true
 # Default: 30
 #
 #timeout=30
+
+labels="<%= @labels %>"


### PR DESCRIPTION
Restart php and nginx after installing New Relic for php only on app
instances
Create newrelic.ini for php 5.6 and 7.0