### PR TITLE
CC-1084 Updated OpenSSL to 1.0.2j

### DIFF
--- a/cookbooks/openssl/attributes/openssl.rb
+++ b/cookbooks/openssl/attributes/openssl.rb
@@ -1,2 +1,2 @@
 default.openssl.using_metadata = !!node.engineyard.metadata("openssl_ebuild_version",nil)
-default.openssl.version = node.engineyard.metadata('openssl_ebuild_version','1.0.2d')
+default.openssl.version = node.engineyard.metadata('openssl_ebuild_version','1.0.2j')


### PR DESCRIPTION
## Description of your patch

Upgrade to version of OpenSSL 1.0.2j

## Recommended Release Notes

Provides OpenSSL 1.0.2 with patches for  CVE-2016-2177, CVE-2016-2178, CVE-2016-2181, CVE-2016-2179, CVE-2016-6302, CVE-2016-8610

## Estimated risk

Low: Updated OpenSSL version

## Components involved

OpenSSL

## Description of testing done

Package testing was performed by Distribution team. Also verified that code change caused 1.0.2j to be used.

## QA Instructions
1. Boot environment on stable stack.
2. Ensure chef runs to completion successfully and app deploys and runs as expected
3. Configure app to use SSL certificate and apply changes
4. Confirm 1.0.2d as the openssl version with openssl version 
5. Confirm the installed version of openssl according to eix openssl  is '1.0.2d'
6. Upgrade to target stack, and click apply
7. Verify 1.0.2j as the openssl version with openssl version 
8. Verify the app is reachable via https and runs as expected
9. Verify the installed version of openssl according to eix openssl  is '1.0.2j'
10. Terminate and recreate environment with code change
11. Verify chef runs to completion successfully and app deploys and runs as expected
12. Configure app to use SSL certificate and apply changes
13. Verify 1.0.2j as the openssl version with openssl version 
14. Verify the app is reachable via https and runs as expected
15. Verify the installed version of openssl according to eix openssl  is '1.0.2j'
16. Verify that 1.0.2j is the latest available version in the 1.0.2 series according to eix
