### PR TITLE
[CC-1090] Fix dj.erb

### DIFF
--- a/cookbooks/delayed_job4/templates/default/dj.erb
+++ b/cookbooks/delayed_job4/templates/default/dj.erb
@@ -154,7 +154,7 @@ if [ -d $RAILS_ROOT ]; then
        # Find children
        WORKER_PID=$(ps axo pid,ppid,command|awk '$2=='$PID' {print $1}')
 
-       kill -15 $PID $PPID; # kill worker and any child that it may have at this very moment
+       kill -15 $PID $WORKER_PID; # kill worker and any child that it may have at this very moment
        logger -t "monit-dj:$WORKER[$$]" "Stopping DJ Worker Process $PID $PPID"
 
        SLEEP_COUNT=0


### PR DESCRIPTION
## Description of your patch

FIXED: Stopping DJ ends up killing the parent process, which is monit. 

## Recommended Release Notes

Custom chef: Fixes an issue with the DelayedJob4 custom chef recipe.

## Estimated risk

Low. Only the DelayedJob4 custom chef recipe was updated.

## Components involved

DelayedJob4 custom chef recipe

## Description of testing done

See QA instructions

## QA Instructions

A. Replicate the error
1. Add an application: https://github.com/radamanthus/noisy_dj and an environment running the stable stack 
2. Modify the delayed_job4 recipe to use a lower memory limit
3. Upload the recipes
4. Boot the environment
5. Get the PID of the monit process
6. Generate 100 jobs: cd /data/noisy_dj/current; ECHO_JOB_COUNT=100 bundle exec rake echo:generate
7. Wait 1 minute
8. Get the PID of the monit process. Verify that it's not the same as the PID obtained in step 5.

B. Verify the fix
9. Upgrade to the target stack
10. Get the PID of the monit process
11. Generate 100 jobs: cd /data/noisy_dj/current; ECHO_JOB_COUNT=100 bundle exec rake echo:generate
12. Wait 1 minute
13. Get the PID of the monit process. Verify that it's not the same as the PID obtained in step 5.
