### PR TITLE
Revert "Modified sidekiq.yml to produce valid YML if a queue name contains punctuation (like ":")"

### DIFF
--- a/cookbooks/sidekiq/templates/default/sidekiq.yml.erb
+++ b/cookbooks/sidekiq/templates/default/sidekiq.yml.erb
@@ -4,6 +4,6 @@
 :verbose: <%= @verbose %>
 :concurrency: <%= @concurrency %>
 :queues:
-<% @queues.each do |queue, priority| %>
-  - [<%= queue.inspect %>, <%= priority %>]
+<% @queues.to_a.each do |q| %>
+  - [<%= q.join(', ') %>]
 <% end %>


### PR DESCRIPTION
Reverts engineyard/ey-cookbooks-stable-v5#62