### PR TITLE
Fix incorrect comparison operator used in collectd check scripts

### DIFF
--- a/cookbooks/collectd/files/default/check_health_for
+++ b/cookbooks/collectd/files/default/check_health_for
@@ -28,7 +28,7 @@ function alert() {
     # no status file for the ACTION exists
     # SEVERITY is not OKAY and ALERT_COUNT is greater than 1
     # SEVERITY is OKAY but an WARN/FAIL alert fired on the last check (ALERT_COUNT will now be > 2)
-    if [[ (! -e "${STATUS_FILE}") || ("${SEVERITY}" != "OKAY" && "${ALERT_COUNT}" > 1) || ("${SEVERITY}" = "OKAY" && "${ALERT_COUNT}" > 2) ]]
+    if [[ (! -e "${STATUS_FILE}") || ("${SEVERITY}" != "OKAY" && "${ALERT_COUNT}" -gt "1") || ("${SEVERITY}" = "OKAY" && "${ALERT_COUNT}" -gt "2") ]]
     then
         echo "PUTNOTIF Time=${timestamp} TYPE=${CHECK_TYPE}-${ACTION} severity=${SEVERITY} message=\"raw_message: $(date +'%T') ${MESSAGE}\""
     fi

--- a/cookbooks/mysql/templates/default/check_mysql.sh.erb
+++ b/cookbooks/mysql/templates/default/check_mysql.sh.erb
@@ -28,7 +28,7 @@ function alert() {
     # no status file for the ACTION exists
     # SEVERITY is not OKAY and ALERT_COUNT is greater than 1
     # SEVERITY is OKAY but an WARN/FAIL alert fired on the last check (ALERT_COUNT will now be > 2)
-    if [[ (! -e "${STATUS_FILE}") || ("${SEVERITY}" != "OKAY" && "${ALERT_COUNT}" > 1) || ("${SEVERITY}" = "OKAY" && "${ALERT_COUNT}" > 2) ]]
+    if [[ (! -e "${STATUS_FILE}") || ("${SEVERITY}" != "OKAY" && "${ALERT_COUNT}" -gt "1") || ("${SEVERITY}" = "OKAY" && "${ALERT_COUNT}" -gt "2") ]]
     then
         echo "PUTNOTIF time=${timestamp} TYPE=process-mysql-${ACTION} severity=${SEVERITY} message=\"raw_message: ${MESSAGE}\""
     fi

--- a/cookbooks/postgresql/templates/default/check_postgres_wrapper.sh.erb
+++ b/cookbooks/postgresql/templates/default/check_postgres_wrapper.sh.erb
@@ -26,7 +26,7 @@ function alert() {
     # no status file for the ACTION exists
     # SEVERITY is not OKAY and ALERT_COUNT is greater than 1
     # SEVERITY is OKAY but an WARN/FAIL alert fired on the last check (ALERT_COUNT will now be > 2)
-    if [[ (! -e "${STATUS_FILE}") || ("${SEVERITY}" != "OKAY" && "${ALERT_COUNT}" > 1) || ("${SEVERITY}" = "OKAY" && "${ALERT_COUNT}" > 2) ]]
+    if [[ (! -e "${STATUS_FILE}") || ("${SEVERITY}" != "OKAY" && "${ALERT_COUNT}" -gt "1") || ("${SEVERITY}" = "OKAY" && "${ALERT_COUNT}" -gt "2") ]]
     then
         echo "PUTNOTIF time=${timestamp} TYPE=process-postgresql-${ACTION} severity=${SEVERITY} message=\"raw_message: ${MESSAGE}\""
     fi


### PR DESCRIPTION

NOTE: QA for this should be handled by one of the non-Erik DBAs.

Description of your patch
-------------

Fix incorrect comparison operator used in collectd check scripts

Recommended Release Notes
-------------

Fix incorrect comparison operator used in collectd check scripts that prevented some OKAY alerts from being delivered.

Estimated risk
-------------

Low

Components involved
-------------

$ git diff --name-only master
cookbooks/collectd/files/default/check_health_for
cookbooks/mysql/templates/default/check_mysql.sh.erb
cookbooks/postgresql/templates/default/check_postgres_wrapper.sh.erb

Description of testing done
-------------

Confirm issue:

1. Boot stable-v5 env. A solo env is fine.
2. Stop the db on it.
3. Confirm failure alerts go out for everything except maybe the checkpoint alert on Postgres servers.
4. Rename the alert failure status files to end with _12, as if they'd already failed that many times.
5. Restart the db.
6. Confirm that OKAY alerts are not sent out in the collectd.log.

Confirm fix:

1. Switch to dev/QA stack with fix.
2. Stop the db on it.
3. Confirm failure alerts go out for everything except maybe the checkpoint alert on Postgres servers.
4. Rename the alert failure status files to end with _12, as if they'd already failed that many times.
5. Restart the db.
6. Confirm that OKAY alerts are sent out in the collectd.log.

QA Instructions
-------------

Same as testing above for each of MySQL and Postgres (any version).
