### PR TITLE
Cc 1069 - Add MySQL 5.5.49 to Stable-v5 (limited access)

### DIFF
--- a/cookbooks/mysql/attributes/version.rb
+++ b/cookbooks/mysql/attributes/version.rb
@@ -2,23 +2,31 @@ lock_major_version = %x{[[ -f "/db/.lock_db_version" ]] && grep -E -o '^[0-9]+\.
 full_version =  %x{[[ -f "/db/.lock_db_version" ]] && grep -E -o '^[0-9]+\.[0-9]+\.[0-9]+' /db/.lock_db_version }
 db_stack = lock_major_version == '' ? attribute.dna['engineyard']['environment']['db_stack_name'] :  "mysql#{lock_major_version.gsub(/\./, '_').strip}"
 
+default['latest_version_55'] = '5.5.49'
 default['latest_version_56'] = '5.6.32'
 default['latest_version_57'] = '5.7.14'
 major_version=''
 
 case db_stack
+when 'mysql5_5'
+  # Note: mysql 5.5 is a limited access feature on this stack; use 5.6 or higher if possible.
+  major_version = '5.5'
+  default['mysql']['latest_version'] = node['latest_version_55']
+  default['mysql']['virtual'] = "#{major_version}-r1"
+  
 when 'mysql5_6', 'aurora5_6', 'mariadb10_0'
-  default['mysql']['latest_version'] = node['latest_version_56']
   major_version = '5.6'
+  default['mysql']['latest_version'] = node['latest_version_56']
+  default['mysql']['virtual'] = major_version
   
 when 'mysql5_7', 'aurora5_7', 'mariadb10_1'
-  default['mysql']['latest_version'] = node['latest_version_57']
   major_version = '5.7'
+  default['mysql']['latest_version'] = node['latest_version_57']
+  default['mysql']['virtual'] = major_version
 
 end
 
 default['mysql']['full_version'] = full_version == '' ? node['mysql']['latest_version'] : full_version
-default['mysql']['virtual'] = major_version
 default['mysql']['short_version'] = major_version
 default['mysql']['logbase'] = "/db/mysql/#{major_version}/log/"
 default['mysql']['datadir'] = "/db/mysql/#{major_version}/data/"

--- a/cookbooks/mysql/recipes/install.rb
+++ b/cookbooks/mysql/recipes/install.rb
@@ -4,6 +4,8 @@ lock_version_file = '/db/.lock_db_version'
 db_running = %x{mysql -N -e "select 1;" 2> /dev/null}.strip == '1'
 
 known_versions = {
+  # Note: mysql 5.5 is a limited access feature on this stack; use 5.6 or higher if possible.
+  'dev-db/mysql' => ['5.5.49'],
   'dev-db/percona-server' => ['5.6.28.76.1', '5.6.29.76.2-r1', '5.6.32.78.1', '5.7.13.6', '5.7.14.8']
 }
 

--- a/cookbooks/mysql/recipes/master.rb
+++ b/cookbooks/mysql/recipes/master.rb
@@ -39,14 +39,14 @@ execute "do-init-mysql" do
     mysql_install_db --basedir=/usr/
   }
   not_if { File.directory?("#{node['mysql']['datadir']}/mysql")  }
-  only_if { node['mysql']['short_version'] == "5.6" }
+  only_if { ['5.5', '5.6'].include?(node['mysql']['short_version']) }
 end
 
 execute "do-init-mysql" do
   command %Q{
     mysqld --initialize-insecure --user=mysql
   }
-  not_if { node['mysql']['short_version'] == "5.6" or File.directory?("#{node['mysql']['datadir']}/mysql") }
+  not_if { ['5.5', '5.6'].include?(node['mysql']['short_version']) or File.directory?("#{node['mysql']['datadir']}/mysql") }
 end
 
 include_recipe "mysql::startup"

--- a/cookbooks/mysql/templates/default/my.conf.erb
+++ b/cookbooks/mysql/templates/default/my.conf.erb
@@ -141,8 +141,9 @@ innodb_buffer_pool_size		= <%= @innodb_buff %>
 innodb_additional_mem_pool_size = 16M
 <% end %>
 <% if @mysql_version == @mysql_5_5 %>
-innodb_adaptive_flushing = 1
-innodb_adaptive_flushing_method = 1
+# -- Stable-v5 uses MySQL Community not Percona
+#innodb_adaptive_flushing = 1
+#innodb_adaptive_flushing_method = 1
 <% end %>
 
 #


### PR DESCRIPTION
Description of your patch
--------------
Adds MySQL Community 5.5.49 to the Stable-v5 Stack. This build is intended for use by customers needing a gradual migration step to the v5 stack and will remain behind a limited access flag.


Recommended Release Notes
--------------
Adds MySQL Community 5.5.49 behind a limited access flag.

Estimated risk
--------------
Low
- An Engine Yard support Engineer must enable this feature for it to be used ensuring it will only be used in limited cases.

Components involved
--------------

$ git diff master --name-only
cookbooks/mysql/attributes/version.rb
cookbooks/mysql/recipes/install.rb
cookbooks/mysql/recipes/master.rb
cookbooks/mysql/templates/default/my.conf.erb

Description of testing done
--------------
Under a testing stack on one of our platform Staging environments

- Provisioned a cluster using an updated testing Stack with automatic version upgrades disabled (default)
- Ran:
  - `mysqld --version`
- Validated:
  - 5.5.49 
  - MySQL is up and running
  - Can add replica databases.

QA Instructions
--------------
NOTE: Requires the release of GD-921 to Production

Enable the limited access flag `mysql5_5_v5`.
Repeat the test above for a Solo configuration
Repeat the test above with a cluster configuration