### PR TITLE
Honor redis utility name for redis.yml generation

### DIFF
--- a/cookbooks/redis/recipes/default.rb
+++ b/cookbooks/redis/recipes/default.rb
@@ -3,8 +3,10 @@
 # Recipe:: default
 #
 
+redis_utility_name = node['redis']['utility_name'] || 'redis'
+
 if ['util'].include?(node['dna']['instance_role'])
-  if node['dna']['name'] == node['redis']['utility_name']
+  if node['dna']['name'] == redis_utility_name
 
     sysctl "Enable Overcommit Memory" do
       variables 'vm.overcommit_memory' => 1
@@ -80,7 +82,7 @@ end
 
 if ['solo', 'app', 'app_master', 'util'].include?(node['dna']['instance_role'])
   instances = node['dna']['engineyard']['environment']['instances']
-  redis_instance = (node['dna']['instance_role'][/solo/] && instances.length == 1) ? instances[0] : instances.find{|i| i['name'] == 'redis'}
+  redis_instance = (node['dna']['instance_role'][/solo/] && instances.length == 1) ? instances[0] : instances.find{|i| i['name'] == redis_utility_name}
 
   if redis_instance
     ip_address = `ping -c 1 #{redis_instance['private_hostname']} | awk 'NR==1{gsub(/\\(|\\)/,"",$3); print $3}'`.chomp


### PR DESCRIPTION
The block in the default recipe that generates `redis.yml` and
the /etc/hosts changes did not previously consider the value of
`node['redis']['utility_name']`, so environments that named their
redis utility instances something other than "redis" were not
getting the app and hosts config.