### PR TITLE
Add EY-HOSTS section to /etc/hosts

### DIFF
--- a/cookbooks/ey-core/recipes/default.rb
+++ b/cookbooks/ey-core/recipes/default.rb
@@ -15,3 +15,5 @@ include_recipe 'timezones'
 #nuke?: include_recipe 'atd'
 include_recipe 'logrotate'
 include_recipe 'lockrun'
+
+include_recipe 'ey-hosts'

--- a/cookbooks/ey-hosts/README.md
+++ b/cookbooks/ey-hosts/README.md
@@ -1,0 +1,19 @@
+ey-hosts
+========
+
+Sets up default /etc/hosts file entries for referring to application, database, and utility instances.
+
+###Naming Convention
+- App Master: ey-app-master
+- App Slave: ey-app-slave[-X]
+- DB Master: ey-db-master
+- DB Replica: ey-db-slave[-X]
+- DB Replica Alternate: ey-db-slave-#{instance_name}[-X]
+- Utility: ey-utility-#{instance_name}[-X]
+
+*Note* For [-X], the `-` is only added if an `X` value exists for a given instance. `X` represents a numeric value that reflects a hosts order in the environment DNA and the dashboard. For hosts based on `instance_name` the `X` reflects the index order on the dashboard for hosts with the same `instance_name`.
+
+dependencies
+============
+
+- ey-lib - provides internal stack functionality

--- a/cookbooks/ey-hosts/metadata.rb
+++ b/cookbooks/ey-hosts/metadata.rb
@@ -1,0 +1,8 @@
+name 'ey-hosts'
+maintainer 'Engine Yard'
+maintainer_email 'support@engineyard.com'
+version '1.0'
+source_url 'https://engineyard.com'
+issues_url 'https://support.engineyard.com'
+
+depends 'ey-lib'

--- a/cookbooks/ey-hosts/recipes/default.rb
+++ b/cookbooks/ey-hosts/recipes/default.rb
@@ -1,0 +1,33 @@
+# Utility instances by instance name (ey-utility-#{name}[-X]) where X is some number if name is not unique
+utility_nodes = node.engineyard.environment.instances.select{|i| ['util'].include?(i['role'])}.map {|i| {"ey-utility-#{i['name']}".gsub(/-$/, '') => node.private_ip_for(i)}}.each_with_object({}) { |el, h| el.each { |k, v| k='' if k.nil?; h[k].nil? ? h[k] = v : h[k] = (Array.new([h[k]]) << v).flatten } }
+
+# DB Replicas by instance name (ey-db-slave-#{name}[-X]) where X is some number if name is not unique
+db_replicas = node.engineyard.environment.instances.select{|i| ['db_slave'].include?(i['role']) and !(i['name'].nil? or i['name'] == '')}.map {|i| {"ey-db-slave-#{i['name']}".gsub(/-$/, '') => node.private_ip_for(i)}}.each_with_object({}) { |el, h| el.each { |k, v| k='' if k.nil?; h[k].nil? ? h[k] = v : h[k] = (Array.new([h[k]]) << v).flatten } }
+
+template "/etc/ey_hosts" do
+  owner 'root'
+  group 'root'
+  mode 0644
+  source "ey_hosts.erb"
+  variables({
+    :utility_nodes => utility_nodes,
+    :db_replicas => db_replicas,
+    :db_replicas_ordered => node.db_slaves,
+    :db_master => node.db_master[0],
+    :app_master => node.app_master[0],
+    :app_slaves => node.app_slaves
+  })
+end
+
+execute "Add EY-HOSTS section to hosts if it doesn't exist" do
+  user "root"
+  command "echo '#---EY-HOSTS-START
+#---EY-HOSTS-END
+' >> /etc/hosts"
+  not_if "grep 'EY-HOSTS-START' /etc/hosts"
+end
+
+execute "Update ey-hosts entries" do
+  user "root"
+  command 'perl -0777 -i -pe "s/(#---EY-HOSTS-START\\n).*(#---EY-HOSTS-END)/\$1`cat /etc/ey_hosts`\n\n\$2/s" /etc/hosts'
+end

--- a/cookbooks/ey-hosts/templates/default/ey_hosts.erb
+++ b/cookbooks/ey-hosts/templates/default/ey_hosts.erb
@@ -1,0 +1,46 @@
+
+<% if @app_master.length > 0 %>
+# Application Master
+<%= @app_master %>        ey-app-master
+<% end %>
+<% if @app_slaves.length > 0 %>
+
+# Application Slaves
+  <% @app_slaves.each_with_index do |host, index| %>
+<%= host %>        ey-app-slave<%= @app_slaves.count > 1 ? "-#{index}" : '' %>   
+  <% end %>
+<% end %>
+<% if @db_master.length > 0 %>
+
+# Database Master
+<%= @db_master %>         ey-db-master
+<% end %>
+<% if @db_replicas.length > 0 or @db_replicas_ordered.length > 0 %>
+
+# Database Replicas
+<% end %>
+<% @db_replicas.each do |key, value| %>
+  <% if value.is_a? String %>
+<%= value %>        <%= key %>
+  <% else %>
+    <% value.each_with_index do |host, index| %>
+<%= host %>        <%= key %>-<%= index %>
+    <% end %>
+  <% end %>
+<% end %>
+<% @db_replicas_ordered.each_with_index do |host, index| %>
+<%= host %>        ey-db-slave<%= @db_replicas_ordered.count > 1 ? "-#{index}" : '' %>    
+<% end %>
+<% if @utility_nodes.length > 0 %>
+
+# Utility Instances
+<% end %>
+<% @utility_nodes.each do |key, value| %>
+  <% if value.is_a? String %>
+<%= value %>        <%= key %>
+  <% else %>
+    <% value.each_with_index do |host, index| %>
+<%= host %>        <%= key %>-<%= index %>
+    <% end %>
+  <% end %>
+<% end %>


### PR DESCRIPTION
Description of your patch
--------------
Adds EY-HOSTS section to /etc/hosts file providing a friendly alias to the internal ip address of each host in the environment.

Recommended Release Notes
--------------
Adds /etc/hosts entries for the private IP of each instance in the environment

Estimated risk
--------------

Low
- Adds functionality that does not exist currently to a rarely leveraged configuration file.

Components involved
--------------

$ git diff next-release --name-only
cookbooks/ey-core/recipes/default.rb
cookbooks/ey-hosts/README.md
cookbooks/ey-hosts/metadata.rb
cookbooks/ey-hosts/recipes/default.rb
cookbooks/ey-hosts/templates/default/ey_hosts.erb

Example
--------------
```
#---EY-HOSTS-START

# Application Master
10.203.197.207        ey-app-master

# Application Slaves
10.230.182.98        ey-app-slave-0
10.183.100.16        ey-app-slave-1

# Database Master
10.218.172.125         ey-db-master

# Database Replicas
10.61.218.153        ey-db-slave-brian_wilson
10.61.218.153        ey-db-slave-0
10.13.193.84        ey-db-slave-1

# Utility Instances
10.33.189.48        ey-utility-test2-0
10.181.36.56        ey-utility-test2-1
10.95.177.162        ey-utility-test1

#---EY-HOSTS-END
```


Description of testing done
--------------
Under the 16.06 stack

- Provisioned a cluster with a variety of instances using an updated stack
- verified the /etc/hosts file has a `#---EY-HOSTS-START` line
- verified the /etc/hosts file has a `#---EY-HOSTS-END` line
- verified that between those lines existed at least one entry for each host in the environment
  - verified that the app_master had an entry named ey-app-master
  - verified that the db_master had an entry named ey-db-master
  - verified that each app slave had an entry named ey-app-slave[-X] where X reflected its order among app slaves starting at 0
     - verified that if there was only one slave with a given instance name the `-X` was not present
  - verified that each db slave had an entry named ey-db-slave[-X] where X reflected its order among db slaves starting at 0
     - verified that if there was only one slave with a given instance name the `-X` was not present
  - verified that each db slave with a instance name had an entry named ey-db-slave-[instance name][-X] where X reflected its order among db slaves with the same name
    - verified that if there was only one slave with a given instance name the `-X` was not present
  - verified that each utility instance had an entry named ey-utility-[instance name][-X] where X reflected its order among utility instances with the same name
    - verified that if there was only one utility with a given instance name the `-X` was not present
    
Under the 12.11 stack

- Provisioned a cluster with a variety of instances using an updated stack
- verified the /etc/hosts file has a `#---EY-HOSTS-START` line
- verified the /etc/hosts file has a `#---EY-HOSTS-END` line
- verified that between those lines existed at least one entry for each host in the environment
  - verified that the app_master had an entry named ey-app-master
  - verified that the db_master had an entry named ey-db-master
  - verified that if there was only one db slave present the instance name was given as ey-db-slave

QA Instructions
--------------

Using the 16.06 stack boot a few of each instance role (app, app_master, db_master, db_slave, util, solo) configure some with overlapping names, some with unique names, and for databases some with no instance names. Verify that each instance in the environment has a hosts alias corresponding to the rules established by the README and validated in the 16.06 environment above.

Solo instances will only show Utility instances in the EY-HOSTS section