### PR TITLE
Disable Transparent Huge Pages on large db & redis instances

### DIFF
--- a/cookbooks/redis/recipes/default.rb
+++ b/cookbooks/redis/recipes/default.rb
@@ -6,6 +6,8 @@
 if ['util'].include?(node['dna']['instance_role'])
   if node['dna']['name'] == node['redis']['utility_name']
 
+    include_recipe "sysctl::tune_large_db"
+
     sysctl "Enable Overcommit Memory" do
       variables 'vm.overcommit_memory' => 1
     end

--- a/cookbooks/sysctl/recipes/tune.rb
+++ b/cookbooks/sysctl/recipes/tune.rb
@@ -56,3 +56,6 @@ sysctl "net.ipv4.tcp_max_orphans" do
   variables 'net.ipv4.tcp_max_orphans' => node['sysctl']['max_orphans']
 end
 
+if node.dna.instance_role[/db|solo/]
+  include_recipe "sysctl::tune_large_db"
+end

--- a/cookbooks/sysctl/recipes/tune_large_db.rb
+++ b/cookbooks/sysctl/recipes/tune_large_db.rb
@@ -1,0 +1,15 @@
+
+thp_filename = '/sys/kernel/mm/transparent_hugepage/enabled'
+if ::File.exists?(thp_filename)
+  execute 'disable transparent huge pages when present' do
+    command "echo never > #{thp_filename}"
+  end
+
+  sysctl "Adjust vm.dirty ratios for large instances" do
+    variables({
+      'vm.dirty_ratio' => '80',
+      'vm.dirty_background_ratio' => '5',
+      'vm.dirty_expire_centisecs' => '12000'
+      })
+  end
+end


### PR DESCRIPTION
Description of your patch
-------------

Disable transparent_hugepages and adjust vm dirty rations on large dbs
    
transparent_hugepages can devastate performance on for database workloads
but is only present on larger instances.  This disables it for database
(and solo) instances when present and also does some vm dirty flushing
tweaking to start background flushing sooner.

Recommended Release Notes
-------------

Disable transparent_hugepages and adjust kernel vm dirty ratios and rates
on database instances when present.

Estimated risk
-------------

Low.

Components involved
-------------

 $ git diff --name-only next-release
cookbooks/redis/recipes/default.rb
cookbooks/sysctl/recipes/tune.rb
cookbooks/sysctl/recipes/tune_large_db.rb

Description of testing done
-------------

Boot both a solo env and a cluster env w/ app_master, db_master, db_slave, an unnamed util, and a util named 'redis' all r3.2XL with fix.

1. Verify the that `never` is bracketed in the following output on the db_master, db_slave, the redis util and solo and that always is bracked on the app_master and unnamed utl:

```
# cat /sys/kernel/mm/transparent_hugepage/enabled
always madvise [never]
```

QA Instructions
-------------

Same as testing above.