### PR TITLE
Custom logrotate (calls logrotate resource defined by main logrotate cookbook)

### DIFF
--- a/examples/logrotate/README.md
+++ b/examples/logrotate/README.md
@@ -1,0 +1,5 @@
+# logrotate
+
+This example contains a complete `cookbooks/` directory that you can use on the stable-v5 stack to generate logrotate configuration files.
+
+See [cookbooks/custom-logrotate](cookbooks/custom-logrotate/README.md) for complete instructions.

--- a/examples/logrotate/cookbooks/custom-logrotate/README.md
+++ b/examples/logrotate/cookbooks/custom-logrotate/README.md
@@ -1,0 +1,63 @@
+# Custom logrotate
+
+This recipe simply calls the `logrotate` resource defined in the main `logrotate` recipe: [cookbooks/logrotate/definitions/logrotate.rb](../../../../cookbooks/logrotate/definitions/logrotate.rb).
+
+## Installation
+
+For simplicity, we recommend that you create the cookbooks directory at the root of your application. If you prefer to keep the infrastructure code separate from application code, you can create a new repository.
+
+Our main recipes have the `logrotate` recipe that defines the `logrotate` resource. To use the `logrotate` resource, you can copy this recipe `custom-logrotate`. You should not copy the actual `logrotate` recipe. That is managed by Engine Yard.
+
+1. Edit `cookbooks/ey-custom/recipes/after-main.rb` and add
+
+    ```
+    include_recipe 'custom-logrotate'
+    ```
+
+2. Edit `cookbooks/ey-custom/metadata.rb` and add
+
+    ```
+    depends 'custom-logrotate'
+    ```
+
+3. Copy `examples/logrotate/cookbooks/custom-logrotate` to `cookbooks/`
+
+    ```
+    cd ~ # Change this to your preferred directory. Anywhere but inside the application
+
+    git clone https://github.com/engineyard/ey-cookbooks-stable-v5
+    cd ey-cookbooks-stable-v5
+    cp examples/logrotate/cookbooks/custom-logrotate /path/to/app/cookbooks/
+    ```
+
+4. Download the ey-core gem on your local machine and upload the recipes
+
+    ```
+    gem install ey-core
+    ey-core recipes upload --environment <nameofenvironment> --path <pathtocookbooksfolder> --apply
+    ```
+
+5. After running chef, check the new logrotate configuration in /etc/logrotate.d/.
+
+    The content would look like:
+
+    ```
+    /path/to/logfiles/*log {
+        daily
+        rotate 30
+        dateext
+        compress
+
+        missingok
+        notifempty
+        sharedscripts
+        extension gz
+        copytruncate
+    }
+    ```
+
+## Customizations
+
+Unlike the usual custom chef recipes, you need to modify the recipe in `cookbooks/custom-logrotate/recipes/default.rb` for customizations.
+
+The available options are shown as comments in custom-logrotate/recipes/default.rb. For more info about those options, run `man logrotate` in the server.

--- a/examples/logrotate/cookbooks/custom-logrotate/metadata.rb
+++ b/examples/logrotate/cookbooks/custom-logrotate/metadata.rb
@@ -1,0 +1,3 @@
+name 'custom-logrotate'
+
+depends 'logrotate'

--- a/examples/logrotate/cookbooks/custom-logrotate/recipes/default.rb
+++ b/examples/logrotate/cookbooks/custom-logrotate/recipes/default.rb
@@ -1,0 +1,50 @@
+# The following generates /etc/logrotate.d/example
+logrotate "example" do
+
+  # Required Setting:
+  files "/path/to/logfiles/*log"
+
+  # Optional Settings:
+  # See `man logrotate` in the server for more details.
+
+  # Default: "daily"
+  # Syntax:
+  # frequency "daily"
+
+  # Default: 30
+  # Syntax:
+  # rotate_count 15
+
+  # Default: false
+  # Syntax:
+  # rotate_if_empty true
+
+  # Default: true
+  # Syntax:
+  # missing_ok false
+
+  # Default: true
+  # Syntax:
+  # compress false
+
+  # Default: true
+  # Description: `true` creates config file, `false` deletes it
+  # Syntax:
+  # enable false
+
+  # Default: true
+  # Syntax:
+  # date_ext false
+
+  # Default: 'gz'
+  # Syntax:
+  # extension 'log'
+
+  # Default: false
+  # Syntax:
+  # copy_then_truncate true
+
+  # Default: false
+  # Syntax:
+  # delay_compress true
+end

--- a/examples/logrotate/cookbooks/ey-custom/metadata.rb
+++ b/examples/logrotate/cookbooks/ey-custom/metadata.rb
@@ -1,0 +1,3 @@
+name 'ey-custom'
+
+depends 'custom-logrotate'

--- a/examples/logrotate/cookbooks/ey-custom/recipes/after-main.rb
+++ b/examples/logrotate/cookbooks/ey-custom/recipes/after-main.rb
@@ -1,0 +1,1 @@
+include_recipe 'custom-logrotate'


### PR DESCRIPTION
Note: custom-logrotate in examples/ does not wrap a recipe under cookbooks/. Instead it just calls the `logrotate` resource defined in the main `logrotate` recipe.

* Generates a file under /etc/logrotate.d/.
* Most options are just logrotate options (see `man logrotate`) but one option, `enable`, will create or delete the config file under /etc/logrotate.d/ depending on the value.
