### PR TITLE
Add the rails-secrets custom chef recipe

### DIFF
--- a/cookbooks/rails_secrets/README.md
+++ b/cookbooks/rails_secrets/README.md
@@ -1,0 +1,7 @@
+# rails_secrets
+
+This recipe is used to put in place a secrets.yml file to instances running the stable-v5 stack.
+
+The rails_secrets recipe is managed by Engine Yard. You should not copy this recipe to your repository but instead copy custom-rails_secrets. Please check the [custom-rails_secrets readme](../../examples/rails_secrets/cookbooks/custom-rails_secrets) for the complete instructions.
+
+We accept contributions for changes that can be used by all customers.

--- a/cookbooks/rails_secrets/metadata.rb
+++ b/cookbooks/rails_secrets/metadata.rb
@@ -1,0 +1,6 @@
+name 'rails_secrets'
+description 'Custom chef recipe for uploading secrets.yml to Engine Yard instances'
+long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
+maintainer 'Engine Yard'
+maintainer_email 'support@engineyard.com'
+version '5.0.0'

--- a/cookbooks/rails_secrets/recipes/default.rb
+++ b/cookbooks/rails_secrets/recipes/default.rb
@@ -1,0 +1,13 @@
+if ['app_master', 'app', 'util', 'solo'].include?(node['dna']['instance_role'])
+  app_names = node['dna']['applications'].keys
+  app_names.each do |app|
+    template "/data/#{app}/shared/config/secrets.yml"do
+      cookbook 'custom-rails_secrets'
+      source "secrets.yml.#{app}.erb"
+      owner node['owner_name']
+      group node['owner_name']
+      mode 0655
+      backup 0
+    end
+  end
+end

--- a/examples/rails_secrets/README.md
+++ b/examples/rails_secrets/README.md
@@ -1,0 +1,6 @@
+# rails_secrets
+
+This example contains a complete cookbooks/ that you can use on the stable-v5 stack.
+
+See https://github.com/engineyard/ey-cookbooks-stable-v5/tree/next-release/examples/rails_secrets/cookbooks/custom-rails_secrets for complete instructions.
+

--- a/examples/rails_secrets/cookbooks/custom-rails_secrets/README.md
+++ b/examples/rails_secrets/cookbooks/custom-rails_secrets/README.md
@@ -1,0 +1,40 @@
+# rails_secrets
+
+This recipe uploads the Rails `secrets.yml` file to `/data/application_name/shared/config/secrets.yml`.
+
+## Installation
+
+For most cases, we recommend that you create the cookbooks directory at the root of your application. However, if you’re using the `rails_secrets` recipe, for security purposes, you should consider putting the cookbooks on its own repository.
+
+Our main recipes have the `rails_secrets` recipe but it is not included by default. To use the `rails_secrets` recipe, you should copy this recipe `custom-rails_secrets`. You should not copy the actual `rails_secrets` recipe. That is managed by Engine Yard.
+
+1. Edit `cookbooks/ey-custom/recipes/after-main.rb` and add
+
+      ```
+      include_recipe 'custom-rails_secrets'
+      ```
+
+2. Edit `cookbooks/ey-custom/metadata.rb` and add
+
+      ```
+      depends 'custom-rails_secrets'
+      ```
+
+3. Copy `examples/rails_secrets/cookbooks/custom-rails_secrets` to `cookbooks/`
+
+      ```
+      cd ~ # Change this to your preferred directory. Anywhere but inside the application
+
+      git clone https://github.com/engineyard/ey-cookbooks-stable-v5
+      cd ey-cookbooks-stable-v5
+      cp examples/rails_secrets/cookbooks/custom-rails_secrets /path/to/app/cookbooks/
+      ```
+4. For each application in the environment, create `/path/to/app/cookbooks/custom-rails_secrets/templates/default/secrets.yml.#{app_name}.erb` 
+
+If you do not have `cookbooks/ey-custom` on your app repository, you can copy `examples/rails_secrets/cookbooks/ey-custom` to `/path/to/app/cookbooks`.
+
+## Customizations
+
+The recipe supports multi-application environments. You need to create a `secrets.yml.#{app_name}.erb` file for each application as described in step #4 of the Installation instructions above.
+
+The file `secrets.yml.todo.erb` has been included as an example. Feel free to remove or modify this file.

--- a/examples/rails_secrets/cookbooks/custom-rails_secrets/metadata.rb
+++ b/examples/rails_secrets/cookbooks/custom-rails_secrets/metadata.rb
@@ -1,0 +1,3 @@
+name 'custom-rails_secrets'
+
+depends 'rails_secrets'

--- a/examples/rails_secrets/cookbooks/custom-rails_secrets/recipes/default.rb
+++ b/examples/rails_secrets/cookbooks/custom-rails_secrets/recipes/default.rb
@@ -1,0 +1,1 @@
+include_recipe 'rails_secrets'

--- a/examples/rails_secrets/cookbooks/custom-rails_secrets/templates/default/secrets.yml.todo.erb
+++ b/examples/rails_secrets/cookbooks/custom-rails_secrets/templates/default/secrets.yml.todo.erb
@@ -1,0 +1,3 @@
+## Put your API tokens here!
+production:
+  secret_key_base: aac80752a59e75f2e1005db44288b87bb158a317b0c4c1bfe51b4ba56126c7cda2702a0b024c026020a44776ce2e8d33d289c032fe3f6cd79e09390dba5aa7ff

--- a/examples/rails_secrets/cookbooks/ey-custom/metadata.rb
+++ b/examples/rails_secrets/cookbooks/ey-custom/metadata.rb
@@ -1,0 +1,3 @@
+name 'ey-custom'
+
+depends 'custom-rails_secrets'

--- a/examples/rails_secrets/cookbooks/ey-custom/recipes/after-main.rb
+++ b/examples/rails_secrets/cookbooks/ey-custom/recipes/after-main.rb
@@ -1,0 +1,1 @@
+include_recipe 'custom-rails_secrets'


### PR DESCRIPTION
## Description of your patch

Adds the rails-secrets custom chef recipe

## Recommended Release Notes

Adds the rails-secrets custom chef recipe

## Estimated risk

Low. Main chef recipes weren’t updated.

## Components involved

Custom chef recipes

## Description of testing done

See QA instructions

## QA Instructions

A. Test on a solo Rails environment 

Enable the custom-rails-secrets recipe
Upload chef and click Apply
Verify that there were no chef errors
Deploy and verify that the application runs after the deploy
Verify that /data/appname/shared/config/secrets.yml has the same content as recipe_home/cookbooks/custom-rails-secrets/templates/default/secrets.yml.appname.erb

B. Test on a cluster Rails environment

Enable the custom-rails-secrets recipe
Upload chef and click Apply
On all instances, Verify that there were no chef errors
Deploy and verify that the application runs after the deploy
On app and util instances, verify that /data/appname/shared/config/secrets.yml has the same content as recipe_home/cookbooks/custom-rails-secrets/templates/default/secrets.yml.appname.erb