### PR TITLE
Add worker memory limit setting for delayed job.

### DIFF
--- a/cookbooks/delayed_job4/attributes/default.rb
+++ b/cookbooks/delayed_job4/attributes/default.rb
@@ -23,5 +23,6 @@ worker_count = if node[:dna][:instance_role] == 'solo'
 default['delayed_job4'] = {
   'is_dj_instance' => (node['dna']['instance_role'] == 'solo') || (node['dna']['instance_role'] == 'util' && node['dna']['name'] == 'delayed_job'),
   'applications' => node[:dna][:applications].map{|app_name, data| app_name},
-  'worker_count' => worker_count
+  'worker_count' => worker_count,
+  'worker_memory' => 300
 }

--- a/cookbooks/delayed_job4/recipes/default.rb
+++ b/cookbooks/delayed_job4/recipes/default.rb
@@ -28,7 +28,8 @@ if node['delayed_job4']['is_dj_instance']
           :app_name => app_name,
           :user => node[:owner_name],
           :worker_name => "#{app_name}_delayed_job#{count+1}",
-          :framework_env => node[:dna][:environment][:framework_env]
+          :framework_env => node[:dna][:environment][:framework_env],
+          :worker_memory => node['delayed_job4']['worker_memory']
         })
       end
     end

--- a/cookbooks/delayed_job4/templates/default/dj.monitrc.erb
+++ b/cookbooks/delayed_job4/templates/default/dj.monitrc.erb
@@ -2,5 +2,5 @@ check process <%= @worker_name %>
   with pidfile /var/run/engineyard/dj/<%= @app_name %>/dj_<%= @worker_name %>.pid
   start program = "/engineyard/custom/dj <%= @app_name %> start <%= @framework_env %> <%= @worker_name %>" with timeout 60 seconds
   stop program = "/engineyard/custom/dj <%= @app_name %> stop <%= @framework_env %> <%= @worker_name %>" with timeout 60 seconds
-  if totalmem is greater than 300 MB then restart # eating up memory?
+  if totalmem is greater than <%= @worker_memory %> MB then restart # eating up memory?
   group dj_<%= @app_name %>

--- a/examples/delayed_job4/cookbooks/custom-delayed_job4/README.md
+++ b/examples/delayed_job4/cookbooks/custom-delayed_job4/README.md
@@ -103,6 +103,15 @@ default['delayed_job4']['worker_count'] = worker_count
 default['delayed_job4']['worker_count'] = 4
 ```
 
+### Set the worker memory limit
+
+Monit keeps track of your DJ workers and by default, it restarts workers exceeding 300MB of memory.
+
+```ruby
+# specify custom memory limit
+default['delayed_job4']['worker_memory'] = 400
+```
+
 ## Restarting your workers
 
 This recipe does NOT restart your workers. The reason for this is that shipping your application and rebuilding your instances (i.e. running chef) are not always done at the same time. It is best to restart your Delayed Job workers when you ship (deploy) your application code.

--- a/examples/delayed_job4/cookbooks/custom-delayed_job4/attributes/default.rb
+++ b/examples/delayed_job4/cookbooks/custom-delayed_job4/attributes/default.rb
@@ -1,3 +1,4 @@
 # default['delayed_job4']['is_dj_instance'] = (node['dna']['instance_role'] == 'util' && node['dna']['name'] == 'delayed_job')
 # default['delayed_job4']['applications'] = %w[todo]
 # default['delayed_job4']['worker_count'] = 4
+# default['delayed_job4']['worker_memory'] = 300


### PR DESCRIPTION
Description of your patch
-------------

This change makes the DJ worker memory limit specified in the monit control file customizable through the attributes in the wrapper cookbook.

This was a customer request: "Could you consider a change to the DJ custom-DJ recipes so we could pass in the memory limit size for monit."

Recommended Release Notes
-------------

Makes DJ worker memory limit customizable through custom-delayed_job4/attributes/default.rb.

Estimated risk
-------------

Low - only applies to those enabling the DJ custom chef recipe, and the change is fairly simple.

How to Test
-------------

Use delayed_job4 custom chef recipe. Check monit control file in /etc/monit.d/delayed_job*.monitrc. Memory limit before restarting worker is 300MB.

Use updated delayed_job4 custom chef recipe without customizing custom-delayed_job4/attributes/default.rb. Results should be the same as before. Memory limit is still at 300MB.

Uncomment the following line in your custom-delayed_job4/attributes/default.rb and specify a different value (e.g. 400):

```
# default['delayed_job4']['worker_memory'] = 300
```

Upload and apply changes, and the monitrc file for DJ should now have 400MB.
