### PR TITLE
Add worker memory limit setting for Sidekiq.

### DIFF
--- a/cookbooks/sidekiq/attributes/default.rb
+++ b/cookbooks/sidekiq/attributes/default.rb
@@ -22,6 +22,9 @@ default['sidekiq'].tap do |sidekiq|
     # :queue_name => priority
     :default => 1
   }
+
+  # Memory limit
+  sidekiq['worker_memory'] = 400 # MB
   
   # Verbose
   sidekiq['verbose'] = false

--- a/cookbooks/sidekiq/recipes/setup.rb
+++ b/cookbooks/sidekiq/recipes/setup.rb
@@ -33,7 +33,7 @@ if node['sidekiq']['is_sidekiq_instance']
         :app_name => app_name, 
         :workers => node['sidekiq']['workers'],
         :rails_env => node.dna['environment']['framework_env'],
-        :memory_limit => 400 # MB
+        :memory_limit => node['sidekiq']['worker_memory']
       })
       notifies :run, "execute[restart-sidekiq-for-#{app_name}]"
     end

--- a/examples/sidekiq/cookbooks/custom-sidekiq/README.md
+++ b/examples/sidekiq/cookbooks/custom-sidekiq/README.md
@@ -90,6 +90,15 @@ larger instance type with more memory and CPU:
     # specify the number of workers
     default['sidekiq']['workers'] = 4
 
+### Set the worker memory limit
+
+Monit keeps track of your Sidekiq workers and by default, it restarts workers exceeding 400MB of memory.
+
+```ruby
+# specify custom memory limit
+default['sidekiq']['worker_memory'] = 450
+```
+
 ## Restarting your workers
 
 This recipe does NOT restart your workers. The reason for this is that shipping

--- a/examples/sidekiq/cookbooks/custom-sidekiq/attributes/default.rb
+++ b/examples/sidekiq/cookbooks/custom-sidekiq/attributes/default.rb
@@ -9,3 +9,6 @@
 
 # run the recipe on a solo instance
 # default['sidekiq']['is_sidekiq_instance'] = (node['dna']['instance_role'] == 'solo')
+
+# Default memory limit
+# default['sidekiq']['worker_memory'] = 400


### PR DESCRIPTION
Description of your patch
-------------

This change makes the Sidekiq worker memory limit specified in the monit control file customizable through the attributes in the wrapper cookbook.

Recommended Release Notes
-------------

Makes Sidekiq worker memory limit customizable (through custom-sidekiq/attributes/default.rb).

Estimated risk
-------------

Low - only applies to those enabling the Sidekiq custom chef recipe, and the change is fairly simple.

How to Test
-------------

Use sidekiq custom chef recipe. Check monit control file in /etc/monit.d/sidekiq*.monitrc. Memory limit before restarting worker is 400MB.

Use updated sidekiq custom chef recipe without customizing custom-sidekiq/attributes/default.rb. Results should be the same as before. Memory limit is still at 400MB.

Uncomment the following line in your custom-sidekiq/attributes/default.rb and specify a different value (e.g. 450):

```
# default['sidekiq']['worker_memory'] = 400
```

Upload and apply changes, and the monitrc file for Sidekiq should now be updated (e.g 450MB).
