### PR TITLE
[CC-1059] Stringify the key when fetching metadata

### DIFF
--- a/cookbooks/ey-lib/libraries/ey-application.rb
+++ b/cookbooks/ey-lib/libraries/ey-application.rb
@@ -78,7 +78,7 @@ class Chef
             detect {|c| c['key'] == 'app_metadata'}.
             dup.reject {|k| k == 'key'}
         end
-        key.nil? ? @component_metadata.dup : @component_metadata.fetch(key,default)
+        key.nil? ? @component_metadata.dup : @component_metadata.fetch(key.to_s,default)
       end
 
       def metadata?(key)

--- a/cookbooks/ey-lib/libraries/metadata.rb
+++ b/cookbooks/ey-lib/libraries/metadata.rb
@@ -6,7 +6,7 @@ class Chef
     #
     def metadata_account_get(name)
       data = node.engineyard.environment.components.select {|e| e['key'] == 'environment_metadata'} if node.engineyard.environment.component?('environment_metadata')
-      data.first[name] if data
+      data.first[name.to_s] if data
     end
 
     def metadata_account_get_with_default(name, default)
@@ -16,7 +16,9 @@ class Chef
     def metadata_env_get(name)
       environment = node.engineyard.environment['name']
       data = node.engineyard.environment.components.select {|e| e['key'] == 'environment_metadata'} if node.engineyard.environment.component?('environment_metadata')
-      data.first["#{name}[#{environment}]"] if data
+      if data
+        data.first[name.to_s] || data.first["#{name}[#{environment}]"]
+      end
     end
 
     def metadata_env_get_with_default(name, default)


### PR DESCRIPTION
## Description of your patch

Bugfix to make metadata fetching work on v5. v5 uses Hash instead of Mash in v4, so keys have to be strings, not symbols.

## Recommended Release Notes

Fixed a bug wherein metadata fails to load properly.

## Estimated risk

High. All code that fetches metadata is affected.

## Components involved

Main chef cookbook

## Description of testing done

See QA instructions

## QA Instructions

Test on Unicorn and Passenger environments
Boot a stable-v5.0.20 environment

Set the metadata at the account, application, environment, and app_deployment level. On all cases the metadata should be picked up and applied to the worker count configuration.
 
Set the metadata worker count to 1
Click Apply
Verify that the metadata is still at the default (see https://support.cloud.engineyard.com/hc/en-us/articles/205407758-Worker-Allocation-on-Engine-Yard-Cloud for the default worker counts)
Upgrade to the QA stack, click Apply
Verify that the worker count has been set to 1