### PR TITLE
Add memcached recipe

### DIFF
--- a/cookbooks/memcached/README.md
+++ b/cookbooks/memcached/README.md
@@ -1,4 +1,7 @@
-memcached
-========
+# Memcached
 
-This is a placeholder stub for memcached that can be overridden.
+This recipe is used to run memcached on the stable-v5 stack.
+
+The memcached recipe is managed by Engine Yard. You should not copy this recipe to your repository but instead copy custom-memcached. Please check the [custom-memcached readme](../../examples/memcached/cookbooks/custom-memcached) for the complete instructions.
+
+We accept contributions for changes that can be used by all customers.

--- a/cookbooks/memcached/attributes/default.rb
+++ b/cookbooks/memcached/attributes/default.rb
@@ -1,0 +1,39 @@
+#
+# Cookbook Name:: memcached
+# Attrbutes:: default
+#
+
+default['memcached'].tap do |memcached|
+
+  # Default: DO NOT install memcached
+  # Override this to true to install memcached
+  memcached['perform_install'] = false
+
+  # Set to true if you want to install from source
+  # Installing from the Gentoo package in the portage tree is faster,
+  # but not all versions are available
+  memcached['install_from_source'] = false
+
+  # If you're installing from the portage tree, the latest available version is 1.4.25
+  memcached['version'] = '1.4.34'
+  memcached['download_url'] = 'https://memcached.org/files/memcached-1.4.34.tar.gz'
+
+  # Install memcached on a utility instance named 'memcached'
+  #memcached['install_type'] = 'NAMED_UTILS'
+  memcached['utility_name'] = 'memcached'
+
+  # Install memcached on all app instances, or on a solo instance
+  memcached['install_type'] = 'ALL_APP_INSTANCES'
+
+  # Amount of memory in MB to be used by memcached
+  memcached['memusage'] = 1024
+
+  # Additional memcached configuration options
+  # Default: no additional options
+  memcached['misc_opts'] = ''
+
+  # Try increasing the growth factor if you allocated more memory to memcached
+  # and you're seeing lots of partially-filled slabs
+  # memcached['misc_opts'] = '-f 1.5'
+  # See https://blog.engineyard.com/2015/fine-tuning-memcached
+end

--- a/cookbooks/memcached/metadata.rb
+++ b/cookbooks/memcached/metadata.rb
@@ -1,8 +1,8 @@
 name 'memcached'
+description 'Configuration & deployment of Memcached on Engine Yard'
+long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 maintainer 'Engine Yard'
 maintainer_email 'support@engineyard.com'
-version '1.0'
-source_url 'https://engineyard.com'
-issues_url 'https://support.engineyard.com'
-
-depends 'ey-lib'
+version '5.0.0'
+issues_url 'https://github.com/engineyard/ey-cookbooks-stable-v5/issues'
+source_url 'https://github.com/engineyard/ey-cookbooks-stable-v5'

--- a/cookbooks/memcached/recipes/configure.rb
+++ b/cookbooks/memcached/recipes/configure.rb
@@ -1,0 +1,51 @@
+require 'pp'
+#
+# Cookbook Name:: memcached_custom
+# Recipe:: configure
+#
+# This drops memcached.yml on all app and utility instances
+#
+
+ey_cloud_report "memcached" do
+  message "Configuring memcached"
+end
+
+def get_app_instances
+  node['dna']['engineyard']['environment']['instances'].
+    select{|i| ['solo','app_master','app'].include?(i['role'])}.
+    map{|i| i['private_hostname']}
+end
+
+def get_utils_by_name(util_name)
+  node['dna']['utility_instances'].
+    select{|i| i['name'] == util_name}.
+    map{|i| i['hostname']}
+end
+
+# Get the list of memcached instances
+memcached_instances = case node['memcached']['install_type']
+when 'ALL_APP_INSTANCES'
+  get_app_instances
+else
+  get_utils_by_name node['memcached']['utility_name']
+end
+
+# Drop the memcached.yml on all app and util instances
+if ['app_master', 'app', 'util', 'solo'].include?(node['dna']['instance_role'])
+  node['dna']['applications'].each do |app_name,data|
+    user = node['dna']['users'].first
+
+    template "/data/#{app_name}/shared/config/memcached.yml" do
+      source "memcached.yml.erb"
+      owner user[:username]
+      group user[:username]
+      mode 0744
+      variables({
+        :framework_env => node['dna']['environment']['framework_env'],
+        :app_name => app_name,
+        :server_names => memcached_instances
+      })
+    end
+
+  end
+end

--- a/cookbooks/memcached/recipes/default.rb
+++ b/cookbooks/memcached/recipes/default.rb
@@ -1,1 +1,10 @@
-# This is a stub, and you should overwrite it.
+require 'pp'
+#
+# Cookbook Name:: memcached
+# Recipe:: default
+#
+
+if node['memcached']['perform_install']
+  include_recipe "memcached::install"
+  include_recipe "memcached::configure"
+end

--- a/cookbooks/memcached/recipes/install.rb
+++ b/cookbooks/memcached/recipes/install.rb
@@ -1,0 +1,57 @@
+require 'pp'
+#
+# Cookbook Name:: memcached-custom
+# Recipe:: install
+#
+
+memcached_version = node['memcached']['version']
+memcached_download_url = node['memcached']['download_url']
+memcached_installer_directory = '/opt/memcached-installer'
+
+ey_cloud_report "memcached" do
+  message "Installing memcached"
+end
+
+Chef::Log.info "INSTALL TYPE: #{node['memcached']['install_type']}"
+Chef::Log.info "INSTANCE ROLE: #{node['dna']['instance_role']}"
+Chef::Log.info "UTILITY NAME: #{node['memcached']['utility_name']}"
+
+is_memcached_instance = case node['memcached']['install_type']
+when 'ALL_APP_INSTANCES'
+  ['solo', 'app_master', 'app'].include?(node['dna']['instance_role'])
+else
+  (node['dna']['instance_role'] == 'util') && (node['dna']['name'] == node['memcached']['utility_name'])
+end
+
+if is_memcached_instance
+  if node['memcached']['install_from_source']
+    include_recipe 'memcached::install_from_source'
+  else
+    include_recipe 'memcached::install_from_package'
+  end
+
+  template "/etc/conf.d/memcached" do
+    source "memcached.erb"
+    owner 'root'
+    group 'root'
+    mode 0644
+    variables :memusage => node['memcached']['memusage'],
+      :port     => 11211,
+      :misc_opts => node['memcached']['misc_opts']
+  end
+
+  directory '/etc/monit.d' do
+    owner 'root'
+    group 'root'
+    mode 0755
+    action :create
+  end
+
+  template '/etc/monit.d/memcached.monitrc' do
+    source 'memcached.monitrc'
+    owner 'root'
+    group 'root'
+    mode 0644
+    notifies :run, 'execute[restart-monit]', :delayed
+  end
+end

--- a/cookbooks/memcached/recipes/install_from_package.rb
+++ b/cookbooks/memcached/recipes/install_from_package.rb
@@ -1,0 +1,15 @@
+memcached_package = 'net-misc/memcached'
+memcached_version = node['memcached']['version']
+
+Chef::Log.info "Installing #{memcached_package} #{memcached_version} from package..."
+
+enable_package memcached_package do
+  version memcached_version
+  override_hardmask true
+  unmask :true
+end
+
+package memcached_package do
+  version memcached_version
+  action :install
+end

--- a/cookbooks/memcached/recipes/install_from_source.rb
+++ b/cookbooks/memcached/recipes/install_from_source.rb
@@ -1,0 +1,31 @@
+memcached_version = node['memcached']['version']
+memcached_download_url = node['memcached']['download_url']
+memcached_installer_directory = '/opt/memcached-installer'
+
+Chef::Log.info "Installing memcached #{memcached_version} from source..."
+
+remote_file "/opt/memcached-#{memcached_version}.tar.gz" do
+  source "#{memcached_download_url}"
+  owner node[:owner_name]
+  group node[:owner_name]
+  mode 0644
+  backup 0
+end
+
+execute "unarchive Memcached installer" do
+  cwd "/opt"
+  command "tar zxf memcached-#{memcached_version}.tar.gz && sync"
+end
+
+execute "Remove old memcached-installer" do
+  command "rm -rf /opt/memcached-installer"
+end
+
+execute "rename /opt/memcached-#{memcached_version} to /opt/memcached-installer" do
+  command "mv /opt/memcached-#{memcached_version} #{memcached_installer_directory}"
+end
+
+execute "run memcached-installer/configure, make, install" do
+  cwd memcached_installer_directory
+  command "./configure && make && make install"
+end

--- a/cookbooks/memcached/templates/default/memcached.erb
+++ b/cookbooks/memcached/templates/default/memcached.erb
@@ -1,0 +1,32 @@
+# Copyright 2003 Gentoo Technologies, Inc
+# $Header: /var/cvsroot/gentoo-x86/net-misc/memcached/files/1.2.6/conf,v 1.1 2008/08/01 15:56:55 caleb Exp $
+# memcached config file
+
+MEMCACHED_BINARY="/usr/bin/memcached"
+
+#Specify memory usage in megabytes (do not use letters)
+#64MB is default
+MEMUSAGE="<%= @memusage %>"
+
+#User to run as
+MEMCACHED_RUNAS="memcached"
+
+#Specify maximum number of concurrent connections
+#1024 is default
+MAXCONN="1024"
+
+#Listen for connections on what address?
+# If this is empty, memcached will listen on 0.0.0.0
+# be sure you have a firewall in place!
+LISTENON="0.0.0.0"
+
+#Listen for connections on what port?
+PORT="<%= @port %>"
+
+#PID file location
+# '-${PORT}.${CONF}.pid' will be appended to this!
+# You do not normally need to change this.
+PIDBASE="/var/run/memcached"
+
+#Other Options
+MISC_OPTS="<%= @misc_opts %>"

--- a/cookbooks/memcached/templates/default/memcached.monitrc
+++ b/cookbooks/memcached/templates/default/memcached.monitrc
@@ -1,0 +1,5 @@
+check process memcached
+  with pidfile /var/run/memcached/memcached.pid
+  start program = "/etc/init.d/memcached restart"
+  stop program = "/etc/init.d/memcached stop"
+  group memcached

--- a/cookbooks/memcached/templates/default/memcached.yml.erb
+++ b/cookbooks/memcached/templates/default/memcached.yml.erb
@@ -1,0 +1,7 @@
+<%= @framework_env %>:
+  <% if !@server_names.nil? && !@server_names.empty? %>
+  servers:
+  <% @server_names.each do |server_name| %>
+  - <%= server_name %>:11211
+  <% end %>
+  <% end %>

--- a/examples/memcached/README.md
+++ b/examples/memcached/README.md
@@ -1,0 +1,7 @@
+# Memcached
+
+This example contains a complete `cookbooks/` directory that you can use on the
+Stable-v5 stack to setup Memcached.
+
+See [cookbooks/custom-memcached](cookbooks/custom-memcached/README.md) for complete
+instructions.

--- a/examples/memcached/cookbooks/custom-memcached/README.md
+++ b/examples/memcached/cookbooks/custom-memcached/README.md
@@ -1,0 +1,125 @@
+# Memcached
+
+The memcached cookbook installs memcached and monitors it with monit. A `/data/app_name/shared/config/memcached.yml` is generated for each application on the environment.
+
+You need to add a memcached client to your app.
+
+## Installation
+
+For simplicity, we recommend that you create the `cookbooks/` directory at the
+root of your application. If you prefer to keep the infrastructure code separate
+from application code, you can create a new repository.
+
+Our main recipes have the `memcached_custom` cookbook but it is not included by default.
+To use the `memcached_custom` cookbook, you should copy the cookbook
+`custom-memcached`. You should not copy the actual `memcached_custom` recipe as
+that is managed by Engine Yard.
+
+  1. Edit `cookbooks/ey-custom/recipes/after-main.rb` and add
+
+	```
+	    include_recipe 'custom-memcached'
+	```
+
+  2. Edit `cookbooks/ey-custom/metadata.rb` and add
+
+	```
+	    depends 'custom-memcached'
+	```
+
+  3. Copy `examples/memcached/cookbooks/custom-memcached` to `cookbooks/`
+
+	```
+	    cd ~ # Change this to your preferred directory. Anywhere but inside the
+	         # application
+	
+	    git clone https://github.com/engineyard/ey-cookbooks-stable-v5
+	    cd ey-cookbooks-stable-v5
+	    cp examples/memcached/cookbooks/custom-memcached /path/to/app/cookbooks/
+	```
+	
+  4. Download the ey-core gem on your local machine and upload the recipes
+
+  	```
+  	gem install ey-core
+  	ey-core recipes upload --environment <nameofenvironment> --path <pathtocookbooksfolder> --apply
+  	```
+
+## Customizations
+
+All customizations go to `cookbooks/custom-memcached/attributes/default.rb`.
+
+### Choose the instances that run the recipe
+
+By default, the recipe runs on a utility instance named 'memcached'. This is configured in `attributes/default.rb`. This will run the memcached daemon on the utility instance named 'memcached' and create a `/data/appname/shared/config/memcached_custom.yml` file that points to the private IP of the memcached instance.
+
+```
+  # Install memcached on a utility instance named 'memcached'
+  memcached['install_type'] = 'NAMED_UTILS'
+  memcached['utility_name'] = 'memcached'
+```
+
+To install memcached on all app instances, comment out the block above and set `memcached['install_type']` to 'ALL_APP_INSTANCES'. This will run the memcached daemon on all app instances and create a `/data/appname/shared/config/memcached_custom.yml` file that points to the private IPs of all the app instances. The memcache client will be responsible for sharding the data across all the instances running memcached
+
+```
+  # Install memcached on all app instances
+  #memcached['install_type'] = 'ALL_APP_INSTANCES'
+```
+
+To install memcached in a solo environment, use the set `install_type` to `ALL_APP_INSTANCES`.
+
+_NOTE: This recipe does not uninstall memcached. If you use the ALL\_APP\_INSTANCES install\_type, then switch to NAMED\_UTILS, memcached will still be installed and running on the app instances. You can uninstall memcached on the app instances by running `monit stop memcached && rm /etc/monit.d/memcached.monitrc && sleep 30 && monit reload`._
+
+### Adjust memory usage
+
+```
+  # Amount of memory in MB to be used by memcached
+  memcached['memusage'] = 1024
+```
+
+### Adjust the growth factor
+
+```
+  # Increase the growth factor.
+  # Try this if you allocated more memory to memcached
+  # and you're seeing lots of partially-filled slabs
+  # memcached['misc_opts'] = '-f 1.5'
+  # See https://blog.engineyard.com/2015/fine-tuning-memcached
+```
+
+## Restarting your application
+
+This recipe does NOT restart your application. The reason for this is that shipping
+your application and rebuilding your instances (i.e. running chef) are not
+always done at the same time. It is best to restart your application
+when you ship (deploy) your application code.
+
+## Test Cases
+
+This custom chef recipe has been verified using these test cases:
+
+```
+A. Do not enable the perform_install flag
+  A1. Chef run should not fail
+  A2. memcached should not be running
+B. Enable the perform_install flag. Install from source 
+  B1. Install on all app instances
+  B1.1. memcached should be running on app_master
+  B1.2. memcached should be running on app instances
+  B1.3. memcached should not be running on utility or database instances
+  B1.4. /data/app_name/shared/config/memcached.yml should list all the app instances in the environment
+  B2. Install on a utility instance named 'memcached'
+  B2.1. memcached should be running on the utility instance named memcached
+  B2.2. memcached should not be running on app_master, app, and database instances
+  B2.3. /data/app_name/shared/config/memcached.yml should list all the utility instances named memcached in the environment
+C. Enable the perform_install flag. Install from package
+  C1. Install on all app instances
+  C1.1. memcached should be running on app_master
+  C1.2. memcached should be running on app instances
+  C1.3. memcached should not be running on utility or database instances
+  C1.4. /data/app_name/shared/config/memcached.yml should list all the app instances in the environment
+  C2. Install on a utility instance named 'memcached'
+  C2.1. memcached should be running on the utility instance named memcached
+  C2.2. memcached should not be running on app_master, app, and database instances
+  C2.3. /data/app_name/shared/config/memcached.yml should list all the utility instances named memcached in the environment
+```

--- a/examples/memcached/cookbooks/custom-memcached/attributes/default.rb
+++ b/examples/memcached/cookbooks/custom-memcached/attributes/default.rb
@@ -1,0 +1,39 @@
+#
+# Cookbook Name:: memcached
+# Attrbutes:: default
+#
+
+default['memcached'].tap do |memcached|
+
+  # Default: DO NOT install memcached
+  # Override this to true to install memcached
+  memcached['perform_install'] = true
+
+  # Set to true if you want to install from source
+  # Installing from the Gentoo package in the portage tree is faster,
+  # but not all versions are available
+  memcached['install_from_source'] = false
+
+  # If you're installing from the portage tree, the latest available version is 1.4.25
+  memcached['version'] = '1.4.34'
+  memcached['download_url'] = 'https://memcached.org/files/memcached-1.4.34.tar.gz'
+
+  # Install memcached on a utility instance named 'memcached'
+  memcached['install_type'] = 'NAMED_UTILS'
+  memcached['utility_name'] = 'memcached'
+
+  # Install memcached on all app instances, or on a solo instance
+  #memcached['install_type'] = 'ALL_APP_INSTANCES'
+
+  # Amount of memory in MB to be used by memcached
+  memcached['memusage'] = 1024
+
+  # Additional memcached configuration options
+  # Default: no additional options
+  memcached['misc_opts'] = ''
+
+  # Try increasing the growth factor if you allocated more memory to memcached
+  # and you're seeing lots of partially-filled slabs
+  # memcached['misc_opts'] = '-f 1.5'
+  # See https://blog.engineyard.com/2015/fine-tuning-memcached
+end

--- a/examples/memcached/cookbooks/custom-memcached/metadata.rb
+++ b/examples/memcached/cookbooks/custom-memcached/metadata.rb
@@ -1,0 +1,3 @@
+name 'custom-memcached'
+
+depends 'memcached'

--- a/examples/memcached/cookbooks/custom-memcached/recipes/default.rb
+++ b/examples/memcached/cookbooks/custom-memcached/recipes/default.rb
@@ -1,0 +1,1 @@
+include_recipe 'memcached'

--- a/examples/memcached/cookbooks/ey-custom/metadata.rb
+++ b/examples/memcached/cookbooks/ey-custom/metadata.rb
@@ -1,0 +1,3 @@
+name 'ey-custom'
+
+depends 'custom-memcached'

--- a/examples/memcached/cookbooks/ey-custom/recipes/after-main.rb
+++ b/examples/memcached/cookbooks/ey-custom/recipes/after-main.rb
@@ -1,0 +1,1 @@
+include_recipe 'custom-memcached'


### PR DESCRIPTION
## Description of your patch

Adds the memcached custom recipe. 

The previous recipe was just a stub. This actually installs memcahced, but it has to be enabled by setting `perform_install` to true in `custom-memcached/attributes/default.rb`.

## Recommended Release Notes

Adds the memcached custom recipe.

## Estimated risk

High. 

Our platform includes memcached in the list of recipes that should be run by default (a legacy from the V4 stack). Breakage on this recipe will cause main chef to fail for all chef runs on V5. To mitigate this, the recipe has an attribute `perform_install` and this is disabled by default.

## Components involved

memcached custom chef recipe

## Description of testing done

See QA instructions

## QA Instructions

Run the test cases in examples/redis/cookbooks/custom-memcached/README.md