### PR TITLE
updating default mysql configuration to adjust open_files_limit, table_open_cache, and show_old_temporals

### DIFF
--- a/cookbooks/mysql/templates/default/my.conf.erb
+++ b/cookbooks/mysql/templates/default/my.conf.erb
@@ -38,11 +38,12 @@ character-sets-dir=/usr/share/mysql/charsets
 
 [mysqld_safe]
 err-log				= <%= @logbase %>mysql.err
-# NOTICE: We no longer set open-file-limit here, this is specified in /etc/init.d/mysql.
-# To allow table cache to be raised
-# open-file-limit = 4096
 
 [mysqld]
+open_files_limit = 65535
+<% if @mysql_version == @mysql_5_6 %>
+show_old_temporals = 1
+<% end %>
 max_connections			= 300
 innodb_file_per_table		= 1
 
@@ -97,7 +98,9 @@ language			= /usr/share/mysql/english
 <% else %>
 key_buffer_size = 32M
 thread_cache_size			= 512
-table_open_cache			= 1024
+<% if @mysql_version == @mysql_5_5 %>
+table_open_cache			= 2000
+<% end %>
 lc-messages-dir = /usr/share/mysql
 lc-messages                    = en_US
 explicit_defaults_for_timestamp 


### PR DESCRIPTION
Description of your patch
--------------
Rollup of multiple database changes

MySQL:

- `table_open_cache`
  - MySQL 5.5 sets a default of 2000 in the mysql config file
  - Uses build default for MySQL 5.6+
- `open_files_limit`
  - Sets to a default of 65,535 for all versions.
- `show_old_temporals`
  - MySQL 5.6 only, sets to true.


Recommended Release Notes
--------------

- Adjusts the MySQL default settings for `table_open_cache`, `open_files_limit`, and `show_old_temporals`.


Estimated risk
--------------
Low

- The MySQL configuration changes don't change the running server and only apply after a restart, the changes are designed to improve reliability.

Components involved
--------------

$ git diff next-release --name-only
cookbooks/mysql/templates/default/my.conf.erb

Description of testing done
--------------
#### Under the tpol-12.11 stack

- Provisioned a cluster using the existing Stack running MySQL 5.6
- Ran:
  - `mysql -e "show global variables like 'table_open_cache'"`
- Validated result:

  ```
  table_open_cache	1024
  ```
  
- Ran:
  - `mysql -e "show global variables like 'open_files_limit'"`
- Validated result:

  ```
  open_files_limit	5000
  ```
  
- Ran:
  - `mysql -e "show global variables like 'show_old_temporals'"`
- Validated result:

  ```
  show_old_temporals 0
  ```

- Ran:

  ```
  sudo mkdir -p /db/ey
  sudo touch /db/ey/no_redis
  sudo monit stop redis
  sudo rm /etc/monid.d/redis.monitrc
  sudo monit reload
  # if applicable
  rm -rf /db/redis
  ```
  
- Upgraded the tpol-12.11 stack from the branch

- Restarted mysql with `/etc/init.d/mysql restart`
- Ran:
  - `mysql -e "show global variables like 'table_open_cache'"`
- Validated result:

  ```
  table_open_cache	2000
  ```
  
- Ran:
  - `mysql -e "show global variables like 'open_files_limit'"`
- Validated result:

  ```
  open_files_limit	65535
  ```
  
- Ran:
  - `mysql -e "show global variables like 'show_old_temporals'"`
- Validated result:

  ```
  show_old_temporals 1
  ```
  
- Created a db replica from a new snapshot
- logged into the replica and ran:
  - `ps -ef |grep '[r]edis'`
- Validated that no processes are listed by the above grep.


QA Instructions
--------------
#### 16.06 MySQL 5.6 ONLY

- Provision a cluster using the existing Stack running MySQL 5.6.
- Run:
  - `mysql -e "show global variables like 'table_open_cache'"`
- Validate result:

  ```
  table_open_cache	1024
  ```
  
- Run:
  - `mysql -e "show global variables like 'open_files_limit'"`
- Validate result:

  ```
  open_files_limit	5000
  ```
  
- Run:
  - `mysql -e "show global variables like 'show_old_temporals'"`
- Validate result:

  ```
  show_old_temporals 0
  ```
  
- Upgrade the stack

- Restart mysql with `/etc/init.d/mysql restart`
- Run:
  - `mysql -e "show global variables like 'table_open_cache'"`
- Validate result:

  ```
  table_open_cache	2000
  ```
  
- Run:
  - `mysql -e "show global variables like 'open_files_limit'"`
- Validate result:

  ```
  open_files_limit	65535
  ```
  
- Run:
  - `mysql -e "show global variables like 'show_old_temporals'"`
- Validate result:

  ```
  show_old_temporals 1
  ```

#### 16.06 MySQL 5.7 ONLY

- Provision a cluster using the existing Stack running MySQL 5.7.
- Run:
  - `mysql -e "show global variables like 'table_open_cache'"`
- Validate result:

  ```
  table_open_cache	1024
  ```
  
- Run:
  - `mysql -e "show global variables like 'open_files_limit'"`
- Validate result:

  ```
  open_files_limit	5000
  ```
  
- Upgrade the stack

- Restart mysql with `/etc/init.d/mysql restart`
- Run:
  - `mysql -e "show global variables like 'table_open_cache'"`
- Validate result:

  ```
  table_open_cache	2000
  ```
  
- Run:
  - `mysql -e "show global variables like 'open_files_limit'"`
- Validate result:

  ```
  open_files_limit	65535
  ```

- Run:
  - `cat /etc/mysql/my.cnf | grep 'show_old_temporals' |wc -l`
- Validate result:

  ```
  0
  ```
