### PR TITLE
Data 305

### DIFF
--- a/cookbooks/collectd/templates/default/ey-alert.erb
+++ b/cookbooks/collectd/templates/default/ey-alert.erb
@@ -52,9 +52,7 @@ class CollectdAlertParser
       raise Timeout::Error, "Timeout connecting to #{url.host}:#{url.port} for #{req.path}, giving up"
     end
 
-    if res.kind_of?(Net::HTTPSuccess)
-      JSON.parse(res.body)
-    else
+    if ! res.kind_of?(Net::HTTPSuccess)
       res.error!
     end
   end

--- a/cookbooks/ey-backup/recipes/mysql.rb
+++ b/cookbooks/ey-backup/recipes/mysql.rb
@@ -42,7 +42,7 @@ end
 
 if node.dna['backup_window'] != 0 && ['db_master','solo'].include?(node.dna['instance_role'])
   encryption_command = @encryption_command
-  backup_command = "eybackup -e mysql #{encryption_command} >> /var/log/eybackup.log"
+  backup_command = "eybackup -e mysql #{encryption_command} >> /var/log/eybackup.log 2>&1"
 
   cron "mysql" do
     command backup_command

--- a/cookbooks/ey-backup/recipes/postgres.rb
+++ b/cookbooks/ey-backup/recipes/postgres.rb
@@ -46,7 +46,7 @@ if node.dna['db_slaves'].empty? && node.dna['backup_window'] != 0
     encryption_command = @encryption_command
 
     backup_cron "postgresql" do
-      command "eybackup -e postgresql #{encryption_command} >> /var/log/eybackup.log"
+      command "eybackup -e postgresql #{encryption_command} >> /var/log/eybackup.log 2>&1"
       month   '*'
       weekday '*'
       day     '*'
@@ -64,7 +64,7 @@ else
     hostname.run_command
 
     cron "postgresql" do
-      command "eybackup -e postgresql #{encryption_command} >> /var/log/eybackup.log"
+      command "eybackup -e postgresql #{encryption_command} >> /var/log/eybackup.log 2>&1"
       month   '*'
       weekday '*'
       day     '*'

--- a/manifest/Gemfile
+++ b/manifest/Gemfile
@@ -2,7 +2,7 @@ source 'https://rubygems.org/' do
   gem 'chef', '~> 12.7'
   gem 'right_aws', '~> 3.1.0'
   gem 'engineyard-serverside', '~> 2.6.6'
-  gem 'ey_cloud_server', '1.4.51'
+  gem 'ey_cloud_server', '1.4.53'
   gem 'ey_services_setup', '0.0.7'
 end
 

--- a/manifest/Gemfile
+++ b/manifest/Gemfile
@@ -2,7 +2,7 @@ source 'https://rubygems.org/' do
   gem 'chef', '~> 12.7'
   gem 'right_aws', '~> 3.1.0'
   gem 'engineyard-serverside', '~> 2.6.6'
-  gem 'ey_cloud_server', '1.4.53'
+  gem 'ey_cloud_server', '1.4.54'
   gem 'ey_services_setup', '0.0.7'
 end
 

--- a/manifest/Gemfile.lock
+++ b/manifest/Gemfile.lock
@@ -50,12 +50,13 @@ GEM
     engineyard-serverside (2.6.6)
     erubis (2.7.0)
     excon (0.54.0)
-    ey_cloud_server (1.4.53)
+    ey_cloud_server (1.4.54)
       aws-s3 (>= 0.6.3)
       ey_enzyme (>= 1.1.10)
       ey_instance_api_client (~> 0.1.11)
       fog-aws (>= 0.3.0)
       json (>= 1.5.5)
+      mime-types (>= 1.16, < 3.0)
       nokogiri (>= 1.6.6.2, <= 1.6.8.1)
       open4 (~> 1.3.0)
     ey_enzyme (2.0.5)
@@ -191,7 +192,7 @@ PLATFORMS
 DEPENDENCIES
   chef (~> 12.7)!
   engineyard-serverside (~> 2.6.6)!
-  ey_cloud_server (= 1.4.53)!
+  ey_cloud_server (= 1.4.54)!
   ey_enzyme (= 2.0.5)!
   ey_services_setup (= 0.0.7)!
   ey_snaplock (= 2.0.3)!

--- a/manifest/Gemfile.lock
+++ b/manifest/Gemfile.lock
@@ -49,14 +49,14 @@ GEM
       unf (>= 0.0.5, < 1.0.0)
     engineyard-serverside (2.6.6)
     erubis (2.7.0)
-    excon (0.52.0)
-    ey_cloud_server (1.4.51)
-      aws-s3 (~> 0.6.3)
-      ey_enzyme (>= 1.1.7)
+    excon (0.54.0)
+    ey_cloud_server (1.4.53)
+      aws-s3 (>= 0.6.3)
+      ey_enzyme (>= 1.1.10)
       ey_instance_api_client (~> 0.1.11)
       fog-aws (>= 0.3.0)
-      json (>= 1.8.3)
-      nokogiri (>= 1.6.6.2)
+      json (>= 1.5.5)
+      nokogiri (>= 1.6.6.2, <= 1.6.8.1)
       open4 (~> 1.3.0)
     ey_enzyme (2.0.5)
       json (~> 1.8, >= 1.8.3)
@@ -73,12 +73,12 @@ GEM
     ffi (1.9.10)
     ffi-yajl (2.2.3)
       libyajl2 (~> 1.2)
-    fog-aws (0.11.0)
+    fog-aws (1.2.0)
       fog-core (~> 1.38)
       fog-json (~> 1.0)
       fog-xml (~> 0.1)
       ipaddress (~> 0.8)
-    fog-core (1.42.0)
+    fog-core (1.43.0)
       builder
       excon (~> 0.49)
       formatador (~> 0.2)
@@ -121,9 +121,8 @@ GEM
       net-ssh-gateway (>= 1.2.0)
     net-telnet (0.1.1)
     netrc (0.11.0)
-    nokogiri (1.6.8)
+    nokogiri (1.6.8.1)
       mini_portile2 (~> 2.1.0)
-      pkg-config (~> 1.1.7)
     ohai (8.16.0)
       chef-config (>= 12.5.0.alpha.1, < 13)
       ffi (~> 1.9)
@@ -137,7 +136,6 @@ GEM
       systemu (~> 2.6.4)
       wmi-lite (~> 1.0)
     open4 (1.3.4)
-    pkg-config (1.1.7)
     plist (3.2.0)
     proxifier (1.0.3)
     rack (1.6.4)
@@ -193,7 +191,7 @@ PLATFORMS
 DEPENDENCIES
   chef (~> 12.7)!
   engineyard-serverside (~> 2.6.6)!
-  ey_cloud_server (= 1.4.51)!
+  ey_cloud_server (= 1.4.53)!
   ey_enzyme (= 2.0.5)!
   ey_services_setup (= 0.0.7)!
   ey_snaplock (= 2.0.3)!


### PR DESCRIPTION
Description of your patch
--------------
Match up Stable-v5 version of ey_cloud_server with Stable-v4

Recommended Release Notes
--------------
- Improves backup logging
- Eliminates ey-alert messages about "unexpected token at success"

Estimated risk
--------------
Low
- These are just minor adjustements to get Stable-v4 and v5 in sync.

Components involved
--------------

$ git diff next-release --name-only
cookbooks/collectd/templates/default/ey-alert.erb
cookbooks/ey-backup/recipes/mysql.rb
cookbooks/ey-backup/recipes/postgres.rb
manifest/Gemfile
manifest/Gemfile.lock

Description of testing done
--------------
#### Under the tpol-2016-0.1 stack for Postgres and MySQL clusters

- Updated to the required stack
- Ran a backup
- Ran a restore
- Ran a GPG encrypted backup
- Ran a restore of an encrypted backup and confirmed the restore operation was blocked
- Ran a download of an encrypted backup and confirmed I was able to decrypt and restore
- Listed available backups

QA Instructions
--------------
To be completed by a member of the Data team, similar to the above.