### PR TITLE
Fix incorrectly setting postgres temp_tablespaces

### DIFF
--- a/cookbooks/postgresql/recipes/server_configure.rb
+++ b/cookbooks/postgresql/recipes/server_configure.rb
@@ -102,7 +102,6 @@ if ['solo', 'db_master'].include?(node.dna['instance_role'])
     backup 0
     notifies :reload, "service[postgresql-#{postgres_version}]"
     variables(
-      :temp_tablespaces => postgres_temp,
       :pg_port => "5432",
       :wal_level => "hot_standby",
       :shared_buffers => node['shared_buffers'],
@@ -158,7 +157,6 @@ if ['db_slave'].include?(node.dna['instance_role'])
     backup 0
     notifies :reload, "service[postgresql-#{postgres_version}]"
     variables(
-      :temp_tablespaces => postgres_temp,
       :pg_port => "5432",
       :wal_level => "hot_standby",
       :shared_buffers => node['shared_buffers'],

--- a/cookbooks/postgresql/templates/default/postgresql.conf.erb
+++ b/cookbooks/postgresql/templates/default/postgresql.conf.erb
@@ -444,7 +444,7 @@ log_autovacuum_min_duration = 2000	# -1 disables, 0 logs all actions and
 
 #search_path = '"$user",public'		# schema names
 #default_tablespace = ''		# a tablespace name, '' uses the default
-temp_tablespaces = '<%= @temp_tablespaces %>'			# a list of tablespace names, '' uses
+#temp_tablespaces = ''			# a list of tablespace names, '' uses
 					# only default tablespace
 #check_function_bodies = on
 #default_transaction_isolation = 'read committed'


### PR DESCRIPTION
Description of your patch
-------------

Fix incorrectly setting postgres temp_tablespaces

Recommended Release Notes
-------------

Fix incorrectly setting postgres temp_tablespaces

Estimated risk
-------------

Low

Components involved
-------------

$ git diff --name-only master 
cookbooks/postgresql/recipes/server_configure.rb
cookbooks/postgresql/templates/default/postgresql.conf.erb

Description of testing done
-------------

* Apply cookbooks w/ fix on Postgres env w/ db_master & db_slave.
* Log into both servers and verify that this returns a blank string:

`psql -t -c"SHOW temp_tablespaces;"`

QA Instructions
-------------

Same as testing above.