### PR TITLE
CC-1114 Define https port

### DIFF
--- a/cookbooks/nginx/definitions/nginx_vhost.rb
+++ b/cookbooks/nginx/definitions/nginx_vhost.rb
@@ -89,6 +89,10 @@ define :nginx_vhost, :stack_config => false, :upstream_ports => [] do
       mode 0644
     end
 
+    sslmeta = node.engineyard.apps.detect {|a| a.metadata?(:nginx_https_port) }
+    nginx_https_port = ( sslmeta and meta.metadata?(:nginx_https_port) ) || 8444
+
+
     managed_template "/data/nginx/servers/#{app.name}.ssl.conf" do
       owner node.engineyard.environment.ssh_username
       group node.engineyard.environment.ssh_username

--- a/cookbooks/nginx/definitions/nginx_vhost.rb
+++ b/cookbooks/nginx/definitions/nginx_vhost.rb
@@ -90,7 +90,7 @@ define :nginx_vhost, :stack_config => false, :upstream_ports => [] do
     end
 
     sslmeta = node.engineyard.apps.detect {|a| a.metadata?(:nginx_https_port) }
-    nginx_https_port = ( sslmeta and meta.metadata?(:nginx_https_port) ) || 8444
+    nginx_https_port = ( sslmeta and meta.metadata?(:nginx_https_port) ) || 8082
 
 
     managed_template "/data/nginx/servers/#{app.name}.ssl.conf" do


### PR DESCRIPTION
## Description of your patch

Bugfix to make https for puma work properly

## Recommended Release Notes

Fixed a bug wherein chef fails to complete with puma and an ssl assigned

## Estimated risk

Low

## Components involved

Nginx Cookbook definition

## Description of testing done

See QA instructions

## QA Instructions

1. Test on Puma environments

2.  Boot a stable stack environment. Verify chef completes

3.  Set the application to use an ssl certificate.

 4.  Run another Chef to put the ssl in place.

5.  Upgrade to new stack

6. Verify chef completes correctly.
 
