### PR TITLE
Modified sidekiq.yml to produce valid YML if a queue name contains punctuation (like ":")

### DIFF
--- a/cookbooks/sidekiq/templates/default/sidekiq.yml.erb
+++ b/cookbooks/sidekiq/templates/default/sidekiq.yml.erb
@@ -4,6 +4,6 @@
 :verbose: <%= @verbose %>
 :concurrency: <%= @concurrency %>
 :queues:
-<% @queues.to_a.each do |q| %>
-  - [<%= q.join(', ') %>]
+<% @queues.each do |queue, priority| %>
+  - [<%= queue.to_s.inspect %>, <%= priority %>]
 <% end %>


### PR DESCRIPTION
Addresses issue @crigor noticed with #62 