### PR TITLE
CC-1109 added support for php 7.1

### DIFF
--- a/cookbooks/php/attributes/php.rb
+++ b/cookbooks/php/attributes/php.rb
@@ -5,8 +5,9 @@ default['php']['version'] = case attribute['dna']['engineyard']['environment']['
     '5.6.25'
   when 'php_7'
     '7.0.11'
+  when 'php_71'
+      '7.1.0'
   else
-   #'7.0.11'
    '5.6.25'	
 end
  


### PR DESCRIPTION
**Description of your patch**

Chef component for php 7.1 version selection, once the option is available via the dashboard

**Recommended Release Notes**

back end support for PHP 7.1 version selection

**Estimated risk**

Low

**Components involved**

php cookbook attributes file

**Description of testing done**

See QA instructions

**QA Instructions**

Bring up a php environment with the updated attributes file

modify the attribute['dna']['engineyard']['environment'][''
components'] php key value to php_71

Run chef locally with PATH=/usr/local/ey_resin/bin ey-enzyme --cached --verbose --chef-bin /usr/local/ey_resin/bin/chef-solo

confirm version is 7.1.0 with php -v and php-fpm -v