### PR TITLE
Cc 1105

### DIFF
--- a/cookbooks/collectd/files/default/check_health_for
+++ b/cookbooks/collectd/files/default/check_health_for
@@ -46,6 +46,36 @@ function alert() {
     exit
 }
 
+always_alert() {
+    SEVERITY="$1"
+    MESSAGE="$2"
+    CHECK_TYPE="$3"
+    timestamp=$(date '+%s')
+
+    echo "PUTNOTIF Time=${timestamp} TYPE=${CHECK_TYPE}-${ACTION} severity=${SEVERITY} message=\"raw_message: $(date +'%T') ${MESSAGE}\""
+
+    STATUS_FILE="${STATUS_DIR}/${ACTION}_OKAY"
+    if [ "${SEVERITY}" != "OKAY" ]
+    then
+        STATUS_FILE="${STATUS_DIR}/${ACTION}_${SEVERITY}"
+    fi
+    echo -e "Time: $(date)\nStatus: ${SEVERITY}\nType: ${CHECK_TYPE}-${ACTION}\nMessage: ${MESSAGE}" > $STATUS_FILE
+}
+
+clear_last_check_after() {
+  local days_count=$1
+  find ${STATUS_FILE} -type f -mtime +${days_count} -delete
+}
+
+join() {
+  # joins arrays with the delimiter passed
+  local d=$1
+  shift
+  echo -n "$1"
+  shift
+  printf "%s" "${@/#/$d}"
+}
+
 # This function is not appropriate for checks that need to run every minute or need to run
 #  at the top of the hour (0 minutes). This was necessary since 0 % {anything} is 0
 function check_interval {
@@ -178,6 +208,86 @@ function check_fs-type {
     alert "OKAY" "FileSystem checks OK." "${check_type}"
   }
   
+}
+
+check_primary-ebs() {
+  # This doesn't actually use WARN and CRIT, but we use them to optionally get check interval (months) and mount count instead
+  [[ -z ${WARN} ]] && WARN=12
+  [[ -z ${CRIT} ]] && CRIT=30
+  months_interval="${WARN}"
+  mount_count_check="${CRIT}"
+  
+  STATUS_FILE="$(ls ${STATUS_DIR}/${ACTION}_* 2> /dev/null)"
+  prior_status=$(echo "${STATUS_FILE}" | awk -F '_' '{print $NF}')
+  check_type='device'
+  clear_last_check_after '7' # clear last check after 7 days
+  
+  if [[ ! -f ${STATUS_FILE} ]] && [[ ! -f '/etc/engineyard/skip_fsck_check' ]]
+  then
+    warning=0
+    failure=0
+    message=()
+    
+    # get filesystems
+    egrep '/db|/data' /proc/mounts | 
+    {
+      while read i
+      do
+        vol_msg=()
+        device=$(echo "${i}" | awk '{print $1}')
+        volume=$(echo "${i}" | awk '{print $2}')
+        tune2fs_out=$(sudo /sbin/tune2fs -l ${device})
+        mount_count=$(echo "${tune2fs_out}" | grep 'Mount count' | awk -F: '{print $2}' | xargs)
+        last_check=$(echo "${tune2fs_out}" | grep 'Last checked' | awk -F': ' '{print $2}' | xargs )
+        fs_state=$(echo "${tune2fs_out}" | grep 'Filesystem state' | awk -F: '{print $2}' | xargs)
+        last_check=$(date -d "${last_check}" '+%Y%m%d')
+        check_due=$(date -d "${last_check}+${months_interval} months" '+%Y%m%d')
+        
+        if [[ $(date '+%Y%m%d') -gt check_due ]]
+        then
+          warning=1
+          vol_msg+=("Last Check: $(date -d ${last_check} '+%Y-%m-%d') Check Due: $(date -d ${check_due} '+%Y-%m-%d')")
+        fi
+    
+        if [[ ${mount_count} -gt ${mount_count_check} ]]
+        then
+          warning=1
+          vol_msg+=("Mount Count: ${mount_count} Check After: ${mount_count_check}")
+        fi
+    
+        if [[ ${fs_state} != 'clean' ]]
+        then
+          failure=1
+          if [[ ${fs_state} == '' ]]
+          then
+            vol_msg+=("An unknown error has occurred.")
+          else
+            vol_msg+=("Unclean Volume State: ${fs_state}")
+          fi
+        fi
+              
+        if [[ ${warning} -gt 0 || ${failure} -gt 0 ]] && [[ ${#vol_msg[@]} -gt 0 ]]
+        then
+          vol_msg=$(join ", " "${vol_msg[@]}")
+          vol_msg="Filesystem Check Warning ${volume} (${device}): ${vol_msg}"
+          message+=("${vol_msg}")
+        fi 
+      done
+    
+      if [[ $failure -eq 1 ]]
+      then
+        message=$(join ', ' "${message[@]}")
+        always_alert "FAILURE" "${message}" "${check_type}"
+      elif [[ $warning -eq 1 ]]
+      then
+        message=$(join ', ' "${message[@]}")
+        always_alert "WARNING" "${message}" "${check_type}"
+      elif [[ ${prior_status} != 'OKAY' ]]
+      then
+        always_alert "OKAY" "FileSystem FSCK checks clean." "${check_type}"
+      fi
+    }
+  fi
 }
 
 eval "check_${ACTION}"

--- a/cookbooks/collectd/templates/default/collectd.conf.erb
+++ b/cookbooks/collectd/templates/default/collectd.conf.erb
@@ -141,6 +141,7 @@ LoadPlugin threshold
   Exec "<%= @user %>" "/engineyard/bin/check_readonly.sh"
   Exec "<%= @user %>" "/engineyard/bin/check_health_for" "ntpd"
   Exec "<%= @user %>" "/engineyard/bin/check_health_for" "fs-type"
+  Exec "<%= @user %>" "/engineyard/bin/check_health_for" "primary-ebs"
 </Plugin>
 <Plugin exec>
   NotificationExec "<%= @user %>" "<%= @alert_script %>"

--- a/cookbooks/ebs/recipes/default.rb
+++ b/cookbooks/ebs/recipes/default.rb
@@ -41,6 +41,8 @@ if (`grep '/db ' /etc/fstab` == "")
       mount "/db" do
         device node['db_volume'].device
         fstype node['db_filesystem']
+        pass 0
+        options "rw,noatime,data=ordered"
         action [:mount, :enable]
       end
 

--- a/cookbooks/ec2/recipes/default.rb
+++ b/cookbooks/ec2/recipes/default.rb
@@ -46,6 +46,7 @@ if data_mounted.stdout == ""
       mount "/data" do
         fstype node['data_filesystem']
         device node['data_volume'].device
+        pass 0
         action :mount
       end
 


### PR DESCRIPTION
Description of your patch
--------------

Disables automated filesystem consistency checks to allow for faster instance recovery.
Adds filesystem consistency healthcheck to alert when checks are needed.
Sets database mounts to use noatime instead of relatime


Recommended Release Notes
--------------
Adds filesystem consistnecy healthcheck to collectd monitoring.
Modifies database mounts to use noatime instead of relatime.

Estimated risk
--------------

Low
- minor changes that improve system visibility and improve performance

Components involved
--------------

$ git diff next-release --name-only
cookbooks/collectd/files/default/check_health_for
cookbooks/collectd/templates/default/collectd.conf.erb
cookbooks/ebs/recipes/default.rb
cookbooks/ec2/recipes/default.rb

Description of testing done
--------------
under a v5 cluster with a Postgres configuration

on the app master instance

     cat /etc/fstab | grep '/data'

verify (***Hint***: the device name (/dev/xvdz1) may vary based on the instance type, this is ok)

     /dev/xvdz1 /data ext3 defaults 0 2

on the database instance

     cat /etc/fstab | grep '/db'

verify 

     /dev/xvdz2 /db ext3 defaults 0 2

set the mount count to something above the alert threshold

     tune2fs -C 36 $(cat /proc/mounts|grep '/db'|awk '{print $1}')

update to the latest stack

Check the dashboard, within a couple minutes you should have see a `Device primary ebs` alert
Follow the process outlined here to address https://gist.github.com/tpoland/863fdbd81c26fd5525796c3b826ca335 (e.g. add a replica database and check its volume). Follow all the way through from Introduction to Cleanup so you get an OKAY alert.

On the replica run

     cat /etc/fstab | grep '/db'
     
verify

     /dev/xvdz2 /db ext3 rw,noatime,data=ordered 0 0
     
add an application slave instance
on the app master instance

     cat /etc/fstab | grep '/data'

verify (***Hint***: the device name (/dev/xvdz1) may vary based on the instance type, this is ok)

    /dev/xvdz1 /data ext3 defaults 0 2

QA Instructions
--------------
### Create a cluster configuration on the existing v4 and v5 stack (database is dealers choice)

on the app master instance

     cat /etc/fstab | grep '/data'

verify (***Hint***: the device name (/dev/xvdz1) may vary based on the instance type, this is ok)

     /dev/xvdz1 /data ext3 defaults 0 2

on the database instance

     cat /etc/fstab | grep '/db'

verify 

     /dev/xvdz2 /db ext3 defaults 0 2

set the mount count to something above the alert threshold

     tune2fs -C 36 $(cat /proc/mounts|grep '/db'|awk '{print $1}')

update to the latest stack

Check the dashboard, within a couple minutes you should have see a `Device primary ebs` alert
Follow the process outlined here to address https://gist.github.com/tpoland/863fdbd81c26fd5525796c3b826ca335 (e.g. add a replica database and check its volume). Follow all the way through from Introduction to Cleanup so you get an OKAY alert.

On the replica run

     cat /etc/fstab | grep '/db'
     
verify

     /dev/xvdz2 /db ext3 rw,noatime,data=ordered 0 0
     
add an application slave instance
on the app master instance

     cat /etc/fstab | grep '/data'

verify (***Hint***: the device name (/dev/xvdz1) may vary based on the instance type, this is ok)

    /dev/xvdz1 /data ext3 defaults 0 2

     
### Boot a Solo cluster using the new stack
On the solo instance

     cat /etc/fstab | egrep '/db|/data'
     
verify

     /dev/xvdz1 /db ext3 defaults 0 0
     /dev/xvdz2 /db ext3 defaults 0 0
