### PR TITLE
[CC-1125] Passenger 5 will fail if more than one domain set in the application

### DIFF
--- a/cookbooks/passenger5/templates/default/nginx_app.conf.erb
+++ b/cookbooks/passenger5/templates/default/nginx_app.conf.erb
@@ -82,7 +82,11 @@ server {
   error_log /var/log/engineyard/nginx/<%= @vhost.app.name %>.error.log notice;
   <% end %>
 
-  rewrite ^/public/(.*) http://api.<%= @vhost.domain_name %>/$1 permanent;
+<% domain =  @vhost.domain_name %>
+<% domain = domain.split(" ") %>
+<% domain = domain.first %>
+
+  rewrite ^/public/(.*) http://api.<%= domain %>/$1 permanent;
 
   #
   # Expire header on assets. For more information on the reasoning behind


### PR DESCRIPTION
Description of your patch
--------------

Fixed a passenger 5 bug caused by multiple domain names in the dashboard not being filtered properly in a configuration file.


Recommended Release Notes
--------------
Fixed a passenger 5 bug caused by multiple domain names

Estimated risk
--------------

Low
- minor changes that only affects the passenger 5 template

Components involved
--------------

$ git diff next-release --name-only
cookbooks/passenger5/templates/default/nginx_app.conf.erb

Description of testing done
--------------
under a v5 cluster with the issue that had previously failed due to the bug added the code and the issue was resolved.


QA Instructions
--------------
### Create an environment on the existing  v5 stack with passenger 5

1.  Add multiple domain names to the applicaton under edit application.
2.  Boot environment
3.  The initial chef run will fail due to nginx
4.  Update to fixed version.
5.  Verify Chef completes.