### PR TITLE
[CC-1126] Update haproxy to 1.6 from 1.5 properly

### DIFF
--- a/cookbooks/haproxy/attributes/haproxy.rb
+++ b/cookbooks/haproxy/attributes/haproxy.rb
@@ -1,1 +1,1 @@
-node.default.haproxy_version = '1.6.2'
+node.default.haproxy_version = '1.6.5'

--- a/cookbooks/lb/attributes/haproxy.rb
+++ b/cookbooks/lb/attributes/haproxy.rb
@@ -1,1 +1,1 @@
-node.default.haproxy_version = '1.6.2'
+node.default.haproxy_version = '1.6.5'


### PR DESCRIPTION
Description of your patch
-------------

Updates haproxy to version 1.6.5 from 1.5.14.

Recommended Release Notes
-------------

Update haproxy to version 1.6

Estimated risk
-------------

Medium

Components involved
-------------

$ git diff --name-only next-release
cookbooks/haproxy/attributes/haproxy.rb
cookbooks/lb/attributes/haproxy.rb

Description of testing done
-------------

* Verify haproxy is version 1.5.14 with `eix haproxy`
* Update cookbooks
* Verify chef completes without issue
* Verify haproxy is now version 1.6.5 with `eix haproxy`

QA Instructions
-------------

Same as testing above.