### PR TITLE
Remove custom-redis from resque-scheduler recipe

### DIFF
--- a/examples/resque_scheduler/cookbooks/custom-redis/README.md
+++ b/examples/resque_scheduler/cookbooks/custom-redis/README.md
@@ -1,3 +1,0 @@
-# Custom Redis
-
-This custom-redis recipe is used in the resque example to install redis on the utility instance named "resque" instead of the default "redis".

--- a/examples/resque_scheduler/cookbooks/custom-redis/attributes/default.rb
+++ b/examples/resque_scheduler/cookbooks/custom-redis/attributes/default.rb
@@ -1,1 +1,0 @@
-default['redis']['utility_name'] = 'resque'

--- a/examples/resque_scheduler/cookbooks/custom-redis/metadata.rb
+++ b/examples/resque_scheduler/cookbooks/custom-redis/metadata.rb
@@ -1,3 +1,0 @@
-name 'custom-redis'
-
-depends 'redis'

--- a/examples/resque_scheduler/cookbooks/custom-redis/recipes/default.rb
+++ b/examples/resque_scheduler/cookbooks/custom-redis/recipes/default.rb
@@ -1,1 +1,0 @@
-include_recipe 'redis'

--- a/examples/resque_scheduler/cookbooks/ey-custom/metadata.rb
+++ b/examples/resque_scheduler/cookbooks/ey-custom/metadata.rb
@@ -1,4 +1,3 @@
 name 'ey-custom'
 
-depends 'custom-redis'
 depends 'custom-resque_scheduler'

--- a/examples/resque_scheduler/cookbooks/ey-custom/recipes/after-main.rb
+++ b/examples/resque_scheduler/cookbooks/ey-custom/recipes/after-main.rb
@@ -1,2 +1,1 @@
-include_recipe 'custom-redis'
 include_recipe 'custom-resque_scheduler'


### PR DESCRIPTION
We need another PR to update the README - add a section about how to modify the Redis recipe for cases where Resque and Redis should be installed on the same utility instance. We'll do that in another PR to avoid merge conflicts with #149