### PR TITLE
Remove custom-redis from resque-scheduler and resque recipes

### DIFF
--- a/custom-cookbooks/redis/cookbooks/custom-redis/README.md
+++ b/custom-cookbooks/redis/cookbooks/custom-redis/README.md
@@ -87,7 +87,80 @@ Note that this is not recommended for production environments. Running Redis on 
    		redis_instances.include?(node['dna']['name'])
  	)
 	```
+	
+#### C. Run Redis on the same instance as Sidekiq
 
+On staging environments, or in a production environment with a low job volume, you might want to run Sidekiq and Redis within the same instance.
+
+* Ensure that these lines are not commented out:
+
+	```
+	redis['utility_name'] = 'redis'
+ 	redis_instances << redis['utility_name']
+ 	redis['is_redis_instance'] = (
+  	  node['dna']['instance_role'] == 'util' &&
+   	  redis_instances.include?(node['dna']['name'])
+ 	)
+	```
+
+* Specify the same instance name for Redis and Sidekiq. 
+
+  On `custom-redis/attributes/default.rb`:
+  
+  ```
+  redis['utility_name'] = 'sidekiq'
+  ```
+  
+  On `custom-sidekiq/attributes/default.rb`:
+  
+  ```
+  default['sidekiq']['is_sidekiq_instance'] = (node['dna']['instance_role'] == 'util' && node['dna']['name'] == 'sidekiq')
+  ```
+
+* If the instance is not yet running, boot an instance with that name.
+
+* Make sure this line is commented out:
+
+	```
+	redis['is_redis_instance'] = ( ['solo', 'app_master'].include?(node['dna']['instance_role']) )
+	```
+	
+#### D. Run Redis on the same instance as Resque
+
+On staging environments, or in a production environment with a low job volume, you might want to run Resque and Redis within the same instance.
+
+* Ensure that these lines are not commented out:
+
+	```
+	redis['utility_name'] = 'redis'
+ 	redis_instances << redis['utility_name']
+ 	redis['is_redis_instance'] = (
+  	  node['dna']['instance_role'] == 'util' &&
+   	  redis_instances.include?(node['dna']['name'])
+ 	)
+	```
+
+* Specify the same instance name for Redis and Resque. 
+
+  On `custom-redis/attributes/default.rb`:
+  
+  ```
+  redis['utility_name'] = 'resque'
+  ```
+  
+  On `custom-resque/attributes/default.rb`:
+  
+  ```
+  default['resque']['is_resque_instance'] = (node['dna']['instance_role'] == 'util' && node['dna']['name'] == 'resque')
+  ```
+
+* If the instance is not yet running, boot an instance with that name.
+
+* Make sure this line is commented out:
+
+	```
+	redis['is_redis_instance'] = ( ['solo', 'app_master'].include?(node['dna']['instance_role']) )
+	
 ### Master-Slave Replication
 
 Master-Slave replication can be used for redundancy, or to minimize the downtime when upgrading the Redis instance.

--- a/custom-cookbooks/resque/cookbooks/custom-redis/README.md
+++ b/custom-cookbooks/resque/cookbooks/custom-redis/README.md
@@ -1,3 +1,0 @@
-# Custom Redis
-
-This custom-redis recipe is used in the resque example to install redis on the utility instance named "resque" instead of the default "redis".

--- a/custom-cookbooks/resque/cookbooks/custom-redis/attributes/default.rb
+++ b/custom-cookbooks/resque/cookbooks/custom-redis/attributes/default.rb
@@ -1,1 +1,0 @@
-default['redis']['utility_name'] = 'resque'

--- a/custom-cookbooks/resque/cookbooks/custom-redis/metadata.rb
+++ b/custom-cookbooks/resque/cookbooks/custom-redis/metadata.rb
@@ -1,3 +1,0 @@
-name 'custom-redis'
-
-depends 'redis'

--- a/custom-cookbooks/resque/cookbooks/custom-redis/recipes/default.rb
+++ b/custom-cookbooks/resque/cookbooks/custom-redis/recipes/default.rb
@@ -1,1 +1,0 @@
-include_recipe 'redis'

--- a/custom-cookbooks/resque/cookbooks/custom-resque/README.md
+++ b/custom-cookbooks/resque/cookbooks/custom-resque/README.md
@@ -41,6 +41,10 @@ Our main recipes have the `resque` recipe but it is not included by default. To 
 
 If you do not have `cookbooks/ey-custom` on your app repository, you can copy `custom-cookbooks/resque/cookbooks/ey-custom` to `/path/to/app/cookbooks`.
 
+## Dependencies
+
+`resque` depends on Redis. We recommend using the [Redis recipe](https://github.com/engineyard/ey-cookbooks-stable-v5/tree/master/cookbooks/redis) to setup Redis on the environment.
+
 ## Customizations
 
 All customizations go to `cookbooks/custom-resque/attributes/default.rb`.

--- a/custom-cookbooks/resque/cookbooks/ey-custom/metadata.rb
+++ b/custom-cookbooks/resque/cookbooks/ey-custom/metadata.rb
@@ -1,4 +1,3 @@
 name 'ey-custom'
 
-depends 'custom-redis'
 depends 'custom-resque'

--- a/custom-cookbooks/resque/cookbooks/ey-custom/recipes/after-main.rb
+++ b/custom-cookbooks/resque/cookbooks/ey-custom/recipes/after-main.rb
@@ -1,2 +1,1 @@
-include_recipe 'custom-redis'
 include_recipe 'custom-resque'

--- a/custom-cookbooks/resque_scheduler/cookbooks/custom-redis/README.md
+++ b/custom-cookbooks/resque_scheduler/cookbooks/custom-redis/README.md
@@ -1,3 +1,0 @@
-# Custom Redis
-
-This custom-redis recipe is used in the resque example to install redis on the utility instance named "resque" instead of the default "redis".

--- a/custom-cookbooks/resque_scheduler/cookbooks/custom-redis/attributes/default.rb
+++ b/custom-cookbooks/resque_scheduler/cookbooks/custom-redis/attributes/default.rb
@@ -1,1 +1,0 @@
-default['redis']['utility_name'] = 'resque'

--- a/custom-cookbooks/resque_scheduler/cookbooks/custom-redis/metadata.rb
+++ b/custom-cookbooks/resque_scheduler/cookbooks/custom-redis/metadata.rb
@@ -1,3 +1,0 @@
-name 'custom-redis'
-
-depends 'redis'

--- a/custom-cookbooks/resque_scheduler/cookbooks/custom-redis/recipes/default.rb
+++ b/custom-cookbooks/resque_scheduler/cookbooks/custom-redis/recipes/default.rb
@@ -1,1 +1,0 @@
-include_recipe 'redis'

--- a/custom-cookbooks/resque_scheduler/cookbooks/custom-resque_scheduler/README.md
+++ b/custom-cookbooks/resque_scheduler/cookbooks/custom-resque_scheduler/README.md
@@ -36,10 +36,14 @@ Our main recipes have the `resque_scheduler` recipe but it is not included by de
 
       ```
       gem install ey-core
-      ey-core recipes upload --environment <nameofenvironment> --apply
+      ey-core recipes upload --environment <nameofenvironment>
       ```
 
 If you do not have `cookbooks/ey-custom` on your app repository, you can copy `custom-cookbooks/resque_scheduler/cookbooks/ey-custom` to `/path/to/app/cookbooks`.
+
+## Dependencies
+
+`resque-scheduler` depends on Redis. We recommend using the [Redis recipe](https://github.com/engineyard/ey-cookbooks-stable-v5/tree/master/cookbooks/redis) to setup Redis on the environment.
 
 ## Customizations
 


### PR DESCRIPTION
..and added pointers to the Redis recipe

Bonus README update included instructions on how to run Redis and Resque/Sidekiq on the same instance.