### PR TITLE
change from compile time to run time evaluation of installed mysql version

### DIFF
--- a/cookbooks/mysql/attributes/version.rb
+++ b/cookbooks/mysql/attributes/version.rb
@@ -1,5 +1,4 @@
 lock_major_version = %x{[[ -f "/db/.lock_db_version" ]] && grep -E -o '^[0-9]+\.[0-9]+' /db/.lock_db_version }
-full_version =  %x{[[ -f "/db/.lock_db_version" ]] && grep -E -o '^[0-9]+\.[0-9]+\.[0-9]+' /db/.lock_db_version }
 db_stack = lock_major_version == '' ? attribute.dna['engineyard']['environment']['db_stack_name'] :  "mysql#{lock_major_version.gsub(/\./, '_').strip}"
 
 default['latest_version_55'] = '5.5.49'
@@ -26,7 +25,6 @@ when 'mysql5_7', 'aurora5_7', 'mariadb10_1'
 
 end
 
-default['mysql']['full_version'] = full_version == '' ? node['mysql']['latest_version'] : full_version
 default['mysql']['short_version'] = major_version
 default['mysql']['logbase'] = "/db/mysql/#{major_version}/log/"
 default['mysql']['datadir'] = "/db/mysql/#{major_version}/data/"

--- a/cookbooks/mysql/recipes/master.rb
+++ b/cookbooks/mysql/recipes/master.rb
@@ -1,5 +1,3 @@
-include_recipe "ebs::default"
-
 ey_cloud_report "mysql" do
   message "processing mysql"
 end

--- a/cookbooks/mysql/recipes/slave.rb
+++ b/cookbooks/mysql/recipes/slave.rb
@@ -1,4 +1,3 @@
-include_recipe "ebs::default"
 include_recipe 'mysql::client'
 
 mysql_slave node.dna['db_host'] do


### PR DESCRIPTION
Description of your patch
--------------

Corrects an issue with the identification of the full mysql version on the Stable-v4 stack that prevents older versions from starting from a snapshot.


Recommended Release Notes
--------------
V4
- Corrects an issue where MySQL versions lower than 5.6.24 won't start when booting from snapshot due to show_old_temporals in the config file.
V5
- Corrects the chef process identifying the full local MySQL version, and moves the EBS mount process earlier in the MySQL cookbook.

Estimated risk
--------------

Low
- This is a bugfix release for Stable-v4
- This fixes a currently 0 impact bug in Stable-v5

Components involved
--------------

$ git diff next-release --name-only
cookbooks/mysql/attributes/version.rb
cookbooks/mysql/recipes/default.rb
cookbooks/mysql/recipes/master.rb
cookbooks/mysql/recipes/slave.rb

Description of testing done
--------------

Under the 12.11 stack

- On the new stack boot an app_master and db_master cluster with mysql 5.6
- on the db_master
  - `echo '5.6.21' > /db/.lock_db_version`
- run chef apply
- restart the database 
  - `/etc/init.d/mysql restart`
- verify the version is 5.6.21 
  - `mysqld --version`
- boot a replica database
- the replica database should start and run chef successfully.

- on the new stack boot a solo instance with mysql 5.6
- on the instance
  - `echo '5.6.21' > /db/.lock_db_version`
- take snapshots and terminate the instance
- reboot from the snapshot created
- the instance should start and run chef successfully
- verify the version is 5.6.21
  - `mysqld --version`


QA Instructions
--------------

Under the 12.11 stack

- On the new stack boot an app_master and db_master cluster with mysql 5.6
- on the db_master
  - `echo '5.6.21' > /db/.lock_db_version`
- run chef apply
- restart the database 
  - `/etc/init.d/mysql restart`
- verify the version is 5.6.21 
  - `mysqld --version`
- boot a replica database
- the replica database should start and run chef successfully.

- on the new stack boot a solo instance with mysql 5.6
- on the instance
  - `echo '5.6.21' > /db/.lock_db_version`
- take snapshots and terminate the instance
- reboot from the snapshot created
- the instance should start and run chef successfully
- verify the version is 5.6.21
  - `mysqld --version`

Under the v5 stack

- boot a cluster running mysql 5.6
- verify that chef runs successfully and the database is running
