### PR TITLE
Add examples/ placeholder

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,1 @@
+The custom chef recipes have moved! You can find them [here](https://github.com/engineyard/ey-cookbooks-stable-v5/tree/master/custom-cookbooks).


### PR DESCRIPTION
We renamed examples/ to custom-cookbooks. Add a pointer to the new location.