### PR TITLE
Fix sidekiq start command

### DIFF
--- a/cookbooks/sidekiq/files/default/sidekiq
+++ b/cookbooks/sidekiq/files/default/sidekiq
@@ -66,7 +66,7 @@ start ()
   fi
 
   # start sidekiq
-  sudo -u "${app_user}" -E -H "${sidekiq}" -d -C "${conf_file}" -e "${rails_env}" -r "${app_root}" -P "${pid_file}" -L "${log_file}" -i ${worker_id} &
+  sudo -u "${app_user}" -E -H "${sidekiq}" -d -C "${conf_file}" -e "${rails_env}" -r "${app_root}" -P "${pid_file}" -L "${log_file}" -i ${worker_id} >> ${log_file} 2>&1 &
   exit $?
 }
 


### PR DESCRIPTION
## Description of your patch

Fixes the Sidekiq recipe to address issue #154

## Recommended Release Notes

Updates the Solr recipe to use the latest IcedTea JDK that includes patches for recent vulnerabilities.

## Estimated risk

Low. 

## Components involved

Sidekiq custom chef recipe

## Description of testing done

See QA instructions

## QA Instructions

1. Verify the error.
Boot a stable-v5.3.0.22 environment running rails_activejob_example. Use the sidekiq recipe to run sidekiq on the environment
Deploy the sidekiq-stdout branch of rails_activejob_example (https://github.com/engineyard/rails_activejob_example/tree/sidekiq-stdout) on an environment
Generate jobs
Verify if there are Broken Pipe errors in the sidekiq log

2. Upgrade to the QA stack
Generate jobs again
Check <Rails.root>/tmp/echo.output to verify that the jobs ran successfully
Verify that there are no Broken Pipe errors in the sidekiq log