### PR TITLE
Update Elasticsearch to use latest JDK

### DIFF
--- a/cookbooks/elasticsearch/attributes/default.rb
+++ b/cookbooks/elasticsearch/attributes/default.rb
@@ -30,7 +30,7 @@ default['elasticsearch'].tap do |elasticsearch|
   elasticsearch['java_package_name'] = 'dev-java/icedtea-bin'
 
   # Which version of the java package to use
-  elasticsearch['java_version'] = '3.0.1'
+  elasticsearch['java_version'] = '3.3.0'
 
   # After installing the Java version we also need to eselect it
   # The version below tells chef what java package to specify in eselect

--- a/cookbooks/elasticsearch/recipes/install.rb
+++ b/cookbooks/elasticsearch/recipes/install.rb
@@ -8,7 +8,7 @@ if ES['is_elasticsearch_instance']
 
   # Update JAVA as the Java on the AMI can sometimes crash
   #
-  Chef::Log.info "Updating Java JDK"
+  Chef::Log.info "Updating Java JDK to #{ES['java_version']}"
   enable_package ES['java_package_name'] do
     version ES['java_version']
     unmask true

--- a/custom-cookbooks/elasticsearch/cookbooks/custom-elasticsearch/attributes/default.rb
+++ b/custom-cookbooks/elasticsearch/cookbooks/custom-elasticsearch/attributes/default.rb
@@ -30,7 +30,7 @@ default['elasticsearch'].tap do |elasticsearch|
   elasticsearch['java_package_name'] = 'dev-java/icedtea-bin'
 
   # Which version of the java package to use
-  elasticsearch['java_version'] = '3.0.1'
+  elasticsearch['java_version'] = '3.3.0'
 
   # After installing the Java version we also need to eselect it
   # The version below tells chef what java package to specify in eselect


### PR DESCRIPTION
## Description of your patch

Updates the Elasticsearch recipe to use the latest IcedTea JDK that includes patches for recent vulnerabilities.

## Recommended Release Notes

Updates the Elasticsearch recipe to use the latest IcedTea JDK that includes patches for recent vulnerabilities.

## Estimated risk

Low. 

## Components involved

Elasticsearch custom chef recipe

## Description of testing done

See QA instructions

## QA Instructions

Install Elasticsearch on an environment. Either Solo or cluster is OK. Verify that there were no chef errors encountered, and that Elasticsearch is running after the chef run.