### PR TITLE
Update Solr to use latest JDK

### DIFF
--- a/cookbooks/solr/attributes/default.rb
+++ b/cookbooks/solr/attributes/default.rb
@@ -1,5 +1,5 @@
 default['solr'].tap do |solr|
-  solr['java_version'] = '3.0.1'
+  solr['java_version'] = '3.3.0'
   solr['java_eselect_version']  = 'icedtea-bin-8'
   solr['solr_version'] = '6.1.0'
   solr['core_name'] = 'default'

--- a/cookbooks/solr/recipes/install.rb
+++ b/cookbooks/solr/recipes/install.rb
@@ -17,7 +17,7 @@ username = node['dna']['engineyard']['environment']['ssh_username']
 if node['solr']['is_solr_instance']
 
   unless use_default_java
-    Chef::Log.info "Updating Java JDK"
+    Chef::Log.info "Updating Java JDK to version #{java_version}"
     enable_package java_package_name do
       version java_version
       unmask true
@@ -25,7 +25,7 @@ if node['solr']['is_solr_instance']
 
     package java_package_name do
       version java_version
-      action :upgrade
+      action :install
     end
 
     execute "Set the default Java version to #{java_eselect_version}" do

--- a/custom-cookbooks/solr/cookbooks/custom-solr/attributes/default.rb
+++ b/custom-cookbooks/solr/cookbooks/custom-solr/attributes/default.rb
@@ -1,5 +1,5 @@
 default['solr'].tap do |solr|
-  solr['java_version'] = '3.0.1'
+  solr['java_version'] = '3.3.0'
   solr['java_eselect_version']  = 'icedtea-bin-8'
   solr['solr_version'] = '6.1.0'
   solr['core_name'] = 'default'


### PR DESCRIPTION
## Description of your patch

Updates the Solr recipe to use the latest IcedTea JDK that includes patches for recent vulnerabilities.

## Recommended Release Notes

Updates the Solr recipe to use the latest IcedTea JDK that includes patches for recent vulnerabilities.

## Estimated risk

Low. 

## Components involved

Solr custom chef recipe

## Description of testing done

See QA instructions

## QA Instructions

Install Solr on an environment. Either Solo or cluster is OK. Verify that there were no chef errors encountered, and that Solr is running after the chef run.