### PR TITLE
Enable Passenger Monitoring

### DIFF
--- a/cookbooks/passenger5/files/default/passenger_killer
+++ b/cookbooks/passenger5/files/default/passenger_killer
@@ -37,7 +37,7 @@ shift `expr $OPTIND - 1`
 app=$1
 [ -n "$app" ] || { echo "$USAGE"; exit 1; }
 kills=0
-passenger-memory-stats | egrep -i " Ra(ils|ck)(App)?:.*\\b$app\\b" > /tmp/$$.tmp
+passenger-memory-stats | egrep -i "Passenger RubyApp:.*\\b$app\\b" > /tmp/$$.tmp
 while read app_pid app_total foo app_real bar baz appdir; do
     app_real=`echo $app_real | sed 's/\..*//'`
     if [ $app_real -gt $LIMIT ]; then

--- a/cookbooks/passenger5/files/default/passenger_monitor
+++ b/cookbooks/passenger5/files/default/passenger_monitor
@@ -45,7 +45,7 @@ done
 # Create an array variable
 declare -a info
 
-for record in `passenger-memory-stats | egrep -i " Ra(ils|ck):" | sed -r '/MB/!d;s/(^[0-9]+)\s*(\b[0-9]+)\.[0-9]\sMB\s+(\b[0-9]+)\.[0-9]+\sMB.*\/([^\/]+)\/current/\1,\2,\3,\4/'`; do
+for record in `passenger-memory-stats | egrep -i "Passenger RubyApp:" | sed -r '/MB/!d;s/(^[0-9]+)\s*(\b[0-9]+)\.[0-9]\sMB\s+(\b[0-9]+)\.[0-9]+\sMB.*\/([^\/]+)\/current\/.*/\1,\2,\3,\4/'`; do
 
   # Turn the record into an array, and assign to local variables for clarity
   info=(`echo ${record//,/ }`)
@@ -83,7 +83,7 @@ exit_code=$?
 ## Kill any passenger workers that are not in $pstats
 if [ "$exit_code" -eq "0" ] ; then
   pstats=$(echo "$raw_stats" | sed -r -e '/PID:/!d' -e 's/.*PID:\s([0-9]+).*/\1/' | sort -n| uniq)
-  for pid in `diff <(ps aux | egrep -i ' Ra(ils|ck)App:' | awk '{print $2}' | sort -n) <(echo "$pstats") | grep '<' | awk '{print $2}'`; do
+  for pid in `diff <(ps aux | egrep -i 'Passenger RubyApp:' | awk '{print $2}' | sort -n) <(echo "$pstats") | grep '<' | awk '{print $2}'`; do
     kill -9 $pid
     logger -t passenger_monitor -s "Killing PID $pid - orphaned process"
   done

--- a/cookbooks/passenger5/recipes/monitoring.rb
+++ b/cookbooks/passenger5/recipes/monitoring.rb
@@ -3,13 +3,13 @@
 # Recipe:: monitoring
 #
 
-if ['app_master', 'app', 'solo'].include?(node[:instance_role])
+if ['app_master', 'app', 'solo'].include?(node.dna['instance_role'])
 
   ey_cloud_report "passenger" do
     message "configuring passenger_monitor and passenger_killer"
   end
 
-  node[:applications].each do |app_name, data|
+  node['dna']['applications'].each do |app_name, data|
 
     # A script to kill VERY large Rack processes with prejudice:
     cookbook_file "/usr/local/bin/passenger_killer" do
@@ -35,7 +35,7 @@ if ['app_master', 'app', 'solo'].include?(node[:instance_role])
     max_megabytes = 800
     # When a Rack process grows to a huge size, passenger_killer will kill it with prejudice
     huge_megabytes = 1200
-    case node[:ec2][:instance_type]
+    case node['ec2']['instance_type']
     when "m1.small"
       max_megabytes = 400
       huge_megabytes = 600
@@ -65,7 +65,7 @@ if ['app_master', 'app', 'solo'].include?(node[:instance_role])
       huge_megabytes = 2000
     end
     # We want to make sure there are at least this many Rack processes running on each app instance:
-    min_rack_processes = (node[:environment][:framework_env] == 'production') ? 3 : 1
+    min_rack_processes = (node[:dna][:environment][:framework_env] == 'production') ? 3 : 1
 
     # Here we are overriding EngineYard's default passenger_monitor cron entry so we can
     # increase the memory limit.  Otherwise, the web processes get killed off very quickly,
@@ -98,7 +98,7 @@ if ['app_master', 'app', 'solo'].include?(node[:instance_role])
       day '*'
       weekday '*'
       month '*'
-      command "/usr/local/bin/rack_counter -i '#{node[:environment][:framework_env]} #{node[:instance_role]}'  -w #{min_rack_processes} #{app_name} >/dev/null 2>&1"
+      command "/usr/local/bin/rack_counter -i '#{node[:dna][:environment][:framework_env]} #{node[:dna][:instance_role]}'  -w #{min_rack_processes} #{app_name} >/dev/null 2>&1"
       action :create  # this actually replaces a cron entry if it already exists
     end
   end


### PR DESCRIPTION
Description of your patch
-------------

The Passenger monitoring recipe is being skipped because it uses the old v4 way of fetching data. This change fixes that, and also updates other node/dna references.

Recommended Release Notes
-------------

Sets up cron jobs for Passenger monitoring that automatically kills worker above a memory threshold.

Estimated risk
-------------

Medium. While it only affects v5/passenger5 environments (around 49 active environments of 33 customers), passenger monitoring kills workers so when enabled, it can potentially interrupt some requests.

How to Test
-------------

Select Passenger 5 as your environment's Application Server Stack. You may need to enable passenger5 feature if it's not showing up in the dropdown.

Once the environment is booted, in your app server, check that the following cron jobs are present:

* passenger_monitor_#{app_name}
* passenger_killer_#{app_name}
* rack_counter_#{app_name}

The passenger_monitor cron job has a default limit of 800, passed as `-l` parameter. The passenger_killer cron job has a default limit of 1200, passed as `-l` parameter. Some instance types have custom thresholds, e.g. if you boot up an m1.medium app instance, passenger_monitor and killer will have 500 and 750 memory limits, respectively.
