### PR TITLE
Remove `--path` from memcache README

### DIFF
--- a/custom-cookbooks/memcached/cookbooks/custom-memcached/README.md
+++ b/custom-cookbooks/memcached/cookbooks/custom-memcached/README.md
@@ -42,7 +42,7 @@ that is managed by Engine Yard.
 
   	```
   	gem install ey-core
-  	ey-core recipes upload --environment <nameofenvironment> --path <pathtocookbooksfolder> --apply
+  	ey-core recipes upload --environment <nameofenvironment> --apply
   	```
 
 ## Customizations


### PR DESCRIPTION
Calling the documented commands ends with:
```
The application encountered the following error:
  invalid option: --path=./cookbooks
```