### PR TITLE
[CC-1138] Update to Ruby 2.2.6 and Ruby 2.3.3

### DIFF
--- a/cookbooks/ey-lib/libraries/ey-environment.rb
+++ b/cookbooks/ey-lib/libraries/ey-environment.rb
@@ -141,8 +141,8 @@ class Chef
           :ruby_213   => "2.1.10",
           :ruby_214   => "2.1.10",
           :ruby_215   => "2.1.10",
-          :ruby_220   => "2.2.5",
-          :ruby_230   => "2.3.1",
+          :ruby_220   => "2.2.6",
+          :ruby_230   => "2.3.3",
         }
         if versions.has_key?(ruby_archtype.to_sym)
           version = versions[ruby_archtype.to_sym]


### PR DESCRIPTION
## Description of your patch

Upgrade Ruby 2.2.x to 2.2.6 and 2.3.x to 2.3.3.
## Recommended Release Notes

Upgrade Ruby 2.2.x to 2.2.6 and 2.3.x to 2.3.3.  

Note: currently running Ruby processes will continue to run on the existing version of ruby.  To update these processes, redeploy your app, and restart any background ruby processes.  If using passenger, run `/etc/init.d/nginx upgrade` on each app instance to restart passenger and its workers on the new version.
## Estimated risk

Low
## Components involved

Ruby
## Description of testing done

Package validated by distribution team
## QA Instructions
1. Build environment on stable stack
2. Ensure chef completes successfully and app deploys and runs as expected
3. Upgrade to target stack
4. Verify chef run completes successfully
5. Verify the correct version of ruby is installed: `ruby -v` should return 2.2.6
6. Deploy the application
7. Verify app deploys and runs as expected, with no loss of changed data
8. Verify that there are no deleted versions of ruby running: lsof | grep DEL | grep ruby 
9. Update Ruby to 2.3
10. Verify chef run completes successfully
11. Verify the correct version of ruby is installed: `ruby -v` should return 2.3.3
12. Terminate and recreate environment on target stack
13. Verify chef run completes successfully
14. Verify the correct version of ruby is installed
15. Verify app deploys and runs as expected, with no loss of changed data
16. Verify that there are no deleted versions of ruby running: lsof | grep DEL | grep ruby 
17. Remove all the metadata that was added by this test
