### PR TITLE
Bump version 4 and 6 of NodeJS

### DIFF
--- a/cookbooks/node/attributes/node.rb
+++ b/cookbooks/node/attributes/node.rb
@@ -15,11 +15,11 @@ fuzzy_version = begin
 
 fallback_nodejs_version = case (fuzzy_version || hard_version)
                            when 'nodejs_6'
-                             '6.4.0'
+                             '6.9.5'
                            when 'nodejs_5'
                              '5.11.0'
                            else
-                             '4.4.5'
+                             '4.7.3'
                            end
 
 default['nodejs']['version'] = node.engineyard.environment.metadata('nodejs_version', fallback_nodejs_version)
@@ -27,18 +27,22 @@ default['nodejs']['version'] = node.engineyard.environment.metadata('nodejs_vers
 default['nodejs']['available_versions'] = [
   '4.4.5', # net-libs/nodejs-4.4.5
   '4.6.0', # net-libs/nodejs-4.6.0
+  '4.7.3', # net-libs/nodejs-4.7.3
   '5.11.0', # net-libs/nodejs-5.11.0
   '6.4.0', # net-libs/nodejs-6.4.0
   '6.7.0' # net-libs/nodejs-6.7.0
+  '6.9.5' # net-libs/nodejs-6.9.5
 ]
 
 if (node.engineyard.metadata('openssl_ebuild_version','1.0.1') =~ /1\.0\.1/)
   default['nodejs']['available_versions'].concat ([
     '4.4.5', # net-libs/nodejs-4.4.5
     '4.6.0', # net-libs/nodejs-4.6.0
+    '4.7.3', # net-libs/nodejs-4.7.3
     '5.11.0', # net-libs/nodejs-5.11.0
     '6.4.0', # net-libs/nodejs-6.4.0
     '6.7.0' # net-libs/nodejs-6.7.0
+    '6.9.5' # net-libs/nodejs-6.9.5
 
   ])
 end


### PR DESCRIPTION
## Description of your patch

- Add availability of 4.7.3 and 6.9.5
- Set default for NodeJS 4 to 4.7.3
- Set default for NodeJS 6 to 6.9.5

## Recommended Release Notes

Add availability of NodeJS version 4.7.3 and 6.9.5
Set default for NodeJS 4 to version 4.7.3
Set default for NodeJS 6 to version 6.9.5

Note: currently running NodeJS processes will continue to run on the existing version of ruby. To update these processes, redeploy your app.

## Estimated risk

Low

## Components involved

NodeJS.  It affects assets compilation for Ruby and PHP apps as well.

## Description of testing done

Package validated by distribution team

## QA Instructions

Testing will only be done on NodeJS apps.  
The version of NodeJS used for assets compilation on Ruby apps is generally specified by the customer on the app's `package.json` file, thus under their control.

1. Create an NodeJS app (can be our demo one).
2. Build environment on stable stack.
3. Leave NodeJS version setting on the default.
4. Ensure chef completes successfully and app deploys and runs as expected
5. Upgrade to target stack.
6. Verify chef run completes successfully
7. Verify the correct version of NodeJS is installed: `node -v` should return 4.4.7
8. Deploy the application.
9. Verify app deploys and runs as expected, with no loss of changed data
10. Verify that there are no deleted versions of NodeJS running: `lsof | grep DEL | grep node`
11. Edit environment and set NodeJS to version 6.
12. Verify chef run completes successfully.
13. Verify the correct version of NodeJS is installed: `node -v` should return 6.9.5
14. Verify chef run completes successfully
15. Verify app deploys and runs as expected, with no loss of changed data
