### PR TITLE
Add support for pending environment timezone feature.

### DIFF
--- a/cookbooks/timezones/README.md
+++ b/cookbooks/timezones/README.md
@@ -1,4 +1,4 @@
 timezones
 ========
 
-Updates the timezone-data package. Attributes/default.rb maintains the version number.
+Updates the timezone-data package. Attributes/default.rb maintains the version number. Sets timezone based on timezone information in DNA if it exists.

--- a/cookbooks/timezones/recipes/default.rb
+++ b/cookbooks/timezones/recipes/default.rb
@@ -9,7 +9,7 @@ package "sys-libs/timezone-data" do
 end
 
 zonepath = '/usr/share/zoneinfo/'
-zone = "#{node[:engineyard][:environment][:timezone]}"
+zone = "#{node.engineyard.environment['timezone']}"
 
 has_nginx = ['solo','app','app_master'].include?(node['instance_role'])
 

--- a/cookbooks/timezones/recipes/default.rb
+++ b/cookbooks/timezones/recipes/default.rb
@@ -7,3 +7,25 @@ package "sys-libs/timezone-data" do
   version node['timezones']['version']
   action :upgrade
 end
+
+zonepath = '/usr/share/zoneinfo/'
+zone = "#{node[:engineyard][:environment][:timezone]}"
+
+has_nginx = ['solo','app','app_master'].include?(node['instance_role'])
+
+if not File.exists?(File.join(zonepath, zone)) and zone != '' and not zone.nil?
+  raise "Timezone '#{zone}' not recognized."
+end
+
+service "vixie-cron"
+service "sysklogd"
+service "nginx"
+
+link '/etc/localtime' do
+  to "#{File.join(zonepath, zone)}"
+  notifies :restart, resources(:service => ["vixie-cron", "sysklogd"]), :delayed
+  if has_nginx
+    notifies :restart, 'service[nginx]', :delayed
+  end
+  only_if {File.exists?(File.join(zonepath, zone)) and zone != '' and not zone.nil?}
+end


### PR DESCRIPTION
Description of your patch
--------------
Adds support for timezones in the DNA set at the environment level.

Recommended Release Notes
--------------
Adds environment level timezone controls to cookbooks.

Estimated risk
--------------

Low
- Nothing is changed if the timezone is unrecognized or not present.
- Based on the existing custom chef cookbooks that are currently used by customers.

Components involved
--------------

$ git diff next-release --name-only
cookbooks/timezones/README.md
cookbooks/timezones/recipes/default.rb

Description of testing done
--------------
Under the 12.11 stack

- Provisioned a solo using the updated stack
- Verified cookbooks completed successfully
- Verified the current timezone with `ls -la /etc/localtime` showed a symlink to `/usr/share/zoneinfo/UTC`
- Added an attribute `"timezone": "America/Anchorage"` in `/etc/chef/dna.json` under `"engineyard":"environment"`
- Ran chef cached using `PATH=/usr/local/ey_resin/bin/:$PATH /usr/local/ey_resin/bin/chef-solo -j /etc/chef/dna.json -c /etc/chef/solo.rb`
- Verified the timezone with `ls -la /etc/localtime` showed a symlink to `/usr/share/zoneinfo/America/Anchorage`
- Added an attribute `"timezone": "EST"` in `/etc/chef/dna.json` under `"engineyard":"environment"`
- Ran chef cached using `PATH=/usr/local/ey_resin/bin/:$PATH /usr/local/ey_resin/bin/chef-solo -j /etc/chef/dna.json -c /etc/chef/solo.rb`
- Verified the timezone with `ls -la /etc/localtime` showed a symlink to `/usr/share/zoneinfo/EST`
- Added an attribute `"timezone": "Gorgonzola"` in `/etc/chef/dna.json` under `"engineyard":"environment"`
- Ran chef cached using `PATH=/usr/local/ey_resin/bin/:$PATH /usr/local/ey_resin/bin/chef-solo -j /etc/chef/dna.json -c /etc/chef/solo.rb`
- Verified chef raised an exception indicating that `"Timezone 'Gorgonzola' not recognized."` and `ls -la /etc/localtime` showed the symlink unchanged as `/usr/share/zoneinfo/EST`

QA Instructions
--------------

Using the 16.06 stack boot a cluster and repeat verify as above. For running chef with cached data you'll need to use the command `PATH=/usr/local/ey_resin/bin ey-enzyme --cached --verbose --chef-bin /usr/local/ey_resin/bin/chef-solo`.