### PR TITLE
Don't alert for database replication while blocking backups are running.

### DIFF
--- a/cookbooks/mysql/templates/default/check_mysql.sh.erb
+++ b/cookbooks/mysql/templates/default/check_mysql.sh.erb
@@ -120,7 +120,7 @@ function check_replication {
 
     if [ -n "$(ps aux | grep [m]ysqldump | grep -v single-transaction)" ]
     then
-        alert "OKAY" "MySQL Replication: Replication is running. Not checking lag because a locking backup is running."
+        # don't alert for replica lag while locking backups are running as we then expect lag
         return
     fi
 

--- a/cookbooks/postgresql/templates/default/check_postgres_wrapper.sh.erb
+++ b/cookbooks/postgresql/templates/default/check_postgres_wrapper.sh.erb
@@ -52,7 +52,7 @@ function in_recovery() {
 function run_check() {
     if [ "${ACTION}" = "checkpoint" -a "$(in_recovery)" -eq "0" -a -n "$(ps aux | grep [p]g_dump)" ]
     then
-        alert "OKAY" "POSTGRES_CHECKPOINT OK: Replication is running. Not checking checkpointing because a backup is running."
+        # don't alert while backups are running on replicas since they can block checkpoints on replicas
         return
     fi
 


### PR DESCRIPTION
Description of your patch
-------------

Don't alert for database replication while blocking backups are running.

Recommended Release Notes
-------------

Don't alert for database replication while blocking backups are running.

Estimated risk
-------------

Low

Components involved
-------------

$ git diff --name-only next-release
cookbooks/mysql/templates/default/check_mysql.sh.erb
cookbooks/postgresql/templates/default/check_postgres_wrapper.sh.erb

Description of testing done
-------------

Have DBAs test.

QA Instructions
-------------

Have DBAs test.