### PR TITLE
Fix Nginx server_name for node apps

### DIFF
--- a/cookbooks/node/recipes/node_app.rb
+++ b/cookbooks/node/recipes/node_app.rb
@@ -110,7 +110,7 @@ node.engineyard.apps.each_with_index do |app, app_index|
       :application => app,
       :port => app_port,
       :http_bind_port => 8081,
-      :server_names => app[:vhosts].first[:domain_name] ? [app[:vhosts].first[:domain_name]] : [],
+      :server_names => app.vhosts.first.domain_name.empty? ? [] : [app.vhosts.first.domain_name],
       :app_name => app_name
     })
     notifies :restart, resources(:service => "nginx"), :delayed
@@ -237,7 +237,7 @@ node.engineyard.apps.each_with_index do |app, app_index|
         :app_name     => app_name,
         :port         => app_port,
         :https_bind_port => 8082,
-        :server_names =>  app[:vhosts][1][:domain_name] ? [app[:vhosts][1][:domain_name]] : [],
+        :server_names => app[:vhosts][1][:name].empty? ? [] : [app[:vhosts][1][:name]],
       })
       notifies :restart, resources(:service => "nginx"), :delayed
     end


### PR DESCRIPTION
Description of your patch
-------------

The `server_name` directive is not properly set for Node.js applications, and this change fixes that.

Recommended Release Notes
-------------

Sets the `server_name` in Nginx configuration for Node.js applications.

Estimated risk
-------------

Low. It only affects v5 node environments that set the domain_name. There's only 10 at this time:

```
(Environment.all(:release_label.like => 'stable-v5-3.0%') & Environment.all(Environment.app_deployments.domain_name.not => "_") & Environment.all(Environment.apps.app_type_id => "nodejs")).select{|e| e.instances.size > 0 }.size
```

How to Test
-------------

Setup a Node.js environment on v5. Test this change for each of these Application Server Stacks:

* Nginx (Recommended)
* Node.js PM2

Keep the Domain Name in the Edit Environment page blank. The /etc/nginx/servers/<app_name>.conf should have:

```
server_name _
```

Set the Domain Name in the Edit Environment page to the public hostname of the app master/solo instance (looks like ec2-54-235-87-74.compute-1.amazonaws.com). Click Apply. The `server_name` in /etc/nginx/servers/<app_name>.conf should change to:

```
server_name <domain name>
```

### Testing SSL

Create a self-signed certificate in https://cloud.engineyard.com/ssl_certificates. For the SSL Certificate Name, choose the public hostname of the app master/solo instance in your environment. Once provisioned, go to the environment dashboard, and under the SSL section, assign the new SSL certificate to the application. Click Apply.

When the Domain Name in the Edit Environment page is blank, the /etc/nginx/servers/<app_name>.ssl.conf should have:

```
server_name _
```

Change the Domain Name to the public hostname of the app master/solo instance of the environment. The <app_name>.ssl.conf should change accordingly. Prior to this fix, the value of `server_name` is always `_`.
