### PR TITLE
Added Elixir App Name for configuration generation

### DIFF
--- a/cookbooks/elixir/recipes/configure.rb
+++ b/cookbooks/elixir/recipes/configure.rb
@@ -50,6 +50,7 @@ node.engineyard.apps.each_with_index do |app, index|
   stepping = 200
   app_base_port = base_port + ( stepping * index )
 
+  elixir_name = app.metadata('elixir_app_name', nil) || app.name
 
   managed_template "/data/#{app.name}/shared/config/prod.secret.exs" do
     owner node.engineyard.environment.ssh_username
@@ -61,6 +62,7 @@ node.engineyard.apps.each_with_index do |app, index|
       :dbuser => node.engineyard.environment.ssh_username,
       :dbpass => node.engineyard.environment.ssh_password,
       :dbname => app.database_name,
+      :elixir_name => elixir_name,
       :app_name => app.name,
       :db_host => node.dna['db_host'] ,
       :port => app_base_port
@@ -91,6 +93,7 @@ node.engineyard.apps.each_with_index do |app, index|
     source "phoenix.monitrc.erb"
     variables(
       :app => app.name,
+      :elixir_name => elixir_name,
       :user => node["owner_name"]
     )
   end

--- a/cookbooks/elixir/recipes/nginx.rb
+++ b/cookbooks/elixir/recipes/nginx.rb
@@ -16,7 +16,6 @@ node.engineyard.apps.each_with_index do |app, index|
   stepping = 200
   app_base_port = base_port + ( stepping * index )
 
-
   template "/data/nginx/servers/#{app.name}.conf" do
     owner ssh_username
     group ssh_username

--- a/cookbooks/elixir/templates/default/phoenix.monitrc.erb
+++ b/cookbooks/elixir/templates/default/phoenix.monitrc.erb
@@ -1,7 +1,7 @@
 check process phoenix_<%= @app %>
-  matching "/data\/<%= @app %>\/shared\/rel\/<%= @app %>\/bin\/<%= @app %>"
+  matching "/data\/<%= @app %>\/shared\/rel\/<%= @elixir_name %>\/bin\/<%= @elixir_name %>"
   group <%= @app %>
-  start program = "/bin/bash -c '/data/<%= @app %>/shared/rel/<%= @app %>/bin/<%= @app %> start'"
+  start program = "/bin/bash -c '/data/<%= @app %>/shared/rel/<%= @elixir_name %>/bin/<%= @elixir_name %> start'"
     as uid <%= @user %> and gid <%= @user %>
- stop program = "/bin/bash -c '/data/<%= @app %>/shared/rel/<%= @app %>/bin/<%= @app %> stop'"
+ stop program = "/bin/bash -c '/data/<%= @app %>/shared/rel/<%= @elixir_name %>/bin/<%= @elixir_name %> stop'"
     as uid <%= @user %> and gid <%= @user %>

--- a/cookbooks/elixir/templates/default/prod.secret.exs.erb
+++ b/cookbooks/elixir/templates/default/prod.secret.exs.erb
@@ -1,12 +1,12 @@
 use Mix.Config
 
-config :<%= @app_name.downcase %>, <%= @app_name.capitalize %>.Endpoint,
+config :<%= @elixir_name.downcase %>, <%= @elixir_name.capitalize %>.Endpoint,
 http: [port: <%= @port %>],
 cache_static_manifest: "priv/static/manifest.json",
 server: true
 
 # Configure your database
-config :<%= @app_name.downcase %>, <%= @app_name.capitalize %>.Repo,
+config :<%= @elixir_name.downcase %>, <%= @elixir_name.capitalize %>.Repo,
   adapter: Ecto.Adapters.Postgres,
   username: "<%= @dbuser %>",
   password: "<%= @dbpass %>",


### PR DESCRIPTION
Description of your patch
-------------

The `elixir_app_name` directive is not properly set for Elixir applications, and this change fixes that.

Recommended Release Notes
-------------

Sets the `elixir_app_name` in prod.secret.exs and monit configurations for Elixir applications.

Estimated risk
-------------

Low. It only affects v5 elixir environments 

How to Test
-------------

Setup an Elixir environment on v5. 

Keep the Application Name in the Edit Application page blank. 

Verify that the monit configuration is the same.

Add a different Elixir Application Name

Run Chef

Verify that the /data/<appname>/shared/config/prod.secret.exs only has the elixir_app_name present and that the monitrc file has both app.name and elixir_app_name present