### PR TITLE
CC-1143 Add Ruby 2.4.0 to v5

### DIFF
--- a/cookbooks/ey-lib/libraries/ey-environment.rb
+++ b/cookbooks/ey-lib/libraries/ey-environment.rb
@@ -143,6 +143,7 @@ class Chef
           :ruby_215   => "2.1.10",
           :ruby_220   => "2.2.6",
           :ruby_230   => "2.3.3",
+          :ruby_240   => "2.4.0",
         }
         if versions.has_key?(ruby_archtype.to_sym)
           version = versions[ruby_archtype.to_sym]

--- a/cookbooks/ruby/recipes/ruby.rb
+++ b/cookbooks/ruby/recipes/ruby.rb
@@ -43,6 +43,25 @@ if component[:version] =~ /^2\.3[\d\.]*\b/
   }
 end
 
+if component[:version] =~ /^2\.4[\d\.]*\b/
+  ruby_mask = '-ruby_targets_ruby24'
+  ruby_dependencies = {
+    "dev-ruby/json"          => "2.0.3",
+    "dev-ruby/racc"          => "1.4.14-r1",
+    "dev-ruby/rake"          => "12.0.0",
+    "dev-ruby/rdoc"          => "5.1.0",
+    "dev-ruby/rubygems"      => "2.6.11",
+    "dev-ruby/did_you_mean"  => "1.1.0",
+    "dev-ruby/kpeg"          => "1.1.0",
+    "dev-ruby/minitest"      => "5.10.1",
+    "dev-ruby/net-telnet"    => "0.1.1-r2",
+    "dev-ruby/power_assert"  => "0.4.1",
+    "dev-ruby/test-unit"     => "3.2.3",
+    "dev-ruby/xmlrpc"        => "0.2.1",
+    "virtual/rubygems"       => "12",
+  }
+end
+
 unmask_package component[:package] do
   version component[:version]
   unmaskfile "ruby"


### PR DESCRIPTION
## Description of your patch

Add Ruby 2.4.0
## Recommended Release Notes

Addition of Ruby 2.4.0
## Estimated risk

Low
## Components involved

dnapi.rb and ruby cookbook

## Description of testing done

Followed QA instructions

## QA Instructions

- Boot environment on stable stack
- Add "ruby_version":"2.4.0" to dna metadata of environment
- Verify chef fails
- Update to target stack
- Verify chef finishes without error
- Verify Ruby version is `2.4.0` with ruby -v on the instance
