### PR TITLE
CC-1147: Fix PM2 worker count on initial boot chef run.

### DIFF
--- a/cookbooks/pm2/recipes/default.rb
+++ b/cookbooks/pm2/recipes/default.rb
@@ -1,3 +1,5 @@
+recipe = self
+
 include_recipe "node::common"
 
 execute "install pm2" do
@@ -29,7 +31,6 @@ template "/etc/monit.d/pm2.monitrc" do
   })
 end
 
-worker_count = get_pool_size
 default_worker_memory = 250
 
 node.engineyard.apps.each_with_index do |app, app_index|
@@ -45,10 +46,10 @@ node.engineyard.apps.each_with_index do |app, app_index|
     group node["owner_name"]
     backup 0
     mode 0755
-    variables(
+    variables(lazy {{
       :app_name => app_name,
-      :worker_count => worker_count,
+      :worker_count => recipe.get_pool_size,
       :worker_memory => memory_option
-    )
+    }})
   end
 end


### PR DESCRIPTION
Description of your patch
-------------

PM2 gets the wrong worker count on initial boot chef run, and fails to take into account the swap. This change uses Chef's lazy evaluation feature to only calculate the pool size after swap is configured.

Recommended Release Notes
-------------

Fix PM2 worker count on initial boot chef run.

Estimated risk
-------------

Low. PM2 is not yet GA.

How to Test
-------------

Refer to our Worker Allocation calculator to figure out the expected number of workers:

https://support.cloud.engineyard.com/hc/en-us/articles/205407758-Worker-Allocation-on-Engine-Yard-Cloud

Make sure that node_pm2 feature is enabled for your account. Boot up a Node.js environment with your selected instance type. Select "Node.js PM2" for the Application Server Stack. Using the QA stack, the number of workers should match the calculated value in the Worker Allocation page. Before the change, the number of workers would match the calculated value if swap_usage_percent is set to 0.
