### PR TITLE
Remove PM2's openrc script as monit already handles PM2 resurrect

### DIFF
--- a/cookbooks/pm2/recipes/default.rb
+++ b/cookbooks/pm2/recipes/default.rb
@@ -11,13 +11,6 @@ link "/usr/bin/pm2" do
   to "/opt/nodejs/current/bin/pm2"
   # only_if { File.exist?("/opt/nodejs/current/bin/pm2") }
   # not_if { File.exists?("/usr/bin/pm2") }
-  notifies :run, "execute[start pm2 at boot]"
-  action :nothing
-end
-
-execute "start pm2 at boot" do
-  command "pm2 startup openrc"
-  # only_if { ::File.exists?("/usr/bin/pm2") }
   action :nothing
 end
 


### PR DESCRIPTION
Description of your patch
-------------

CC-1144 originally reports that pm2 is not started by the right user. But instead of fixing the openrc script, we have to remove the entire script because it duplicates the functionality of the pm2 monit script that already ensures that pm2 is resurrected.

Recommended Release Notes
-------------

Remove PM2 openrc script to avoid duplicate functionality with pm2 monitrc script that resurrects PM2.

Estimated risk
-------------

Low. PM2 is not yet GA and only being tested by a couple of customers.

How to Test
-------------

First, make sure that node_pm2 feature is enabled for your account. Setup an environment and select "Node.js PM2" for the Application Server Stack. If you use stable-v5-3.0.24, you can still see the pm2 service added to runlevel default with the following command:

```
rc-update show -v
```

You will also see the openrc script in /etc/init.d/pm2*.

If you use the QA stack on a **freshly built** environment, running `rc-update show -v` will not show pm2. The script /etc/init.d/pm2* will also not be present. Verify that /etc/monit.d/pm2* is present, and make sure it's running via `monit summary`. Click the Restart button on one of the app instances of your environment. After the restart, pm2 should still be showing as running in `monit summary`. Also, switch to deploy user, and check that there are pm2 workers running.

```
su - deploy
pm2 list
```

Note that the number of workers before the restart may not be the same as the number of workers after the restart. There's an issue when the PM2 is killed where the dump file (contains the information used by `pm2 resurrect`) is regenerated and the worker count changes. This particular issue isn't covered in this change.
