### PR TITLE
fail2ban: let monit start the service

### DIFF
--- a/cookbooks/fail2ban/recipes/service.rb
+++ b/cookbooks/fail2ban/recipes/service.rb
@@ -11,7 +11,7 @@ end
 # enabling the service
 service 'fail2ban' do
   supports [:status => true, :restart => true]
-  action [:enable, :start]
+  action [:enable]
   status_command "/etc/init.d/fail2ban status | grep -q 'status: started'"
 end
 


### PR DESCRIPTION
Do not start the service, otherwise there might arise a race condition wherein chef tries to start the service and monit already started it so chef fails.