### PR TITLE
CC-1148 Updated 2.4.0 to 2.4.1

### DIFF
--- a/cookbooks/ey-lib/libraries/ey-environment.rb
+++ b/cookbooks/ey-lib/libraries/ey-environment.rb
@@ -143,7 +143,7 @@ class Chef
           :ruby_215   => "2.1.10",
           :ruby_220   => "2.2.6",
           :ruby_230   => "2.3.3",
-          :ruby_240   => "2.4.0",
+          :ruby_240   => "2.4.1",
         }
         if versions.has_key?(ruby_archtype.to_sym)
           version = versions[ruby_archtype.to_sym]


### PR DESCRIPTION
## Description of your patch

Add Ruby 2.4.1
## Recommended Release Notes

Addition of Ruby 2.4.1
## Estimated risk

Low
## Components involved

dnapi.rb

## Description of testing done

Followed QA instructions

## QA Instructions

- Boot environment on stable stack
- Add "ruby_version":"2.4.1" to dna metadata of environment
- Verify chef fails
- Update to target stack
- Verify chef finishes without error
- Verify Ruby version is `2.4.1` with ruby -v on the instance