### PR TITLE
add support for Postgres 9.4.11

### DIFF
--- a/cookbooks/postgresql/attributes/version.rb
+++ b/cookbooks/postgresql/attributes/version.rb
@@ -1,6 +1,6 @@
 case attribute.dna.engineyard.environment.db_stack_name
 when "postgres9_4"
-  default['postgresql']['latest_version'] = "9.4.8"
+  default['postgresql']['latest_version'] = "9.4.11"
   default['postgresql']['short_version'] = "9.4"
 when "postgres9_5"
   default['postgresql']['latest_version'] = "9.5.3"

--- a/cookbooks/postgresql/recipes/server_install.rb
+++ b/cookbooks/postgresql/recipes/server_install.rb
@@ -1,7 +1,7 @@
 postgres_version = node['postgresql']['short_version']
 
 known_ebuild_versions = %w[
-  9.4.8
+  9.4.8   9.4.11
   9.5.3
 ]
 


### PR DESCRIPTION
Description of your patch
--------------

Updates Postgresql-server to 9.4.11.


Recommended Release Notes
--------------
Adds support PostgreSQL 9.4.11. See our [Upgrade Procedures](https://support.cloud.engineyard.com/hc/en-us/articles/205408178-Database-Version-Upgrade-Policies) for additional details about applying this update.

Estimated risk
--------------

Low
- Customers need to take additional steps to apply this update or must have opted in to automatic updates.
- Recommended procedure for databases is to always test new releases in a non-Production environment before upgrading Production.

Components involved
--------------

$ git diff master --name-only
cookbooks/postgresql/attributes/version.rb
cookbooks/postgresql/recipes/server_install.rb

Description of testing done
--------------
Under the 16.06 stack

- Provisioned a cluster using the existing Stack with automatic version upgrades disabled (default)
- Ran:
  - `postgres --version`
- Validated:
  - 9.4.8  (any version <= 9.4.8 is expected)
- Deployed to tpol-2016 dev stack.
- Upgraded the environment,
- Ran: 
  - `postgres --version`
- Validated
  - 9.4.8 (version should be the same as the prior check)
- Edit environment, remove the check next to "Prevent database version changes", saved change
- Clicked "Apply" for the environment on the dashboard
- Ran:
  - `postgres --version`
- Validated:
  - 9.4.11
- Ran:
  - `/etc/init.d/postgresql-9.4 restart`
- Validated:
  - Postgresql restarts successfully

QA Instructions
--------------
Repeat test above

