### PR TITLE
Add support for additional internal netmasks for VPC support.

### DIFF
--- a/cookbooks/postgresql/recipes/server_configure.rb
+++ b/cookbooks/postgresql/recipes/server_configure.rb
@@ -215,10 +215,13 @@ file "#{postgres_root}/#{postgres_version}/custom_pg_hba.conf" do
   not_if { FileTest.exists?("#{postgres_root}/#{postgres_version}/custom_pg_hba.conf") }
 end
 
-cidr = '10.0.0.0/8'
 ip = %x{ifconfig eth0 | grep inet | awk '{print $2}' | awk -F: '{print $NF}'}
-if ip =~ /^172\.31\./
-  cidr = '172.31.0.0/16'
+if ip =~ /^10\./
+  cidr = '10.0.0.0/8'
+elsif ip =~ /^172\./
+  cidr = '172.16.0.0/12'
+elsif ip =~ /^192\./
+  cidr = '192.168.0.0/16'
 end
 
 # Chef versions that don't support the lazy evaluation keyword


### PR DESCRIPTION
Description of your patch
--------------

Adds custom VPC CIDR support to Postgres Host Based Authentication.


Recommended Release Notes
--------------
Adds support for custom VPCs to pg_hba.conf

Estimated risk
--------------

Low
- Adds better intelligency about how CIDR is set to the Postgres recipes.
- Recommended procedure for databases is to always test new releases in a non-Production environment before upgrading Production.

Components involved
--------------

$ git diff master --name-only
cookbooks/postgresql/recipes/server_configure.rb

Description of testing done
--------------
Under the 16.06 stack

- Enable the `VPCs` feature for the account
- In Tools->Networks add a VPC if one doesn't already exist using a 192.168.0.0/16 or 172.16.0.0/12 CIDR
- Boot the environment as a cluster
- Interrogate the `cat /db/postgresql/*/data/pg_hba.conf| grep deploy`, the CIDR will be 10.0.0.0/8 which would block access fromt he application
  - if you connect from the app master with `psql -h ey-db-master` you will encounter the error
    
    psql: FATAL:  no pg_hba.conf entry for host "172.20.4.205", user "postgres", database "postgres", SSL off

- Update the stack
- After updates are applied `cat /db/postgresql/*/data/pg_hba.conf| grep deploy` the CIDR should now match the global CIDR used for your VPC
  - if you connect from the app master with `psql -h ey-db-master` you should be able to connect without error

QA Instructions
--------------
May need to be tested by Rad/Eugene

On the existing 12.11 stack

- Enable the `VPCs` feature for the account
- In Tools->Networks add a VPC if one doesn't already exist using a 192.168.0.0/16 or 172.16.0.0/12 CIDR
- Boot the environment as a cluster
- Interrogate the `cat /db/postgresql/*/data/pg_hba.conf| grep deploy`, the CIDR will be 10.0.0.0/8 which would block access fromt he application
  - if you connect from the app master with `psql -h ey-db-master` you will encounter the error
    
    psql: FATAL:  no pg_hba.conf entry for host "172.20.4.205", user "postgres", database "postgres", SSL off

- Update the stack
- After updates are applied `cat /db/postgresql/*/data/pg_hba.conf| grep deploy` the CIDR should now match the global CIDR used for your VPC
  - if you connect from the app master with `psql -h ey-db-master` you should be able to connect without error
