### PR TITLE
CC-1058 Add environment variable support for passenger 5 to be read

### DIFF
--- a/cookbooks/passenger5/files/default/env.custom
+++ b/cookbooks/passenger5/files/default/env.custom
@@ -1,0 +1,1 @@
+#Custom Environment Variables should be added here

--- a/cookbooks/passenger5/recipes/install.rb
+++ b/cookbooks/passenger5/recipes/install.rb
@@ -163,6 +163,15 @@
     backup 0
   end
 
+  cookbook_file "/data/#{app_name}/shared/config/env.custom" do
+    source "env.custom"
+    owner node["owner_name"]
+    group node["owner_name"]
+    mode 0644
+    backup 0
+    not_if { FileTest.exists?("/data/#{app_name}/shared/config/env.custom") }
+  end
+
   # Reload monit after making changes
   execute "monit-reload" do
     command "monit quit && telinit q"

--- a/cookbooks/passenger5/templates/default/app_control.erb
+++ b/cookbooks/passenger5/templates/default/app_control.erb
@@ -7,6 +7,7 @@ then
 fi
 
 export HOME="/home/<%= @user %>"
+source "/data/<%= @app_name %>/shared/config/env.custom"
 
 cd /data/<%= @app_name %>/
 


### PR DESCRIPTION
## Description of your patch

Adds passenger 5 to have env.custom support

## Recommended Release Notes

Creates and includes env.custom support for passenger 5

## Estimated risk

Low

## Components involved

Passenger 5 recipe

## Description of testing done

See QA instructions

## QA Instructions

Solo, new environment

1. Boot instance on old stack with passenger 5
2. Verify boot of instance
3. Verify chef runs 
4. Verify deploy and application start
5. Verify no env.custom exists in /data/appname/shared/config/env.custom 
6. Upgrade to new stack
7. Verify env.custom  now exists 
8. Run a deploy and verify application deploys and functions
