### PR TITLE
CC-1161: Fix test for detecting orphan passenger processes

### DIFF
--- a/cookbooks/passenger5/files/default/passenger_monitor
+++ b/cookbooks/passenger5/files/default/passenger_monitor
@@ -83,7 +83,7 @@ exit_code=$?
 ## Kill any passenger workers that are not in $pstats
 if [ "$exit_code" -eq "0" ] ; then
   pstats=$(echo "$raw_stats" | sed -r -e '/PID:/!d' -e 's/.*PID:\s([0-9]+).*/\1/' | sort -n| uniq)
-  for pid in `diff <(ps aux | egrep -i 'Passenger RubyApp:' | awk '{print $2}' | sort -n) <(echo "$pstats") | grep '<' | awk '{print $2}'`; do
+  for pid in `diff <(ps aux | egrep -i '[P]assenger RubyApp:' | awk '{print $2}' | sort -n) <(echo "$pstats") | grep '<' | awk '{print $2}'`; do
     kill -9 $pid
     logger -t passenger_monitor -s "Killing PID $pid - orphaned process"
   done


### PR DESCRIPTION
## Description of your patch

Fixes the test for detecting orphan passenger processes

## Recommended Release Notes

Fixes the test for detecting orphan passenger processes

## Estimated risk

Low

## Components involved

Passenger chef recipe

## Description of testing done

See QA instructions

## QA Instructions

Boot an Nginx/Passenger5 environment under the latest stable-v5 stack
Run `tail -f /var/log/syslog | grep illing` on the solo/app instances. You should see a new entry every minute
Upgrade the environment to the QA stack
Verify that the chef run was successful
Run `tail -f /var/log/syslog | grep illing` on the solo/app instances. You should no longer see a new entry every minute