### PR TITLE
Updates Percona-Server to 5.6.35 and 5.7.17 and updates PostgreSQL to 9.5.6.

### DIFF
--- a/cookbooks/mysql/attributes/version.rb
+++ b/cookbooks/mysql/attributes/version.rb
@@ -2,8 +2,8 @@ lock_major_version = %x{[[ -f "/db/.lock_db_version" ]] && grep -E -o '^[0-9]+\.
 db_stack = lock_major_version == '' ? attribute.dna['engineyard']['environment']['db_stack_name'] :  "mysql#{lock_major_version.gsub(/\./, '_').strip}"
 
 default['latest_version_55'] = '5.5.49'
-default['latest_version_56'] = '5.6.32'
-default['latest_version_57'] = '5.7.14'
+default['latest_version_56'] = '5.6.35'
+default['latest_version_57'] = '5.7.17'
 major_version=''
 
 case db_stack

--- a/cookbooks/mysql/recipes/install.rb
+++ b/cookbooks/mysql/recipes/install.rb
@@ -6,7 +6,7 @@ db_running = %x{mysql -N -e "select 1;" 2> /dev/null}.strip == '1'
 known_versions = {
   # Note: mysql 5.5 is a limited access feature on this stack; use 5.6 or higher if possible.
   'dev-db/mysql' => ['5.5.49'],
-  'dev-db/percona-server' => ['5.6.28.76.1', '5.6.29.76.2-r1', '5.6.32.78.1', '5.7.13.6', '5.7.14.8']
+  'dev-db/percona-server' => ['5.6.28.76.1', '5.6.29.76.2-r1', '5.6.32.78.1', '5.6.35.81.0', '5.7.13.6', '5.7.14.8', '5.7.17.13']
 }
 
 execute "dropping lock version file" do

--- a/cookbooks/mysql/templates/default/my.conf.erb
+++ b/cookbooks/mysql/templates/default/my.conf.erb
@@ -46,6 +46,7 @@ show_old_temporals = 1
 <% end %>
 max_connections			= 300
 innodb_file_per_table		= 1
+secure_file_priv = ''
 
 <% if @mysql_version < @mysql_5_6 %>
 log-slow-queries		= <%= @logbase %>slow_query.log

--- a/cookbooks/postgresql/attributes/version.rb
+++ b/cookbooks/postgresql/attributes/version.rb
@@ -3,6 +3,6 @@ when "postgres9_4"
   default['postgresql']['latest_version'] = "9.4.8"
   default['postgresql']['short_version'] = "9.4"
 when "postgres9_5"
-  default['postgresql']['latest_version'] = "9.5.3"
+  default['postgresql']['latest_version'] = "9.5.6"
   default['postgresql']['short_version'] = "9.5"
 end

--- a/cookbooks/postgresql/recipes/server_install.rb
+++ b/cookbooks/postgresql/recipes/server_install.rb
@@ -3,6 +3,7 @@ postgres_version = node['postgresql']['short_version']
 known_ebuild_versions = %w[
   9.4.8
   9.5.3
+  9.5.6
 ]
 
 execute "dropping lock version file" do


### PR DESCRIPTION
Description of your patch
--------------

Updates Percona-Server to 5.6.35 and 5.7.17 and updates PostgreSQL to 9.5.6.


Recommended Release Notes
--------------
Adds Percona-Server 5.6.35 and 5.5.54; adds PostgreSQL 9.5.6. See our [Upgrade Procedures](https://support.cloud.engineyard.com/hc/en-us/articles/205408178-Database-Version-Upgrade-Policies) for additional details about applying these updates.

Estimated risk
--------------

Low
- Customers need to take additional steps to apply this update or must have opted in to automatic updates.
- Recommended procedure for databases is to always test new releases in a non-Production environment before upgrading Production.

Components involved
--------------

$ git diff master --name-only
cookbooks/mysql/attributes/version.rb
cookbooks/mysql/recipes/install.rb
cookbooks/mysql/templates/default/my.conf.erb
cookbooks/postgresql/attributes/version.rb
cookbooks/postgresql/recipes/server_install.rb

Description of testing done
--------------
Under the 12.11 stack

- Provisioned a cluster using the existing Stack with automatic version upgrades disabled (default)
- Ran:
  - `mysqld --version`
- Validated:
  - 5.6.32  (any version prior to 5.6.35 or 5.5.54 is expected)
- Deployed to tpol-12.11 dev stack.
- Upgraded the environment,
- Ran: 
  - `mysqld --version`
- Validated
  - 5.6.32 (version should be the same as the prior check)
- Edit environment, remove the check next to "Prevent database version changes", saved change
- Clicked "Apply" for the environment on the dashboard
- Ran:
  - `mysqld --version`
- Validated:
  - 5.6.35
- Ran:
  - `/etc/init.d/mysql restart`
- Validated:
  - MySQL restarts successfully

QA Instructions
--------------

Using the 16.06 stack enable the `mysql5_7` feature and boot a cluster running MySQL 5.7.
Repeat the testing above expecting 5.7.17 after the upgrade.

Using the 16.06 stack with Postgres 9.5

- Provision a cluster using the existing Stack with automatic version upgrades disabled (default)
- Run:
  - `postgres --version`
- Validate:
  - 9.5.3  (any version <= 9.5.6 is expected)
- Upgrade the stack.
- Upgraded the environment,
- Run: 
  - `postgres --version`
- Validate
  - 9.5.3 (version should be the same as the prior check)
- Edit environment, remove the check next to "Prevent database version changes", saved change
- Click "Apply" for the environment on the dashboard
- Run:
  - `postgres --version`
- Validate:
  - 9.5.6
- Run:
  - `/etc/init.d/postgresql-9.5 restart`
- Validate:
  - Postgresql restarts successfully



