### PR TITLE
CC-1162: In memcached.yml, add servers list under defaults section

### DIFF
--- a/cookbooks/memcached/templates/default/memcached.yml.erb
+++ b/cookbooks/memcached/templates/default/memcached.yml.erb
@@ -1,7 +1,15 @@
+defaults:
+  <% if !@server_names.nil? && !@server_names.empty? %>
+  servers:
+  <% @server_names.each do |server_name| %>
+    - <%= server_name %>:11211
+  <% end %>
+  <% end %>
+
 <%= @framework_env %>:
   <% if !@server_names.nil? && !@server_names.empty? %>
   servers:
   <% @server_names.each do |server_name| %>
-  - <%= server_name %>:11211
+    - <%= server_name %>:11211
   <% end %>
   <% end %>


### PR DESCRIPTION
Description of your patch
-------------

This change adds a servers list under the defaults section of memcached.yml.

In v4 main chef, we provide the list of memcached servers under the defaults section of the memcached.yml. In v4 custom chef, servers are listed under the framework env section. In v5, we followed the v4 custom chef and listed it under the framework env section too. But for customers expecting the old structure from v4 main chef, it broke their memcached setup. To make migrating from v4 to v5 easier, we should provide the list of servers on both defaults and framework env sections.

Recommended Release Notes
-------------

Add list of memcached servers under the defaults section of memcached.yml.

Estimated risk
-------------

Low. Memcached is not enabled by default. And for those expecting the servers list under the framework env section, it's still there. This just adds more info under a new defaults section.

How to Test
-------------

Prepare a v5 environment with at least 2 app instances.

Enable the memcached recipe. See:

https://github.com/engineyard/ey-cookbooks-stable-v5/tree/next-release/custom-cookbooks/memcached

Customize the custom-memcached/attributes/default.rb to set memcached version to 1.4.25. Comment out the line with `NAMED_UTILS` and uncomment the line with `ALL_APP_INSTANCES`:

```
# memcached['install_type'] = 'NAMED_UTILS'

memcached['install_type'] = 'ALL_APP_INSTANCES'
```

Upload recipes to your environment and click Apply. Once enabled, check /data/\<app name\>/shared/config/memcached.yml. If you use the latest stack  stable-v5-3.0.26, you can only see the list of memcached servers under the framework environment section, and there's no defaults section yet. For example:

```
production:
  servers:
  - ip-10-171-175-126.ec2.internal:11211
  - ip-10-228-122-239.ec2.internal:11211
```

If you use the QA stack with the new change, there's a new section `defaults` that also contains the list of servers. Also, the servers list item are indented from `servers:` unlike before. For example:

```
defaults:
  servers:
    - ip-10-171-175-126.ec2.internal:11211
    - ip-10-228-122-239.ec2.internal:11211

production:
  servers:
    - ip-10-171-175-126.ec2.internal:11211
    - ip-10-228-122-239.ec2.internal:11211
```

Expect the server names in the list to match the private hostnames of the app instances in your environment.
