### PR TITLE
Add env_vars custom chef recipe

### DIFF
--- a/cookbooks/env_vars/README.md
+++ b/cookbooks/env_vars/README.md
@@ -1,0 +1,7 @@
+# env_vars
+
+This recipe is used to upload a /data/app_name/shared/config/env.custom file on the stable-v5 stack. This file is used to load environment variables for the web application; the v5 scripts for Passenger and Unicorn were written to source this file on startup.
+
+The env_vars recipe is managed by Engine Yard. You should not copy this recipe to your repository but instead copy custom-env_vars. Please check the [custom-env_vars readme](../../custom-cookbooks/env_vars/cookbooks/custom-env_vars) for the complete instructions.
+
+We accept contributions for changes that can be used by all customers.

--- a/cookbooks/env_vars/attributes/default.rb
+++ b/cookbooks/env_vars/attributes/default.rb
@@ -1,0 +1,12 @@
+default['env_vars'].tap do |e|
+
+  # If you want to restart the application during the chef run, set this to true
+  #
+  # NOTE: This will restart your application on ALL app instances at the same time
+  #
+  # A better way is schedule a maintenance window,
+  # during which you will iterate through all the application instances and run:
+  # /engineyard/bin/app_<application_name> restart
+  #
+  e['perform_restart'] = false
+end

--- a/cookbooks/env_vars/metadata.rb
+++ b/cookbooks/env_vars/metadata.rb
@@ -1,0 +1,8 @@
+name 'env_vars'
+description 'Recipe to populate env.custom for use with environment variables in Engine Yard'
+long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
+maintainer 'Engine Yard'
+maintainer_email 'support@engineyard.com'
+version '5.0.0'
+issues_url 'https://github.com/engineyard/ey-cookbooks-stable-v5/issues'
+source_url 'https://github.com/engineyard/ey-cookbooks-stable-v5'

--- a/cookbooks/env_vars/recipes/default.rb
+++ b/cookbooks/env_vars/recipes/default.rb
@@ -1,0 +1,28 @@
+#
+# Cookbook Name:: env_vars
+# Recipe:: default
+#
+
+if ['solo', 'app', 'app_master', 'util'].include?(node['dna']['instance_role'])
+
+  ssh_username = node['dna']['engineyard']['environment']['ssh_username']
+  perform_restart = node['env_vars']['perform_restart']
+
+  node['dna']['applications'].each do |app_name, data|
+    cookbook_file "/data/#{app_name}/shared/config/env.custom" do
+      cookbook 'custom-env_vars'
+      source "env.custom"
+      owner ssh_username
+      group ssh_username
+      mode 0744
+    end
+
+    if perform_restart
+      execute "/engineyard/bin/app_todo restart" do
+        action :run
+        user ssh_username
+      end
+    end
+  end
+
+end

--- a/custom-cookbooks/env_vars/cookbooks/custom-env_vars/README.md
+++ b/custom-cookbooks/env_vars/cookbooks/custom-env_vars/README.md
@@ -1,0 +1,55 @@
+# env_vars
+
+This recipe uploads an env.custom file that can be used to configure environment variables for applications running on Engine Yard Cloud. Engine Yard Cloud scripts for Passenger, Puma and Unicorn source this env.custom file to set the environment variables.
+
+
+## Installation
+
+For simplicity, we recommend that you create the cookbooks directory at the root of your application. If you prefer to keep the infrastructure code separate from application code, you can create a new repository.
+
+Our main recipes have the `env_vars` recipe but it is not included by default. To use the `env_vars` recipe, you should copy this recipe `custom-env_vars`. You should not copy the actual `env_vars ` recipe. That is managed by Engine Yard.
+
+1. Edit `cookbooks/ey-custom/env_vars/after-main.rb` and add
+
+      ```
+      include_recipe 'custom-env_vars'
+      ```
+
+2. Edit `cookbooks/ey-custom/metadata.rb` and add
+
+      ```
+      depends 'custom-env_vars'
+      ```
+
+3. Copy `custom-cookbooks/env_vars/cookbooks/custom-env_vars ` to `cookbooks/`
+
+      ```
+      cd ~ # Change this to your preferred directory. Anywhere but inside the application
+
+      git clone https://github.com/engineyard/ey-cookbooks-stable-v5
+      cd ey-cookbooks-stable-v5
+      cp custom-cookbooks/fail2ban/cookbooks/custom-env_vars /path/to/app/cookbooks/
+      ```
+
+4. Download the ey-core gem on your local machine and upload the recipes
+
+  ```
+  gem install ey-core
+  ey-core recipes upload --environment <nameofenvironment> --path <pathtocookbooksfolder>
+  ```
+
+## Customizations
+
+All customizations go to `cookbooks/custom-env_vars/attributes/default.rb`.
+
+### Restart the application during the chef run
+
+Every time you update `env.custom`, you need to restart the application. A Unicorn or Puma hot restart will not do; you need to start a new master process that has sourced the updated `env.custom` file.
+
+If you want to restart the application during the chef run, set `perform_restart` to true:
+
+```
+e['perform_restart'] = true
+```
+
+NOTE: We do not recommend using this for production environments. For production, you can cycle through the instances and run `/engineyard/bin/app_<application_name> restart` on each one.

--- a/custom-cookbooks/env_vars/cookbooks/custom-env_vars/attributes/default.rb
+++ b/custom-cookbooks/env_vars/cookbooks/custom-env_vars/attributes/default.rb
@@ -1,0 +1,12 @@
+default['env_vars'].tap do |e|
+
+  # If you want to restart the application during the chef run, set this to true
+  #
+  # NOTE: This will restart your application on ALL app instances at the same time
+  #
+  # A better way is schedule a maintenance window,
+  # during which you will iterate through all the application instances and run:
+  # /engineyard/bin/app_<application_name> restart
+  #
+  e['perform_restart'] = false
+end

--- a/custom-cookbooks/env_vars/cookbooks/custom-env_vars/files/default/env.custom
+++ b/custom-cookbooks/env_vars/cookbooks/custom-env_vars/files/default/env.custom
@@ -1,0 +1,12 @@
+# This file is source by the Passenger, Puma and Unicorn app control scripts
+# If you want to set environment variables for your web application, set them here
+#
+# Note that if you want to set the environment variables for your cron jobs and background jobs
+# then you will also have to source this file
+
+# You can tweak these variables to do GC tuning on a Unicorn environment
+export RUBY_HEAP_MIN_SLOT=10000
+export RUBY_HEAP_SLOTS_INCREMENT=10000
+export RUBY_HEAP_SLOTS_GROWTH_FACTOR=1.8
+export RUBY_GC_MALLOC_LIMIT=8000000
+export RUBY_HEAP_FREE_MIN=4096

--- a/custom-cookbooks/env_vars/cookbooks/custom-env_vars/metadata.rb
+++ b/custom-cookbooks/env_vars/cookbooks/custom-env_vars/metadata.rb
@@ -1,0 +1,3 @@
+name 'custom-env_vars'
+
+depends 'env_vars'

--- a/custom-cookbooks/env_vars/cookbooks/custom-env_vars/recipes/default.rb
+++ b/custom-cookbooks/env_vars/cookbooks/custom-env_vars/recipes/default.rb
@@ -1,0 +1,1 @@
+include_recipe 'env_vars'

--- a/custom-cookbooks/env_vars/cookbooks/ey-custom/metadata.rb
+++ b/custom-cookbooks/env_vars/cookbooks/ey-custom/metadata.rb
@@ -1,0 +1,3 @@
+name "ey-custom"
+
+depends "custom-env_vars"

--- a/custom-cookbooks/env_vars/cookbooks/ey-custom/recipes/after-main.rb
+++ b/custom-cookbooks/env_vars/cookbooks/ey-custom/recipes/after-main.rb
@@ -1,0 +1,1 @@
+include_recipe "custom-env_vars"


### PR DESCRIPTION
## Description of your patch

Adds the env_vars custom chef recipe

## Recommended Release Notes

Adds the env_vars custom chef recipe

## Estimated risk

Low. 

## Components involved

Custom chef recipes

## Description of testing done

See QA instructions

## QA Instructions

Test on a Passenger environment for the todo application
Add env_vars to the custom chef recipes
Boot the environment on the QA stack
Upload and run the recipes
Verify that the chef run was successful

Add this line to custom-env_vars/files/default/env.custom then upload and apply:
  
```
export ENV_VAR_TEST=YEHEY
```

Deploy the env_vars branch

Open the todo app home page. You should see this text:
  
ENV_VAR_TEST: YEHEY