### PR TITLE
Updates ey_cloud_server to 1.4.60 (DATA-479)

### DIFF
--- a/manifest/Gemfile
+++ b/manifest/Gemfile
@@ -2,7 +2,7 @@ source 'https://rubygems.org/' do
   gem 'chef', '~> 12.7'
   gem 'right_aws', '~> 3.1.0'
   gem 'engineyard-serverside', '~> 2.6.6'
-  gem 'ey_cloud_server', '1.4.58'
+  gem 'ey_cloud_server', '1.4.60'
   gem 'ey_services_setup', '0.0.7'
 end
 

--- a/manifest/Gemfile.lock
+++ b/manifest/Gemfile.lock
@@ -3,10 +3,6 @@ GEM
   remote: https://nextgem.engineyard.com/
   specs:
     addressable (2.4.0)
-    aws-s3 (0.6.3)
-      builder
-      mime-types
-      xml-simple
     builder (3.2.2)
     chef (12.10.24)
       bundler (>= 1.10)
@@ -49,12 +45,11 @@ GEM
       unf (>= 0.0.5, < 1.0.0)
     engineyard-serverside (2.6.6)
     erubis (2.7.0)
-    excon (0.54.0)
-    ey_cloud_server (1.4.58)
-      aws-s3 (>= 0.6.3)
+    excon (0.55.0)
+    ey_cloud_server (1.4.60)
       ey_enzyme (>= 1.1.10)
       ey_instance_api_client (~> 0.1.11)
-      fog-aws (>= 0.3.0)
+      fog-aws (>= 1.2.1)
       json (>= 1.5.5)
       mime-types (>= 1.16, < 3.0)
       nokogiri (>= 1.6.6.2, <= 1.6.8.1)
@@ -74,21 +69,21 @@ GEM
     ffi (1.9.10)
     ffi-yajl (2.2.3)
       libyajl2 (~> 1.2)
-    fog-aws (1.2.0)
+    fog-aws (1.3.0)
       fog-core (~> 1.38)
       fog-json (~> 1.0)
       fog-xml (~> 0.1)
       ipaddress (~> 0.8)
-    fog-core (1.43.0)
+    fog-core (1.44.2)
       builder
       excon (~> 0.49)
       formatador (~> 0.2)
     fog-json (1.0.2)
       fog-core (~> 1.0)
       multi_json (~> 1.10)
-    fog-xml (0.1.2)
+    fog-xml (0.1.3)
       fog-core
-      nokogiri (~> 1.5, >= 1.5.11)
+      nokogiri (>= 1.5.11, < 2.0.0)
     formatador (0.2.5)
     fuzzyurl (0.8.0)
     hashie (3.4.4)
@@ -184,7 +179,6 @@ GEM
     unf_ext (0.0.7.2)
     uuidtools (2.1.5)
     wmi-lite (1.0.0)
-    xml-simple (1.1.5)
 
 PLATFORMS
   ruby
@@ -192,7 +186,7 @@ PLATFORMS
 DEPENDENCIES
   chef (~> 12.7)!
   engineyard-serverside (~> 2.6.6)!
-  ey_cloud_server (= 1.4.58)!
+  ey_cloud_server (= 1.4.60)!
   ey_enzyme (= 2.0.5)!
   ey_services_setup (= 0.0.7)!
   ey_snaplock (= 2.0.3)!


### PR DESCRIPTION
Description of your patch
--------------
Enhancements and bug fixes for eybackup/ey_cloud_server.

Recommended Release Notes
--------------
- Improves functionality and alerting for logical backups (eybackup).
  - Corrects issue where mysql backups were recording database name in the backup
  - Adds server identity to mysql backups to make them useful for replication-based restores
  - Prevents and warns about overlapping backup runs; provides an override option off by default.
  - cli improves backup errors when params specified incorrectly (leaving off db arg)
  - listing backups with all now properly indexes multiple databases in environment
  - OKAY messages only sent on first success after backup failure
  - Error messages are printed to /var/log/engineyard/eybackup/#{dbname}.alert
  - Backup Size and datestamps are printed to /var/log/engineyard/eybackup/#{dbname}.sizes which is capped at 100 lines
  - new_backup option now backs up a specific db if listed, otherwise will back up all databases
  - postgres restores perform analyze after load; adds a skip_analyze option
  - adds multi-part upload and uploads up to 4.9TB as a single file
  - adds Server Side Encryption (S3 managed keys) for all new S3 uploads
- Improves functionality and wording for eyrestore tool
  - eyrestore displays bucket name hint when unable to access other environment
  - eyrestore no longer requires both the database specified in both the --databases and --index args
  - eyrestore with gpg backups should say download when restoring with gpz extension
- Updates fog-aws module from 0.3.0 to 1.2.1
- Deprecates and removes unused aws-s3 gem


Estimated risk
--------------
Medium
- Logical backups are a critical path component of the Engine Yard stack, these changes have been carefully reviewed prior to preparing this release.

Components involved
--------------

$ git diff next-release --name-only
manifest/Gemfile
manifest/Gemfile.lock

Description of testing done
--------------
#### Under the tpol-12.11 stack for Postgres and MySQL clusters

- Updated to the required stack
- Ran a backup
- Ran a restore
- Ran a GPG encrypted backup
- Ran a restore of an encrypted backup and confirmed the restore operation was blocked
- Ran a download of an encrypted backup and confirmed I was able to decrypt and restore
- Listed available backups

QA Instructions
--------------
Repeat the backup and restore tests above for Postgres and MySQL on Solo and Cluster configurations.