### PR TITLE
bugfix for noisy filesystem check OKAY alerts

### DIFF
--- a/cookbooks/collectd/files/default/check_health_for
+++ b/cookbooks/collectd/files/default/check_health_for
@@ -285,6 +285,9 @@ check_primary-ebs() {
       elif [[ ${prior_status} != 'OKAY' ]]
       then
         always_alert "OKAY" "FileSystem FSCK checks clean." "${check_type}"
+      elif [[ ${prior_status} == 'OKAY' ]]
+      then
+        echo -e "Time: $(date)\nStatus: OKAY\nType: ${check_type}-primary-ebs\nMessage: FileSystem FSCK checks clean." > ${STATUS_FILE}
       fi
     }
   fi


### PR DESCRIPTION
Description of your patch
--------------

Corrects noisy FSCK healthcheck alerts (firing every 7 days with an OKAY status)


Recommended Release Notes
--------------
Eliminates redundant OKAY messages for filesystem healthchecks.

Estimated risk
--------------

Low
- minor changes that improve system visibility and improve performance

Components involved
--------------

$ git diff next-release --name-only
cookbooks/collectd/files/default/check_health_for

Description of testing done
--------------
Manually adjusted the file on a live instance and verified the change corrected the issue seen.

QA Instructions
--------------
### Create a cluster configuration on the existing stack (database is dealers choice)

on the app master instance, verify the first health-check OKAY status is received, wait 65 minutes (AWSM filters out redundant alerts)

     touch -t 201704152240 /tmp/check_primary-ebs_status/primary-ebs_OKAY

This puts a date of April 2017 on the last check which will result in the next run checking ebs status. Verify the dashboard shows another OKAY alert.

Upgrade to the new stack, wait 65 minutes (or longer)

     touch -t 201704152240 /tmp/check_primary-ebs_status/primary-ebs_OKAY

Wait 2 minutes. Confirm the date stamp of the file has been updated to a current date stamp and that a new OKAY alert has not been received on the dashboard.
