### PR TITLE
Adjusts ey-hosts generation to only include hosts if their IP can be resolved at runtime

### DIFF
--- a/cookbooks/ey-hosts/recipes/default.rb
+++ b/cookbooks/ey-hosts/recipes/default.rb
@@ -1,8 +1,8 @@
 # Utility instances by instance name (ey-utility-#{name}[-X]) where X is some number if name is not unique
-utility_nodes = node.engineyard.environment.instances.select{|i| ['util'].include?(i['role'])}.map {|i| {"ey-utility-#{i['name']}".gsub(/-$/, '') => node.private_ip_for(i)}}.each_with_object({}) { |el, h| el.each { |k, v| k='' if k.nil?; h[k].nil? ? h[k] = v : h[k] = (Array.new([h[k]]) << v).flatten } }
+utility_nodes = node.engineyard.environment.instances.select{|i| ['util'].include?(i['role'])}.map {|i| {"ey-utility-#{i['name']}".gsub(/-$/, '') => node.private_ip_for(i)}}.each_with_object({}) { |el, h| el.each { |k, v| k='' if k.nil?; h[k].nil? ? h[k] = v : h[k] = (Array.new([h[k]]) << v).compact.flatten } }
 
 # DB Replicas by instance name (ey-db-slave-#{name}[-X]) where X is some number if name is not unique
-db_replicas = node.engineyard.environment.instances.select{|i| ['db_slave'].include?(i['role']) and !(i['name'].nil? or i['name'] == '')}.map {|i| {"ey-db-slave-#{i['name']}".gsub(/-$/, '') => node.private_ip_for(i)}}.each_with_object({}) { |el, h| el.each { |k, v| k='' if k.nil?; h[k].nil? ? h[k] = v : h[k] = (Array.new([h[k]]) << v).flatten } }
+db_replicas = node.engineyard.environment.instances.select{|i| ['db_slave'].include?(i['role']) and !(i['name'].nil? or i['name'] == '')}.map {|i| {"ey-db-slave-#{i['name']}".gsub(/-$/, '') => node.private_ip_for(i)}}.each_with_object({}) { |el, h| el.each { |k, v| k='' if k.nil?; h[k].nil? ? h[k] = v : h[k] = (Array.new([h[k]]) << v).compact.flatten } }
 
 template "/etc/ey_hosts" do
   owner 'root'

--- a/cookbooks/ey-hosts/templates/default/ey_hosts.erb
+++ b/cookbooks/ey-hosts/templates/default/ey_hosts.erb
@@ -18,29 +18,29 @@
 <% if @db_replicas.length > 0 or @db_replicas_ordered.length > 0 %>
 
 # Database Replicas
-<% end %>
-<% @db_replicas.each do |key, value| %>
-  <% if value.is_a? String %>
+  <% @db_replicas.each do |key, value| %>
+    <% if value.is_a? String %>
 <%= value %>        <%= key %>
-  <% else %>
-    <% value.each_with_index do |host, index| %>
+    <% elsif value.is_a? Array %>
+      <% value.each_with_index do |host, index| %>
 <%= host %>        <%= key %>-<%= index %>
+      <% end %>
     <% end %>
   <% end %>
-<% end %>
-<% @db_replicas_ordered.each_with_index do |host, index| %>
+  <% @db_replicas_ordered.each_with_index do |host, index| %>
 <%= host %>        ey-db-slave<%= @db_replicas_ordered.count > 1 ? "-#{index}" : '' %>    
+  <% end %>
 <% end %>
 <% if @utility_nodes.length > 0 %>
 
 # Utility Instances
-<% end %>
-<% @utility_nodes.each do |key, value| %>
-  <% if value.is_a? String %>
+  <% @utility_nodes.each do |key, value| %>
+    <% if value.is_a? String %>
 <%= value %>        <%= key %>
-  <% else %>
-    <% value.each_with_index do |host, index| %>
+    <% elsif value.is_a? Array %>
+      <% value.each_with_index do |host, index| %>
 <%= host %>        <%= key %>-<%= index %>
+      <% end %>
     <% end %>
   <% end %>
 <% end %>


### PR DESCRIPTION
Description of your patch
--------------
Corrects EY-HOSTS section skip reporting against hosts for which an IP address cannot be resolved. Currently can happen when RDS replica hosts are removed from a database service (they aren't currently removed from DNA Triage-9440)

Recommended Release Notes
--------------
Adjusts ey-hosts generation to only include hosts if their IP can be resolved at runtime

Estimated risk
--------------

Low
- Improves resiliency for situations where a hostname cannot be resolved.

Components involved
--------------

$ git diff next-release --name-only
cookbooks/ey-hosts/recipes/default.rb
cookbooks/ey-hosts/templates/default/ey_hosts.erb

Example
--------------
```
#---EY-HOSTS-START

# Application Master
10.203.197.207        ey-app-master

# Application Slaves
10.230.182.98        ey-app-slave-0
10.183.100.16        ey-app-slave-1

# Database Master
10.218.172.125         ey-db-master

# Database Replicas
10.61.218.153        ey-db-slave-brian_wilson
10.61.218.153        ey-db-slave-0
10.13.193.84        ey-db-slave-1

# Utility Instances
10.33.189.48        ey-utility-test2-0
10.181.36.56        ey-utility-test2-1
10.95.177.162        ey-utility-test1

#---EY-HOSTS-END
```


Description of testing done
--------------
Under the 16.06 stack and a Postgres Database

- Enable the Database Service feature (Early Access)
- Enable the Db provider (Early Access)
- Provision an RDS database service with 1 replica
- Boot an environment and select AWS RDS as the Provider
- Select the database service created
- Boot the environment
- Verify the RDS replica is displayed in `/etc/hosts`
- Terminate the RDS replica 
- When termination completes run chef
- verify chef will fail or will display a replica hostname without an IP address to the right
- Upgrade to the new stack revision
- Run chef
- Verify the chef error (if any) has cleared, and the replica name is no longer present in the file.

Under the 12.11 stack and a Postgres Database

- Enable the Database Service feature (Early Access)
- Enable the Db provider (Early Access)
- Provision an RDS database service with 1 replica
- Boot an environment and select AWS RDS as the Provider
- Select the database service created
- Boot the environment
- Verify the RDS replica is displayed in `/etc/hosts`
- Terminate the RDS replica 
- When termination completes run chef
- verify chef will fail or will display a replica hostname without an IP address to the right
- Upgrade to the new stack revision
- Run chef
- Verify the chef error (if any) has cleared, and the replica name is no longer present in the file.


QA Instructions
--------------

Repeat the steps above with a MySQL database.