### PR TITLE
Add Elasticsearch 5.x support

### DIFF
--- a/cookbooks/elasticsearch/attributes/default.rb
+++ b/cookbooks/elasticsearch/attributes/default.rb
@@ -16,15 +16,20 @@ default['elasticsearch'].tap do |elasticsearch|
 
   # Elasticsearch version to install
   # Go to https://www.elastic.co/downloads/past-releases to see the available version
-  elasticsearch['version'] = '2.4.4'
+  elasticsearch['version'] = '5.4.0'
+  #elasticsearch['version'] = '2.4.4'
   # This is the SHA256 checksum. Note that this is different from the SHA1 checksum in the Elastic website
-  elasticsearch['checksum'] = 'bee3ca3d5b2103e09b18e1791d1cc504388b992cc4ebf74869568db13c3d4372'
+  # To generate the SHA256 checksum, download the file and then run:
+  # - Linux: sha256sum <zipfile>
+  # - OSX: shasum -a 256 <zipfile>
+  elasticsearch['checksum'] = '719860ffdf01a7a3b153757f49a3fbf77d70b78b692773e96c266c141e0c30a7'   # checksum for 5.4.0
+  #elasticsearch['checksum'] = 'bee3ca3d5b2103e09b18e1791d1cc504388b992cc4ebf74869568db13c3d4372'  # checksum for 2.4.4
 
   # NOTE: Elasticsearch 5.x.x does not yet work on EY Cloud. Feel free to open a Pull Request to address this!
   # Use this URL for the 5.x.x versions
-  #elasticsearch['download_url'] = "https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-#{elasticsearch['version']}.zip"
+  elasticsearch['download_url'] = "https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-#{elasticsearch['version']}.zip"
   # Use this URL for the 2.4.x versions
-  elasticsearch['download_url'] = "https://download.elastic.co/elasticsearch/release/org/elasticsearch/distribution/zip/elasticsearch/#{elasticsearch['version']}/elasticsearch-#{elasticsearch['version']}.zip"
+  #elasticsearch['download_url'] = "https://download.elastic.co/elasticsearch/release/org/elasticsearch/distribution/zip/elasticsearch/#{elasticsearch['version']}/elasticsearch-#{elasticsearch['version']}.zip"
 
   # Gentoo Java package name to use
   elasticsearch['java_package_name'] = 'dev-java/icedtea-bin'
@@ -47,4 +52,13 @@ default['elasticsearch'].tap do |elasticsearch|
   elasticsearch['fdulimit'] = nil
   elasticsearch['defaultreplicas'] = 1
   elasticsearch['defaultshards'] = 6
+
+  # JVM Options, will be used to populate /etc/elasticsearch/jvm.options
+  # For guidelines on how to calculate the optimal JVM memory settings,
+  # see https://www.elastic.co/guide/en/elasticsearch/reference/master/heap-size.html
+  elasticsearch['jvm_options'] = {
+    :Xms => '2g',
+    :Xmx => '2g',
+    :Xss => '1m'
+  }
 end

--- a/cookbooks/elasticsearch/definitions/plugin.rb
+++ b/cookbooks/elasticsearch/definitions/plugin.rb
@@ -6,18 +6,18 @@ define :es_plugin, :name => nil do
     Chef::Log.info "attempting to install ElasticSearch plugin #{name}"
 
     execute "plugin install #{name}" do
-      cwd "/usr/lib/elasticsearch-#{node['elasticsearch_version']}"
-      command "/usr/lib/elasticsearch-#{node['elasticsearch_version']}/bin/plugin -install #{name}"
-      not_if { File.directory?("/usr/lib/elasticsearch-#{node['elasticsearch_version']}/plugins/#{name}") }
+      cwd "/opt/elasticsearch"
+      command "/opt/elasticsearch/bin/plugin -install #{name}"
+      not_if { File.directory?("/opt/elasticsearch/plugins/#{name}") }
     end
 
   when :remove
     Chef::Log.info "attempting to remove ElasticSearch plugin #{name}"
 
     execute "plugin remove #{name}" do
-      cwd "/usr/lib/elasticsearch-#{node['elasticsearch_version']}"
-      command "/usr/lib/elasticsearch-#{node['elasticsearch_version']}/bin/plugin -remove #{name}"
-      not_if { File.directory?("/usr/lib/elasticsearch-#{node['elasticsearch_version']}/plugins/#{name}") }
+      cwd "/opt/elasticsearch"
+      command "/opt/elasticsearch/bin/plugin -remove #{name}"
+      not_if { File.directory?("/opt/elasticsearch/plugins/#{name}") }
     end
   end
 end

--- a/cookbooks/elasticsearch/files/default/etc-security-limits.conf
+++ b/cookbooks/elasticsearch/files/default/etc-security-limits.conf
@@ -1,0 +1,56 @@
+# /etc/security/limits.conf
+#
+#Each line describes a limit for a user in the form:
+#
+#<domain>        <type>  <item>  <value>
+#
+#Where:
+#<domain> can be:
+#        - an user name
+#        - a group name, with @group syntax
+#        - the wildcard *, for default entry
+#        - the wildcard %, can be also used with %group syntax,
+#                 for maxlogin limit
+#
+#<type> can have the two values:
+#        - "soft" for enforcing the soft limits
+#        - "hard" for enforcing hard limits
+#
+#<item> can be one of the following:
+#        - core - limits the core file size (KB)
+#        - data - max data size (KB)
+#        - fsize - maximum filesize (KB)
+#        - memlock - max locked-in-memory address space (KB)
+#        - nofile - max number of open files
+#        - rss - max resident set size (KB)
+#        - stack - max stack size (KB)
+#        - cpu - max CPU time (MIN)
+#        - nproc - max number of processes
+#        - as - address space limit (KB)
+#        - maxlogins - max number of logins for this user
+#        - maxsyslogins - max number of logins on the system
+#        - priority - the priority to run user process with
+#        - locks - max number of file locks the user can hold
+#        - sigpending - max number of pending signals
+#        - msgqueue - max memory used by POSIX message queues (bytes)
+#        - nice - max nice priority allowed to raise to values: [-20, 19]
+#        - rtprio - max realtime priority
+#
+#<domain>      <type>  <item>         <value>
+#
+
+#*               soft    core            0
+#*               hard    rss             10000
+#@student        hard    nproc           20
+#@faculty        soft    nproc           20
+#@faculty        hard    nproc           50
+#ftp             hard    nproc           0
+#@student        -       maxlogins       4
+
+*                soft    nofile          65535
+*                hard    nofile          65535
+
+elasticsearch    soft    nofile          65536
+elasticsearch    hard    nofile          65536
+
+# End of file

--- a/cookbooks/elasticsearch/files/default/usr-local-bin-monit
+++ b/cookbooks/elasticsearch/files/default/usr-local-bin-monit
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+# set process limits
+# NOTE: These changes are needed by Elasticsearch 5.x
+ulimit -n 65536
+sysctl -w vm.max_map_count=262144
+
+# launch monit with the arguments passed to us
+exec /usr/bin/monit $@

--- a/cookbooks/elasticsearch/metadata.rb
+++ b/cookbooks/elasticsearch/metadata.rb
@@ -3,6 +3,6 @@ description 'Configuration & deployment of Elasticsearch on Engine Yard'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 maintainer 'Engine Yard'
 maintainer_email 'support@engineyard.com'
-version '5.0.0'
+version '5.1.0'
 issues_url 'https://github.com/engineyard/ey-cookbooks-stable-v5/issues'
 source_url 'https://github.com/engineyard/ey-cookbooks-stable-v5'

--- a/cookbooks/elasticsearch/recipes/configure_cluster.rb
+++ b/cookbooks/elasticsearch/recipes/configure_cluster.rb
@@ -12,7 +12,7 @@ else
     end
   end
 
-  template "/usr/lib/elasticsearch-#{ES['version']}/config/elasticsearch.yml" do
+  template "/opt/elasticsearch/config/elasticsearch.yml" do
     source "elasticsearch.yml.erb"
     owner "elasticsearch"
     group "nogroup"
@@ -22,7 +22,8 @@ else
       :elasticsearch_expected => elasticsearch_expected,
       :elasticsearch_defaultshards => ES['defaultshards'],
       :elasticsearch_clustername => ES['clustername'],
-      :elasticsearch_host => node['fqdn']
+      :elasticsearch_host => node['fqdn'],
+      :is_V2 => ES['version'].match(/^2/)
     )
     mode 0600
     backup 0

--- a/cookbooks/elasticsearch/recipes/configure_limits.rb
+++ b/cookbooks/elasticsearch/recipes/configure_limits.rb
@@ -1,0 +1,22 @@
+# Elasticsearch 5.x requires higher limits for max files descriptors and vm.max_map_count
+
+# Override /etc/security/limits.conf
+# NOTE: If you have recipes that also override /etc/security/limits.conf then
+# you have to integrate your customizations here
+is_V2 = node['elasticsearch']['version'].match(/^2/)
+if is_V2
+  cookbook_file "/etc/security/limits.conf" do
+    source "etc-security-limits.conf"
+    owner "root"
+    group "root"
+    mode 600
+  end
+
+  # Override the monit wrapper
+  cookbook_file "/usr/local/bin/monit" do
+    source "usr-local-bin-monit"
+    owner "root"
+    group "root"
+    mode 600
+  end
+end

--- a/cookbooks/elasticsearch/recipes/default.rb
+++ b/cookbooks/elasticsearch/recipes/default.rb
@@ -10,4 +10,7 @@ include_recipe 'elasticsearch::download'
 include_recipe 'elasticsearch::install'
 if ES['is_elasticsearch_instance'] && ES['configure_cluster']
   include_recipe 'elasticsearch::configure_cluster'
+  unless ES['version'].match(/^2/)
+    include_recipe 'elasticsearch::configure_limits'
+  end
 end

--- a/cookbooks/elasticsearch/recipes/install.rb
+++ b/cookbooks/elasticsearch/recipes/install.rb
@@ -26,7 +26,7 @@ if ES['is_elasticsearch_instance']
     action :run
   end
 
-  directory "/usr/lib/elasticsearch-#{ES['version']}" do
+  directory "/opt/elasticsearch-#{ES['version']}" do
     owner "elasticsearch"
     group "nogroup"
     mode 0755
@@ -49,18 +49,18 @@ if ES['is_elasticsearch_instance']
   bash "copy elasticsearch root" do
     user "elasticsearch"
     cwd ES['tmp_dir']
-    code %(cp -r #{ES['tmp_dir']}/elasticsearch-#{ES['version']}/* /usr/lib/elasticsearch-#{ES['version']})
-    not_if { File.exists? "/usr/lib/elasticsearch-#{ES['version']}/lib" }
+    code %(cp -r #{ES['tmp_dir']}/elasticsearch-#{ES['version']}/* /opt/elasticsearch-#{ES['version']})
+    not_if { File.exists? "/opt/elasticsearch-#{ES['version']}/lib" }
   end
 
-  directory "/usr/lib/elasticsearch-#{ES['version']}/plugins" do
+  directory "/opt/elasticsearch-#{ES['version']}/plugins" do
     owner "elasticsearch"
     group "nogroup"
     mode 0755
   end
 
-  link "/usr/lib/elasticsearch" do
-    to "/usr/lib/elasticsearch-#{ES['version']}"
+  link "/opt/elasticsearch" do
+    to "/opt/elasticsearch-#{ES['version']}"
     owner "elasticsearch"
     group "nogroup"
     mode 0755
@@ -90,7 +90,7 @@ if ES['is_elasticsearch_instance']
     only_if "stat -c %U /var/log/elasticsearch/*log* |grep -v elasticsearch"
   end
 
-  directory "/usr/lib/elasticsearch-#{ES['version']}/data" do
+  directory "/data/elasticsearch-#{ES['version']}/data" do
     owner "elasticsearch"
     group "nogroup"
     mode 0755
@@ -101,7 +101,7 @@ if ES['is_elasticsearch_instance']
   if File.new("/proc/mounts").readlines.join.match(/\/usr\/lib[0-9]*\/elasticsearch-#{ES['version']}\/data/)
     Chef::Log.info("Elastic search bind already complete")
   else
-    mount "/usr/lib/elasticsearch-#{ES['version']}/data" do
+    mount "/data/elasticsearch-#{ES['version']}/data" do
       device ES['home']
       fstype "none"
       options "bind,rw"
@@ -109,26 +109,45 @@ if ES['is_elasticsearch_instance']
     end
   end
 
-  template "/usr/lib/elasticsearch-#{ES['version']}/config/logging.yml" do
-    source "logging.yml.erb"
-    mode 0644
+  if ES['version'].match(/^2/)
+    template "/opt/elasticsearch-#{ES['version']}/config/logging.yml" do
+      source "logging.yml.erb"
+      mode 0644
+    end
   end
 
   directory "/usr/share/elasticsearch" do
-    group "elasticsearch"
+    owner "elasticsearch"
     group "nogroup"
     mode 0755
   end
 
+  if Gem::Version.new(ES['version']) < Gem::Version.new('5.0.0')
+    elasticsearch_classpath = "$ES_HOME/lib/elasticsearch-#{ES['version']}.jar:$ES_HOME/lib/*"
+  else
+    elasticsearch_classpath = "$ES_HOME/lib/*"
+  end
   template "/usr/share/elasticsearch/elasticsearch.in.sh" do
     source "elasticsearch.in.sh.erb"
     mode 0644
     backup 0
     variables(
-      :elasticsearch_version => ES['version']
+      :elasticsearch_classpath => elasticsearch_classpath
     )
   end
 
+  # Create the jvm.options file
+  template "/opt/elasticsearch/config/jvm.options" do
+    cookbook "custom-elasticsearch"
+    source "jvm.options.erb"
+    mode 0644
+    backup 0
+    variables(
+      :Xms => ES['jvm_options']['Xms'],
+      :Xmx => ES['jvm_options']['Xmx'],
+      :Xss => ES['jvm_options']['Xss']
+    )
+  end
 
   # Add log rotation for the elasticsearch logs
   cookbook_file "/etc/logrotate.d/elasticsearch" do

--- a/cookbooks/elasticsearch/templates/default/elasticsearch.in.sh.erb
+++ b/cookbooks/elasticsearch/templates/default/elasticsearch.in.sh.erb
@@ -1,4 +1,4 @@
-ES_CLASSPATH=$ES_HOME/lib/elasticsearch-<%= @elasticsearch_version %>.jar:$ES_HOME/lib/*
+ES_CLASSPATH=<%= @elasticsearch_classpath %>
 
 if [ "x$ES_MIN_MEM" = "x" ]; then
     ES_MIN_MEM=256m

--- a/cookbooks/elasticsearch/templates/default/elasticsearch.monitrc.erb
+++ b/cookbooks/elasticsearch/templates/default/elasticsearch.monitrc.erb
@@ -1,6 +1,6 @@
 check process elasticsearch
 with pidfile /var/run/elasticsearch/elasticsearch.pid
-  start program = "/usr/lib/elasticsearch/bin/elasticsearch -d -p /var/run/elasticsearch/elasticsearch.pid" as uid <%= @owner %> with timeout 90 seconds
+  start program = "/opt/elasticsearch/bin/elasticsearch -d -p /var/run/elasticsearch/elasticsearch.pid" as uid <%= @owner %> with timeout 90 seconds
   stop program = "/bin/bash -c '/bin/kill `cat /var/run/elasticsearch/elasticsearch.pid`'" with timeout 90 seconds
   group elasticsearch
   if failed

--- a/cookbooks/elasticsearch/templates/default/elasticsearch.yml.erb
+++ b/cookbooks/elasticsearch/templates/default/elasticsearch.yml.erb
@@ -1,5 +1,7 @@
 path:
+  <% if @is_V2 %>
   work: /var/lib/elasticsearch/work
+  <% end %>
   logs: /var/log/elasticsearch
   data: /data/elasticsearch
 
@@ -14,8 +16,10 @@ network:
 discovery:
   zen:
     minimum_master_nodes: 1
+    <% if @is_V2 %>
     ping.timeout: 3s
     ping.multicast.enabled: false
+    <% end %>
     ping.unicast.hosts: ["<%= @elasticsearch_instances %>"]
 
 gateway:

--- a/custom-cookbooks/elasticsearch/cookbooks/custom-elasticsearch/README.md
+++ b/custom-cookbooks/elasticsearch/cookbooks/custom-elasticsearch/README.md
@@ -50,14 +50,15 @@ Results should be simlar to:
 
 ```
 {
-  "name" : "Bloodlust",
+  "name" : "PcF22DZ",
   "cluster_name" : "elasticsearch",
+  "cluster_uuid" : "4QH3ZKEFTo6E0NP6G5Y9Jw",
   "version" : {
-    "number" : "2.4.0",
-    "build_hash" : "ce9f0c7394dee074091dd1bc4e9469251181fc55",
-    "build_timestamp" : "2016-08-29T09:14:17Z",
+    "number" : "5.4.0",
+    "build_hash" : "780f8c4",
+    "build_date" : "2017-04-28T17:43:27.229Z",
     "build_snapshot" : false,
-    "lucene_version" : "5.5.2"
+    "lucene_version" : "6.5.0"
   },
   "tagline" : "You Know, for Search"
 }
@@ -108,6 +109,24 @@ elasticsearch['is_elasticsearch_instance'] = ( ['solo', 'app_master'].include?(n
 ```
 #elasticsearch['is_elasticsearch_instance'] = ( node['dna']['instance_role'] == 'util' && node['dna']['name'].include?('elasticsearch_') )
 ```
+
+### Configure JVM Options
+
+You can configure the JVM minimum and maximum heap size, and the stack size setting by editing the jvm_options key in `attributes/default.rb`:
+
+```
+elasticsearch['jvm_options'] = {
+  :Xms => '2g',
+  :Xmx => '2g',
+  :Xss => '1m'
+}
+```
+
+For guidelines on how to calculate the optimal JVM memory settings, see [https://www.elastic.co/guide/en/elasticsearch/reference/master/heap-size.html](https://www.elastic.co/guide/en/elasticsearch/reference/master/heap-size.html).
+
+You can also hard-code other JVM options by editing `custom-elasticsearch/templates/default/jvm.options.erb`.
+
+After updating the JVM options, you need to restart Elasticsearch by running `sudo monit restart elasticsearch` on all Elasticsearch instances. The recipe does not automatically restart Elasticsearch as that can cause downtime.
 
 ## Upgrading
 

--- a/custom-cookbooks/elasticsearch/cookbooks/custom-elasticsearch/attributes/default.rb
+++ b/custom-cookbooks/elasticsearch/cookbooks/custom-elasticsearch/attributes/default.rb
@@ -16,11 +16,15 @@ default['elasticsearch'].tap do |elasticsearch|
 
   # Elasticsearch version to install
   # Go to https://www.elastic.co/downloads/past-releases to see the available version
+  #elasticsearch['version'] = '5.5.0'
   elasticsearch['version'] = '2.4.4'
   # This is the SHA256 checksum. Note that this is different from the SHA1 checksum in the Elastic website
-  elasticsearch['checksum'] = 'bee3ca3d5b2103e09b18e1791d1cc504388b992cc4ebf74869568db13c3d4372'
+  # To generate the SHA256 checksum, download the file and then run:
+  # - Linux: sha256sum <zipfile>
+  # - OSX: shasum -a 256 <zipfile>
+  #elasticsearch['checksum'] = '02d9b16334ca97eaaab308bb65743ba18249295d4414f6967c2daf13663cf01d'   # checksum for 5.5.0
+  elasticsearch['checksum'] = 'bee3ca3d5b2103e09b18e1791d1cc504388b992cc4ebf74869568db13c3d4372'  # checksum for 2.4.4
 
-  # NOTE: Elasticsearch 5.x.x does not yet work on EY Cloud. Feel free to open a Pull Request to address this!
   # Use this URL for the 5.x.x versions
   #elasticsearch['download_url'] = "https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-#{elasticsearch['version']}.zip"
   # Use this URL for the 2.4.x versions
@@ -47,4 +51,13 @@ default['elasticsearch'].tap do |elasticsearch|
   elasticsearch['fdulimit'] = nil
   elasticsearch['defaultreplicas'] = 1
   elasticsearch['defaultshards'] = 6
+
+  # JVM Options, will be used to populate /etc/elasticsearch/jvm.options
+  # For guidelines on how to calculate the optimal JVM memory settings,
+  # see https://www.elastic.co/guide/en/elasticsearch/reference/master/heap-size.html
+  elasticsearch['jvm_options'] = {
+    :Xms => '2g',
+    :Xmx => '2g',
+    :Xss => '1m'
+  }
 end

--- a/custom-cookbooks/elasticsearch/cookbooks/custom-elasticsearch/templates/default/jvm.options.erb
+++ b/custom-cookbooks/elasticsearch/cookbooks/custom-elasticsearch/templates/default/jvm.options.erb
@@ -1,0 +1,115 @@
+## JVM configuration
+
+################################################################
+## IMPORTANT: JVM heap size
+################################################################
+##
+## You should always set the min and max JVM heap
+## size to the same value. For example, to set
+## the heap to 4 GB, set:
+##
+## -Xms4g
+## -Xmx4g
+##
+## See https://www.elastic.co/guide/en/elasticsearch/reference/current/heap-size.html
+## for more information
+##
+################################################################
+
+# Xms represents the initial size of total heap space
+# Xmx represents the maximum size of total heap space
+
+-Xms<%= @Xms %>
+-Xmx<%= @Xmx %>
+
+################################################################
+## Expert settings
+################################################################
+##
+## All settings below this section are considered
+## expert settings. Don't tamper with them unless
+## you understand what you are doing
+##
+################################################################
+
+## GC configuration
+-XX:+UseConcMarkSweepGC
+-XX:CMSInitiatingOccupancyFraction=75
+-XX:+UseCMSInitiatingOccupancyOnly
+
+## optimizations
+
+# disable calls to System#gc
+-XX:+DisableExplicitGC
+
+# pre-touch memory pages used by the JVM during initialization
+-XX:+AlwaysPreTouch
+
+## basic
+
+# force the server VM (remove on 32-bit client JVMs)
+-server
+
+# explicitly set the stack size (reduce to 320k on 32-bit client JVMs)
+-Xss<%= @Xss %>
+
+# set to headless, just in case
+-Djava.awt.headless=true
+
+# ensure UTF-8 encoding by default (e.g. filenames)
+-Dfile.encoding=UTF-8
+
+# use our provided JNA always versus the system one
+-Djna.nosys=true
+
+# use old-style file permissions on JDK9
+-Djdk.io.permissionsUseCanonicalPath=true
+
+# flags to configure Netty
+-Dio.netty.noUnsafe=true
+-Dio.netty.noKeySetOptimization=true
+-Dio.netty.recycler.maxCapacityPerThread=0
+
+# log4j 2
+-Dlog4j.shutdownHookEnabled=false
+-Dlog4j2.disable.jmx=true
+-Dlog4j.skipJansi=true
+
+## heap dumps
+
+# generate a heap dump when an allocation from the Java heap fails
+# heap dumps are created in the working directory of the JVM
+-XX:+HeapDumpOnOutOfMemoryError
+
+# specify an alternative path for heap dumps
+# ensure the directory exists and has sufficient space
+#-XX:HeapDumpPath=${heap.dump.path}
+
+## GC logging
+
+#-XX:+PrintGCDetails
+#-XX:+PrintGCTimeStamps
+#-XX:+PrintGCDateStamps
+#-XX:+PrintClassHistogram
+#-XX:+PrintTenuringDistribution
+#-XX:+PrintGCApplicationStoppedTime
+
+# log GC status to a file with time stamps
+# ensure the directory exists
+#-Xloggc:${loggc}
+
+# By default, the GC log file will not rotate.
+# By uncommenting the lines below, the GC log file
+# will be rotated every 128MB at most 32 times.
+#-XX:+UseGCLogFileRotation
+#-XX:NumberOfGCLogFiles=32
+#-XX:GCLogFileSize=128M
+
+# Elasticsearch 5.0.0 will throw an exception on unquoted field names in JSON.
+# If documents were already indexed with unquoted fields in a previous version
+# of Elasticsearch, some operations may throw errors.
+#
+# WARNING: This option will be removed in Elasticsearch 6.0.0 and is provided
+# only for migration purposes.
+#-Delasticsearch.json.allow_unquoted_field_names=true
+


### PR DESCRIPTION
## Description of your patch

Adds Elasticsearch 5.x support

## Recommended Release Notes

Adds Elasticsearch 5.x support

## Estimated risk

Low. 

## Components involved

Custom chef recipes

## Description of testing done

See QA instructions

## QA Instructions

A. New Elasticsearch setup
Test on configuration A (solo) and B (cluster)
Under configuration B, add a utility instance named 'elasticsearch'
Follow the instructions in README to install Elasticsearch 5.5
Verify that Elasticsearch installs without any chef errors
Follow the instructions in README to configure the jvm options. 
Set the stack size (Xss) to 512k, upload and run chef, and restart Elasticsearch. Run `ps -ef | grep "[e]lastic"` to verify that the new Elasticsearch process is running with a 512k stack size.

B. Verify that current Elasticsearch setup still works
Test on configuration A (solo) with a utility instance named elasticsearch
Boot on the latest v5 stack
Follow the instructions to install Elasticsearch 2.4.4 on the utility instance
Upgrade to the QA stack
Verify that Elasticsearch is still running
Restart elasticsearch with`sudo monit restart elasticsearch` on the utility instance. Verify that the restart was successful and that version 2.4.4 is running (it wasn't inadvertently upgraded to version 5.5).