### PR TITLE
Increase postgis install timeout for smaller instance types (DATA-496)

### DIFF
--- a/cookbooks/postgresql/recipes/postgis_build.rb
+++ b/cookbooks/postgresql/recipes/postgis_build.rb
@@ -20,4 +20,5 @@ end
 package "dev-db/postgis" do
   version node[:postgis_version]
   action :install
+  timeout 1200
 end


### PR DESCRIPTION
Description of your patch
--------------

increase postgis install timeout for smaller instance types


Recommended Release Notes
--------------
Reduces the possibility of postgis install causing chef to timeout on instances with low CPU availability.

Estimated risk
--------------

Low
- Adds a timeout attribute that sets the timeout to 1200 seconds instead of the chef default of 600

Components involved
--------------

$ git diff master --name-only
cookbooks/postgresql/recipes/postgis_build.rb

Description of testing done
--------------
Under the 16.06 stack

The timeout condition is difficult to reproduce so there is no regression test with this PR

- booted a t2.micro solo instance
- deployed the updated codebase
- enabled the postgis extension by creating the file `/db/postgresql/extensions.json` with the content (dbguru is the name of the application):
    
    ```
    {
     	"dbguru": ["postgis"]
    }
    ```
        
- Ran chef, confirmed chef run completed successfully
- connected to the database `psql -U postgres dbguru`
- verified the presence of the postgis extension `\dx`

QA Instructions
--------------

Repeat the test above as an independent QA validation.