### PR TITLE
CC-1177: Remove misplaced comma in papertrail attributes.

### DIFF
--- a/cookbooks/papertrail/attributes/default.rb
+++ b/cookbooks/papertrail/attributes/default.rb
@@ -1,7 +1,7 @@
 app_name = node.dna[:applications].keys.first
 
 default['papertrail'].tap do |papertrail|
-  papertrail['syslog_ng_version']      = '3.7.3',
+  papertrail['syslog_ng_version']      = '3.7.3'
   papertrail['remote_syslog_version']  = 'v0.16'
   papertrail['remote_syslog_filename'] = 'remote_syslog_linux_amd64.tar.gz'
   papertrail['remote_syslog_checksum'] = '04055643eb1c0db9ec61a67bdfd58697912acb467f58884759a054f6b5d6bb56'


### PR DESCRIPTION
Description of your patch
-------------

The misplaced comma in papertrail/attributes/default.rb is causing the papertrail recipe to add an incorrect entry to /etc/portage/package.keywords/local file:

```
=app-admin/syslog-ng-["3.7.3", "v0.16"]
```

This change simply removes the comma.

Recommended Release Notes
-------------

Removes a misplaced comma on the syslog_ng version line in the papertrail attributes file.

Estimated risk
-------------

Low. Papertrail is not enabled by default. Customers who have enabled it have the incorrect behavior that this change fixes.

How to Test
-------------

Prepare a v5 environment.

Enable the papertrail recipe. See:

https://github.com/engineyard/ey-cookbooks-stable-v5/tree/next-release/custom-cookbooks/papertrail

Upload recipes to your environment and click Apply. Check /etc/portage/package.keywords/local and notice the invalid entry:

```
=app-admin/syslog-ng-["3.7.3", "v0.16"]
```

If you click Apply again, the recipe will add another invalid entry to /etc/portage/package.keywords/local.

If you use the QA stack with the new change, you'll see that it will add a proper entry to /etc/portage/package.keywords/local:

```
=app-admin/syslog-ng-3.7.3
```
