### PR TITLE
CC-1181: Stricter /db and /data matching for check_primary-ebs.

### DIFF
--- a/cookbooks/collectd/files/default/check_health_for
+++ b/cookbooks/collectd/files/default/check_health_for
@@ -229,7 +229,7 @@ check_primary-ebs() {
     message=()
     
     # get filesystems
-    egrep '/db|/data' /proc/mounts | 
+    egrep ' /db | /data ' /proc/mounts | 
     {
       while read i
       do


### PR DESCRIPTION
Description of your patch
-------------

We have a couple of customers with a custom nfs setup where the remote host directory is /data. For example,

```
domU-12-31-39-04-D9-8F.compute-1.internal:/data /shared [...]
```

As a result, our `check_primary-ebs` that supposedly checks the /data and /db volumes only, inadvertently matches this /shared volume.

Another issue is the nfs setup where the local mount point directory is the one matching /data or /db. For example:

```
appname@files.mydomain.com:/home/appname /data/client_data fuse.sshfs rw[...]
```

This change updates the `check_primary-ebs` to use a slightly stricter regex that prevents both these cases.

Recommended Release Notes
-------------

Excludes nfs remote host directory /data or /db from the primary EBS filesystem health check. Also excludes nfs mount point directory /data/subdir or /db/subdir from this same health check.

Estimated risk
-------------

Low - minor change in filesystem health check.

Components involved
-------------

collectd - check_health_for "primary-ebs"

Description of testing done
-------------

The regex has already been tested in the change for v4.

I updated cookbooks/collectd/files/default/check_health_for, and uploaded and applied it to my test environment. 

Verified that /engineyard/bin/check_health_for is updated. Then, I deleted /tmp/check_primary-ebs_status/primary-ebs_OKAY, and waited for a new primary-ebs_OKAY to be created. Checked that the new alert showed up in the environment dashboard.

QA Instructions
-------------

Boot up a solo environment using the QA stack.

Check that /tmp/check_primary-ebs_status/primary-ebs_OKAY exists.

Delete the file /tmp/check_primary-ebs_status/primary-ebs_OKAY and check if it is regenerated.

Verify that the new alerts show up in the environment dashboard. It should look like the following:

```
 Application and Database (i-abcd1234)
 Device primary ebs: 06:26:18 FileSystem FSCK checks clean.
```
