### PR TITLE
CC-1194: Fix quoting of PostgreSQL extension names

### DIFF
--- a/cookbooks/postgresql/resources/pg_extension.rb
+++ b/cookbooks/postgresql/resources/pg_extension.rb
@@ -35,10 +35,10 @@ action :install do
             quoted_ext_name = "'#{ext_name}'"
           else
             cmd = 'CREATE EXTENSION IF NOT EXISTS'
-            quoted_ext_name = ext_name
+            quoted_ext_name = '"' + ext_name + '"'
           end
           execute "Postgresql loading #{use_load ? 'library': 'extension'} #{ext_name}" do
-            command %Q(psql -U postgres -d #{db_name} -c "#{cmd} #{quoted_ext_name} #{"SCHEMA #{schema_name}" if !schema_name.nil? } #{"VERSION #{version}" if !version.nil?} #{"FROM #{old_version}" if !old_version.nil?};")
+            command %Q(psql -U postgres -d #{db_name} -c '#{cmd} #{quoted_ext_name} #{"SCHEMA #{schema_name}" if !schema_name.nil? } #{"VERSION #{version}" if !version.nil?} #{"FROM #{old_version}" if !old_version.nil?};')
           end
       
           # and a couple follow up commands for Postgis


### PR DESCRIPTION
## Description of your patch

Fixes the chef error encountered when installing some PostgreSQL extensions

## Recommended Release Notes

Fixes the chef error encountered when installing some PostgreSQL extensions

## Estimated risk

Low

## Components involved

PostgreSQL chef recipe

## Description of testing done

See QA instructions

## QA Instructions

Test on configuration A

Boot latest stable-v5 stack

Follow the instructions in https://github.com/engineyard/ey-cookbooks-stable-v5/tree/next-release/cookbooks/postgresql#extensions to enable the following extensions:
- postgis
- uuid-ossp 
- auto_explain

Verify that chef fails when attempting to install uuid-ossp or one of the other extensions

Upgrade to the QA stack

Verify that chef runs cleanly and that the extensions have been installed
(To see the list of installed extensions, run `psql -U deploy todo -c "\dx"`)

Terminate the environment

Boot the environment again. Verify that there were no chef errors and that the extensions have been installed