### PR TITLE
Update Erlang from 18.3 to 19 due to regression

### DIFF
--- a/cookbooks/elixir/attributes/elixir.rb
+++ b/cookbooks/elixir/attributes/elixir.rb
@@ -2,6 +2,6 @@ default['elixir']['full_atom'] = "dev-lang/elixir"
 default['elixir']['erlang']['full_atom'] = "dev-lang/erlang"
 default['elixir']['config']['file'] = "elixir_app.config"
 default['elixir']['version'] = "1.3.4"
-default['elixir']['erlang']['version'] = "18.3"
+default['elixir']['erlang']['version'] = "19.1.6"
 default['elixir']['port'] = "8000"
 default['elixir']['cookie'] = node['dna']['environment']['name']


### PR DESCRIPTION
Description of your patch
-------------

Updates erlang in the elixir cookbook from 18.3 to 19 due to an erlang regression with Openssl


Recommended Release Notes
-------------

Updates Elixir Erlang from 18 to 19

Estimated risk
-------------

Low - unreleased stack

Components involved
-------------

elixir

Description of testing done
-------------

The attribute change was tested via an overlay with elixir enabled

I updated the attributes file with the desired Erlang version

QA Instructions
-------------

Boot up a solo environment using the QA stack.

Check that iex shows OTP 18

Update cookbooks and verify iex shows OTP 19
