### PR TITLE
Remove unnecessary that made the ElasticSearch recipe not apply limits

### DIFF
--- a/cookbooks/elasticsearch/recipes/configure_limits.rb
+++ b/cookbooks/elasticsearch/recipes/configure_limits.rb
@@ -3,20 +3,18 @@
 # Override /etc/security/limits.conf
 # NOTE: If you have recipes that also override /etc/security/limits.conf then
 # you have to integrate your customizations here
-is_V2 = node['elasticsearch']['version'].match(/^2/)
-if is_V2
-  cookbook_file "/etc/security/limits.conf" do
-    source "etc-security-limits.conf"
-    owner "root"
-    group "root"
-    mode 600
-  end
 
-  # Override the monit wrapper
-  cookbook_file "/usr/local/bin/monit" do
-    source "usr-local-bin-monit"
-    owner "root"
-    group "root"
-    mode 600
-  end
+cookbook_file "/etc/security/limits.conf" do
+  source "etc-security-limits.conf"
+  owner "root"
+  group "root"
+  mode 600
+end
+
+# Override the monit wrapper
+cookbook_file "/usr/local/bin/monit" do
+  source "usr-local-bin-monit"
+  owner "root"
+  group "root"
+  mode 600
 end


### PR DESCRIPTION
The check was happening two places, first in https://github.com/engineyard/ey-cookbooks-stable-v5/blob/e390995050812566a4114cdb35040b1cb2fe6455/cookbooks/elasticsearch/recipes/default.rb#L13-L15

And then in https://github.com/engineyard/ey-cookbooks-stable-v5/blob/e390995050812566a4114cdb35040b1cb2fe6455/cookbooks/elasticsearch/recipes/configure_limits.rb#L6-L7

The second line prevents this from ever applying the changes. 

This partly fixes #231 .