### PR TITLE
Add timezone attribute to postgresql.conf

### DIFF
--- a/cookbooks/postgresql/recipes/server_configure.rb
+++ b/cookbooks/postgresql/recipes/server_configure.rb
@@ -93,6 +93,10 @@ if ['solo', 'db_master'].include?(node.dna['instance_role'])
     user "postgres"
     not_if { FileTest.directory?("#{postgres_root}/#{postgres_version}/data") }
   end
+  
+  zone = "#{node.engineyard.environment['timezone']}"
+  zonepath = "/usr/share/zoneinfo/#{zone}"
+  timezone = (File.exists?(zonepath) and !zone.empty? ) ? zone : 'GMT'
 
   template "#{postgres_root}/#{postgres_version}/data/postgresql.conf" do
     source "postgresql.conf.erb"
@@ -120,7 +124,8 @@ if ['solo', 'db_master'].include?(node.dna['instance_role'])
       :postgres_root => postgres_root,
       :postgres_version => postgres_version,
       :hot_standby => "on",
-      :archive_timeout => '0'
+      :archive_timeout => '0',
+      :timezone => timezone
     )
   end
 end

--- a/cookbooks/postgresql/templates/default/postgresql.conf.erb
+++ b/cookbooks/postgresql/templates/default/postgresql.conf.erb
@@ -462,7 +462,7 @@ log_autovacuum_min_duration = 2000	# -1 disables, 0 logs all actions and
 
 datestyle = 'iso, mdy'
 #intervalstyle = 'postgres'
-#timezone = unknown			# actually, defaults to TZ environment
+timezone = <%= @timezone %>			# actually, defaults to TZ environment
 					# setting
 #timezone_abbreviations = 'Default'     # Select the set of available time zone
 					# abbreviations.  Currently, there are


### PR DESCRIPTION
Description of your patch
--------------
Adds explicit default timezone setting to Postgres in support of the Timezones DNA feature.

Recommended Release Notes
--------------
Adds support for timezone controls to PostgreSQL

Estimated risk
--------------

Low
- Nothing is changed if the timezone is unrecognized or not present.

Components involved
--------------

$ git diff next-release --name-only
cookbooks/postgresql9/recipes/server_configure.rb
cookbooks/postgresql9/templates/default/postgresql.conf.erb

Description of testing done
--------------
Under the 12.11 stack

- Provisioned a solo using the updated stack
- Verified cookbooks completed successfully
- Verified the current timezone with `psql -c 'show timezone'` showed a value of `GMT`
- Added an attribute `"timezone": "America/Anchorage"` in `/etc/chef/dna.json` under `"engineyard":"environment"`
- Ran chef cached using `PATH=/usr/local/ey_resin/bin/:$PATH /usr/local/ey_resin/bin/chef-solo -j /etc/chef/dna.json -c /etc/chef/solo.rb`
- Verified the timezone with `psql -c 'show timezone'` showed a value of `America/Anchorage`
- Added an attribute `"timezone": "Gorgonzola"` in `/etc/chef/dna.json` under `"engineyard":"environment"`
- Ran chef cached using `PATH=/usr/local/ey_resin/bin/:$PATH /usr/local/ey_resin/bin/chef-solo -j /etc/chef/dna.json -c /etc/chef/solo.rb`
- Verified chef raised an exception indicating that `"Timezone 'Gorgonzola' not recognized."` and `psql -c 'show timezone'` showed a value of `America/Anchorage`

QA Instructions
--------------

Using the 16.06 stack boot a cluster and repeat verify as above. For running chef with cached data you'll need to use the command `PATH=/usr/local/ey_resin/bin ey-enzyme --cached --verbose --chef-bin /usr/local/ey_resin/bin/chef-solo`.