### PR TITLE
Bump minor Postgres 9.5 version to 9.5.7, add Postgres 9.6 with 9.6.3

### DIFF
--- a/cookbooks/postgresql/attributes/version.rb
+++ b/cookbooks/postgresql/attributes/version.rb
@@ -1,10 +1,13 @@
 case attribute.dna.engineyard.environment.db_stack_name
 when "postgres9_4"
-  default['postgresql']['latest_version'] = "9.4.11"
-  default['postgresql']['short_version'] = "9.4"
+  default['postgresql']['latest_version'] = '9.4.12'
+  default['postgresql']['short_version'] = '9.4'
 when "postgres9_5"
-  default['postgresql']['latest_version'] = "9.5.6"
-  default['postgresql']['short_version'] = "9.5"
+  default['postgresql']['latest_version'] = '9.5.7'
+  default['postgresql']['short_version'] = '9.5'
+when "postgres9_6"
+  default['postgresql']['latest_version'] = '9.6.3'
+  default['postgresql']['short_version'] = '9.6'
 end
 default['postgresql']['datadir'] = "/db/postgresql/#{node['postgresql']['short_version']}/data/"
 default['postgresql']['dbroot'] = '/db/postgresql/'

--- a/cookbooks/postgresql/recipes/server_configure.rb
+++ b/cookbooks/postgresql/recipes/server_configure.rb
@@ -103,7 +103,7 @@ if ['solo', 'db_master'].include?(node.dna['instance_role'])
     notifies :reload, "service[postgresql-#{postgres_version}]"
     variables(
       :pg_port => "5432",
-      :wal_level => "hot_standby",
+      :wal_level => postgres_version >= '9.6' ? 'replica' : 'hot_standby',
       :shared_buffers => node['shared_buffers'],
       :maintenance_work_mem => node['maintenance_work_mem'],
       :work_mem => node['work_mem'],

--- a/cookbooks/postgresql/recipes/server_install.rb
+++ b/cookbooks/postgresql/recipes/server_install.rb
@@ -1,9 +1,9 @@
 postgres_version = node['postgresql']['short_version']
 
 known_ebuild_versions = %w[
-  9.4.8   9.4.11
-  9.5.3
-  9.5.6
+  9.4.8   9.4.11  9.4.12
+  9.5.3   9.5.6   9.5.7
+  9.6.3
 ]
 
 execute "dropping lock version file" do


### PR DESCRIPTION
Description of your patch
--------------

Updates Postgresql-server 9.5 to 9.5.7
Adds new major version for 9.6 of 9.6.3.

Recommended Release Notes
--------------
Adds support for Postgres versions 9.5.7 and 9.6.3

Estimated risk
--------------

Low
- Customers need to take additional steps to apply this update or must have opted in to automatic updates.
- Recommended procedure for databases is to always test new releases in a non-Production environment before upgrading Production.

Components involved
--------------

$ git diff next-release --name-only
cookbooks/postgresql/attributes/version.rb
cookbooks/postgresql/recipes/server_configure.rb
cookbooks/postgresql/recipes/server_install.rb

Description of testing done
--------------
On Mission Under the tpol-2016-0.1 stack

- Provisioned a cluster using the upgraded Stack with automatic version upgrades disabled (default)
- Ran:
  - `postgres --version`
- Validated:
  - 9.6.3
- Booted a replica database, verified replication started up and runs
- Promoted the replica database, verified successful promotion.

QA Instructions
--------------

Using the 16.06 stack with a Postgres 9.5 database

- Provisioned a cluster using the existing Stack with automatic version upgrades disabled (default)
- Ran:
  - `postgres --version`
- Validated:
  - 9.5.6  (any version <= 9.5.6 is expected)
- Upgraded the environment,
- Ran: 
  - `postgres --version`
- Validated
  - 9.5.6 (version should be the same as the prior check)
- Edit environment, remove the check next to "Prevent database version changes", saved change
- Clicked "Apply" for the environment on the dashboard
- Ran:
  - `postgres --version`
- Validated:
  - 9.5.7
- Ran:
  - `/etc/init.d/postgresql-9.5 restart`
- Validated:
  - Postgresql restarts successfully

Postgres 9.6 major version testing will not be possible until the feature is released in AWSM behind a feature flag. This release has to publish first so we can lock down supported stack versions in AWSM.
