### PR TITLE
Correct dna attribute so nginx is restarted on tzone change

### DIFF
--- a/cookbooks/timezones/recipes/default.rb
+++ b/cookbooks/timezones/recipes/default.rb
@@ -11,7 +11,7 @@ end
 zonepath = '/usr/share/zoneinfo/'
 zone = "#{node.engineyard.environment['timezone']}"
 
-has_nginx = ['solo','app','app_master'].include?(node['instance_role'])
+has_nginx = ['solo','app','app_master'].include?(node.dna['instance_role'])
 
 if not File.exists?(File.join(zonepath, zone)) and zone != '' and not zone.nil?
   raise "Timezone '#{zone}' not recognized."


### PR DESCRIPTION
Description of your patch
--------------
Adjusts timezone feature to restart nginx when timezone is updated

Recommended Release Notes
--------------
Feature is not useable yet, no release note required. 

Estimated risk
--------------
Low
- Corrects what would have been a bug in an already low risk feature.

Components involved
--------------
$ git diff next-release --name-only
cookbooks/timezones/recipes/default.rb

QA Instructions
--------------
Under the 16.06 stack

- Provisioned a solo using the updated stack
- Verified cookbooks completed successfully
- Verified the current timezone with `ls -la /etc/localtime` showed a symlink to `/usr/share/zoneinfo/UTC`
- Added an attribute `"timezone": "America/Anchorage"` in `/etc/chef/dna.json` under `"engineyard":"environment"`
- Check the timestamp of nginx with `ps -ef |grep nginx`
- Ran chef cached using `PATH=/usr/local/ey_resin/bin ey-enzyme --cached --verbose --chef-bin /usr/local/ey_resin/bin/chef-solo`
- Check the timestamp of nginx with `ps -ef|grep nginx` and confirm it has a new timestamp (ie. it has restarted).