### PR TITLE
Tinyproxy: ensure tinyproxy directory is owned by nobody after a takeover

### DIFF
--- a/cookbooks/tinyproxy/libraries/cleanup_tinyproxy_monitrc.rb
+++ b/cookbooks/tinyproxy/libraries/cleanup_tinyproxy_monitrc.rb
@@ -1,0 +1,10 @@
+class Chef
+  class Recipe
+    def cleanup_tinyproxy_monitrc
+      file '/etc/monit.d/tinyproxy.monitrc' do
+        action :delete
+        ignore_failure
+      end
+    end
+  end
+end


### PR DESCRIPTION
also removes tinyproxy monitrc on non-tinyproxy instances