### PR TITLE
sets default config for root to use socket file when connecting local…

### DIFF
--- a/cookbooks/mysql/recipes/user_my.cnf.rb
+++ b/cookbooks/mysql/recipes/user_my.cnf.rb
@@ -15,7 +15,7 @@ template "/root/.my.cnf" do
     :home_dir => '/root/',
     :mysql_version => Gem::Version.new(node['mysql']['short_version']),
     :mysql_5_7 => Gem::Version.new('5.7'),
-    :host => node.dna['instance_role'][/^(db|solo)/] ? '127.0.0.1' : node.dna['db_host'],
+    :host => node.dna['instance_role'][/^(db|solo)/] ? 'localhost' : node.dna['db_host'],
   })
   source "user_my.cnf.erb"
 end


### PR DESCRIPTION
Description of your patch
--------------

Enables SSL feature to work with `skip_name_resolve`


Recommended Release Notes
--------------
Corrects MySQL SSL errors when `skip_name_resolve` setting is configured.

Estimated risk
--------------

Low
- corrects a bug for a rarely used configuration option.

Components involved
--------------

$ git diff next-release --name-only
cookbooks/mysql/recipes/user_my.cnf.rb

Description of testing done
--------------

#### For MySQL

- Boot a cluster using MySQL 5.6 on Stable-v5 3.0.30
- Edit /db/mysql.d/custom.cnf with the following contents

    [mysqld]
    skip_name_resolve
    
- restart mysql with /etc/init.d/mysql restart
- remove grant for deploy user `mysql -e "revoke all privileges on *.* from deploy@'%';"`
- Run chef apply
  - apply should fail
- Upgrade to the test stack
- Chef runs automatically and should succeed
  
QA Instructions
--------------

Independently repeat as above optionally with a solo.