### PR TITLE
adds capability to select util,app,db or all instances. fixes #239

### DIFF
--- a/cookbooks/cron/recipes/default.rb
+++ b/cookbooks/cron/recipes/default.rb
@@ -4,7 +4,34 @@
 #
 
 # Find all cron jobs specified in attributes/cron.rb where current node name matches instance_name
-crons = node[:custom_crons].find_all {|c| c[:instance_name] == node.dna[:name] }
+named_crons = node[:custom_crons].find_all {|c| c[:instance_name] == node.dna[:name] }
+
+# Find all cron jobs for utility instances
+util_crons = node[:custom_crons].find_all {|c| c[:instance_name] == 'util' }
+
+# Find all cron jobs for application instances
+app_crons = node[:custom_crons].find_all {|c| c[:instance_name] == 'app' }
+
+# Find all cron jobs for ALL instances
+all_crons = node[:custom_crons].find_all {|c| c[:instance_name] == 'all' }
+
+# Find all cron jobs for Database instances
+db_crons = node[:custom_crons].find_all {|c| c[:instance_name] == 'db' }
+
+crons = all_crons + named_crons
+
+
+if node['dna']['instance_role'] == 'util'
+    crons = crons + util_crons
+end
+
+if node['dna']['instance_role'] == 'app' || node['dna']['instance_role'] == 'app_master'
+    crons = crons + app_crons
+end
+
+if node['dna']['instance_role'] == 'db_master' || node['dna']['instance_role'] == 'db_slave'
+    crons = crons + db_crons
+end
 
 crons.each do |cron|
   cron cron[:name] do
@@ -18,3 +45,5 @@ crons.each do |cron|
     command  cron[:command]
   end
 end
+
+

--- a/custom-cookbooks/cron/cookbooks/custom-cron/README.md
+++ b/custom-cookbooks/cron/cookbooks/custom-cron/README.md
@@ -1,14 +1,14 @@
 # custom-cron
 
 This is a wrapper cookbook around Engine Yard's cron cookbook.  It automates the
-addition of cron jobs  for the application user (`deploy`)on the utility
-instance name specified for each cron job. All cron jobs are specified in the
+addition of cron jobs  for the application user (`deploy`)on the 
+instance name or type specified for each cron job. All cron jobs are specified in the
 attributes file of the cron cookbook.
 
 ## Limitations
 This cookbook will not install cron jobs for the root user, it must be modified
 if this is required.  Cron jobs are installed for the default application user,
-typically called deploy.
+typically called `deploy`.
 
 ## Installation
 
@@ -55,16 +55,16 @@ Yard.
 All customizations go to `cookbooks/custom-cron/attributes/default.rb`.
 
 Add your cron jobs as an array of hashes in `default[:custom_crons]` You must
-specify a name, time, command and instance name.  The time value must be the
+specify a name, time, command and instance name or instance type. They following arguments are valid: `app`, `db`, `util`, `all`, or "instance_name".  The time value must be the
 full string containing minute, hour, day, month and weekday separated by spaces
 (eg: '* * * * *').
 
 ```
 default[:custom_crons] = [
-   {:name => "test1", :time => "10 * * * *",
-    :command => "echo 'test1'", :instance_name => "cron"
+   {:name => "Install on myRedisInstance only", :time => "10 * * * *",
+    :command => "echo 'test1'", :instance_name => "myRedisInstance"
   },
-  {:name => "test2", :time => "10 1 * * *",
-   :command => "echo 'test2'", :instance_name => "cron"}
+  {:name => "Install on all instances", :time => "10 1 * * *",
+   :command => "echo 'test2'", :instance_name => "all"}
 ]
 ```


### PR DESCRIPTION
#### Description of your patch
Cron recipe is extended to allow the use of keywords "all", "util", "app" and "db" apart from instance name

#### Recommended Release Notes
N/A

#### Estimated risk
Low

#### Components involved
README

#### Description of testing done
Tested on an env with util/app_master/app server. Different cronjobs were set up based on keywords

#### QA Instructions
No QA needed
