### PR TITLE
Backup on MySQL DB slave if it is available

### DIFF
--- a/cookbooks/ey-backup/recipes/mysql.rb
+++ b/cookbooks/ey-backup/recipes/mysql.rb
@@ -60,7 +60,6 @@ if has_backups_enabled && (db_slaves_available && is_db_slave && is_first_slave 
   end
 else
   cron 'mysql' do
-    user   cronjob_user
     action :delete
   end
 end

--- a/cookbooks/ey-backup/recipes/mysql.rb
+++ b/cookbooks/ey-backup/recipes/mysql.rb
@@ -43,12 +43,11 @@ end
 has_backups_enabled  = node.dna['backup_window'] != 0
 db_slaves_available  = node.dna['db_slaves'].any?
 is_db_master_or_solo = ['db_master','solo'].include?(node.dna['instance_role'])
-is_db_slave          = 'db_slave' == node.dna['instance_role']
 
 # The backup target is the first db-slave, we do this to avoid multiple db-slaves doing backups
 is_backup_target = node.dna['db_slaves'].first == (node['ec2'] && node['ec2']['local_hostname'] ? node['ec2']['local_hostname'] : hostname.stdout)
 
-if has_backups_enabled && (db_slaves_available && is_db_slave && is_backup_target || !db_slaves_available && is_db_master_or_solo)
+if has_backups_enabled && (db_slaves_available && is_backup_target || !db_slaves_available && is_db_master_or_solo)
   encryption_command = @encryption_command
   backup_command = "eybackup -e mysql #{encryption_command} >> /var/log/eybackup.log 2>&1"
 

--- a/cookbooks/ey-backup/recipes/mysql.rb
+++ b/cookbooks/ey-backup/recipes/mysql.rb
@@ -44,7 +44,9 @@ has_backups_enabled  = node.dna['backup_window'] != 0
 db_slaves_available  = node.dna['db_slaves'].any?
 is_db_master_or_solo = ['db_master','solo'].include?(node.dna['instance_role'])
 is_db_slave          = 'db_slave' == node.dna['instance_role']
-is_backup_target     = node.dna['db_slaves'].first == (node['ec2'] && node['ec2']['local_hostname'] ? node['ec2']['local_hostname'] : hostname.stdout)
+
+# The backup target is the first db-slave, we do this to avoid multiple db-slaves doing backups
+is_backup_target = node.dna['db_slaves'].first == (node['ec2'] && node['ec2']['local_hostname'] ? node['ec2']['local_hostname'] : hostname.stdout)
 
 if has_backups_enabled && (db_slaves_available && is_db_slave && is_backup_target || !db_slaves_available && is_db_master_or_solo)
   encryption_command = @encryption_command

--- a/cookbooks/ey-backup/recipes/mysql.rb
+++ b/cookbooks/ey-backup/recipes/mysql.rb
@@ -46,7 +46,7 @@ is_db_master_or_solo = ['db_master','solo'].include?(node.dna['instance_role'])
 is_db_slave          = 'db_slave' == node.dna['instance_role']
 is_first_slave       = node.dna['db_slaves'].first == (node['ec2'] && node['ec2']['local_hostname'] ? node['ec2']['local_hostname'] : hostname.stdout)
 
-if has_backups_enabled && (db_slaves_available && is_db_slave && is_first_slave || is_db_master_or_solo)
+if has_backups_enabled && (db_slaves_available && is_db_slave && is_first_slave || !db_slaves_available && is_db_master_or_solo)
   encryption_command = @encryption_command
   backup_command = "eybackup -e mysql #{encryption_command} >> /var/log/eybackup.log 2>&1"
 

--- a/cookbooks/ey-backup/recipes/mysql.rb
+++ b/cookbooks/ey-backup/recipes/mysql.rb
@@ -44,9 +44,9 @@ has_backups_enabled  = node.dna['backup_window'] != 0
 db_slaves_available  = node.dna['db_slaves'].any?
 is_db_master_or_solo = ['db_master','solo'].include?(node.dna['instance_role'])
 is_db_slave          = 'db_slave' == node.dna['instance_role']
-is_first_slave       = node.dna['db_slaves'].first == (node['ec2'] && node['ec2']['local_hostname'] ? node['ec2']['local_hostname'] : hostname.stdout)
+is_backup_target     = node.dna['db_slaves'].first == (node['ec2'] && node['ec2']['local_hostname'] ? node['ec2']['local_hostname'] : hostname.stdout)
 
-if has_backups_enabled && (db_slaves_available && is_db_slave && is_first_slave || !db_slaves_available && is_db_master_or_solo)
+if has_backups_enabled && (db_slaves_available && is_db_slave && is_backup_target || !db_slaves_available && is_db_master_or_solo)
   encryption_command = @encryption_command
   backup_command = "eybackup -e mysql #{encryption_command} >> /var/log/eybackup.log 2>&1"
 

--- a/cookbooks/ey-backup/recipes/mysql.rb
+++ b/cookbooks/ey-backup/recipes/mysql.rb
@@ -21,35 +21,46 @@ end
 @encryption_command =  ""
 
 node.engineyard.environment['apps'].each do |app|
-	app['components'].each do |component|
-	  if component['key'] == 'encrypted_backup'
-	    include_recipe 'ey-backup::encrypted'
+  app['components'].each do |component|
+    if component['key'] == 'encrypted_backup'
+      include_recipe 'ey-backup::encrypted'
 
-	    @long_key_id =  ""
+      @long_key_id =  ""
 
-	    gpg_keys = Mixlib::ShellOut.new("gpg --list-keys --with-colon")
-	    gpg_keys.run_command
-	    gpg_keys.stdout.each_line do |line|
+      gpg_keys = Mixlib::ShellOut.new("gpg --list-keys --with-colon")
+      gpg_keys.run_command
+      gpg_keys.stdout.each_line do |line|
         if line[0..2] == 'pub'
           @long_key_id = line.split(':')[4]
         end
       end
 
-  	  @encryption_command = "-k #{@long_key_id}" unless @long_key_id.empty?
+      @encryption_command = "-k #{@long_key_id}" unless @long_key_id.empty?
     end
-	end
+  end
 end
 
-if node.dna['backup_window'] != 0 && ['db_master','solo'].include?(node.dna['instance_role'])
+has_backups_enabled  = node.dna['backup_window'] != 0
+db_slaves_available  = node.dna['db_slaves'].any?
+is_db_master_or_solo = ['db_master','solo'].include?(node.dna['instance_role'])
+is_db_slave          = 'db_slave' == node.dna['instance_role']
+is_first_slave       = node.dna['db_slaves'].first == (node['ec2'] && node['ec2']['local_hostname'] ? node['ec2']['local_hostname'] : hostname.stdout)
+
+if has_backups_enabled && (db_slaves_available && is_db_slave && is_first_slave || is_db_master_or_solo)
   encryption_command = @encryption_command
   backup_command = "eybackup -e mysql #{encryption_command} >> /var/log/eybackup.log 2>&1"
 
-  cron "mysql" do
+  cron 'mysql' do
     command backup_command
     month   '*'
     weekday '*'
     day     '*'
     hour    node['backup_hour']     # this attribute is set by ey-base/attributes/snapshot_and_backup_intervals.rb
     minute  node['backup_minute']
+  end
+else
+  cron 'mysql' do
+    user   cronjob_user
+    action :delete
   end
 end

--- a/cookbooks/ey-backup/recipes/postgres.rb
+++ b/cookbooks/ey-backup/recipes/postgres.rb
@@ -45,7 +45,8 @@ db_slaves_available  = node.dna['db_slaves'].any?
 is_db_master_or_solo = ['db_master','solo'].include?(node.dna['instance_role'])
 is_db_slave          = 'db_slave' == node.dna['instance_role']
 
-is_backup_target     = node.dna['db_slaves'].first == (node['ec2'] && node['ec2']['local_hostname'] ? node['ec2']['local_hostname'] : hostname.stdout)
+# The backup target is the first db-slave, we do this to avoid multiple db-slaves doing backups
+is_backup_target = node.dna['db_slaves'].first == (node['ec2'] && node['ec2']['local_hostname'] ? node['ec2']['local_hostname'] : hostname.stdout)
 
 if has_backups_enabled && (db_slaves_available && is_db_slave && is_backup_target || !db_slaves_available && is_db_master_or_solo)
   encryption_command = @encryption_command

--- a/cookbooks/ey-backup/recipes/postgres.rb
+++ b/cookbooks/ey-backup/recipes/postgres.rb
@@ -43,12 +43,11 @@ end
 has_backups_enabled  = node.dna['backup_window'] != 0
 db_slaves_available  = node.dna['db_slaves'].any?
 is_db_master_or_solo = ['db_master','solo'].include?(node.dna['instance_role'])
-is_db_slave          = 'db_slave' == node.dna['instance_role']
 
 # The backup target is the first db-slave, we do this to avoid multiple db-slaves doing backups
 is_backup_target = node.dna['db_slaves'].first == (node['ec2'] && node['ec2']['local_hostname'] ? node['ec2']['local_hostname'] : hostname.stdout)
 
-if has_backups_enabled && (db_slaves_available && is_db_slave && is_backup_target || !db_slaves_available && is_db_master_or_solo)
+if has_backups_enabled && (db_slaves_available && is_backup_target || !db_slaves_available && is_db_master_or_solo)
   encryption_command = @encryption_command
 
   cron 'postgresql' do

--- a/cookbooks/ey-backup/recipes/postgres.rb
+++ b/cookbooks/ey-backup/recipes/postgres.rb
@@ -46,7 +46,7 @@ is_db_master_or_solo = ['db_master','solo'].include?(node.dna['instance_role'])
 is_db_slave          = 'db_slave' == node.dna['instance_role']
 is_first_slave       = node.dna['db_slaves'].first == (node['ec2'] && node['ec2']['local_hostname'] ? node['ec2']['local_hostname'] : hostname.stdout)
 
-if has_backups_enabled && (db_slaves_available && is_db_slave && is_first_slave || is_db_master_or_solo)
+if has_backups_enabled && (db_slaves_available && is_db_slave && is_first_slave || !db_slaves_available && is_db_master_or_solo)
   encryption_command = @encryption_command
 
   cron 'postgresql' do

--- a/cookbooks/ey-backup/recipes/postgres.rb
+++ b/cookbooks/ey-backup/recipes/postgres.rb
@@ -44,9 +44,10 @@ has_backups_enabled  = node.dna['backup_window'] != 0
 db_slaves_available  = node.dna['db_slaves'].any?
 is_db_master_or_solo = ['db_master','solo'].include?(node.dna['instance_role'])
 is_db_slave          = 'db_slave' == node.dna['instance_role']
-is_first_slave       = node.dna['db_slaves'].first == (node['ec2'] && node['ec2']['local_hostname'] ? node['ec2']['local_hostname'] : hostname.stdout)
 
-if has_backups_enabled && (db_slaves_available && is_db_slave && is_first_slave || !db_slaves_available && is_db_master_or_solo)
+is_backup_target     = node.dna['db_slaves'].first == (node['ec2'] && node['ec2']['local_hostname'] ? node['ec2']['local_hostname'] : hostname.stdout)
+
+if has_backups_enabled && (db_slaves_available && is_db_slave && is_backup_target || !db_slaves_available && is_db_master_or_solo)
   encryption_command = @encryption_command
 
   cron 'postgresql' do

--- a/cookbooks/ey-backup/recipes/postgres.rb
+++ b/cookbooks/ey-backup/recipes/postgres.rb
@@ -40,41 +40,26 @@ node.engineyard.environment['apps'].each do |app|
 	end
 end
 
-if node.dna['db_slaves'].empty? && node.dna['backup_window'] != 0
-  # No slaves detected, put the backup on the solo/db_master if backups are enabled
-  if ['db_master','solo'].include?(node.dna['instance_role'])
-    encryption_command = @encryption_command
+has_backups_enabled  = node.dna['backup_window'] != 0
+db_slaves_available  = node.dna['db_slaves'].any?
+is_db_master_or_solo = ['db_master','solo'].include?(node.dna['instance_role'])
+is_db_slave          = 'db_slave' == node.dna['instance_role']
+is_first_slave       = node.dna['db_slaves'].first == (node['ec2'] && node['ec2']['local_hostname'] ? node['ec2']['local_hostname'] : hostname.stdout)
 
-    backup_cron "postgresql" do
-      command "eybackup -e postgresql #{encryption_command} >> /var/log/eybackup.log 2>&1"
-      month   '*'
-      weekday '*'
-      day     '*'
-      hour    node['backup_hour']       # this attribute is set by ey-base/attributes/snapshot_and_backup_intervals.rb
-      minute  node['backup_minute']
-    end
+if has_backups_enabled && (db_slaves_available && is_db_slave && is_first_slave || is_db_master_or_solo)
+  encryption_command = @encryption_command
+
+  cron 'postgresql' do
+    command "eybackup -e postgresql #{encryption_command} >> /var/log/eybackup.log 2>&1"
+    month   '*'
+    weekday '*'
+    day     '*'
+    hour    node['backup_hour']     # this attribute is set by ey-base/attributes/snapshot_and_backup_intervals.rb
+    minute  node['backup_minute']
   end
-  # Slaves detected, put them on the db_slave if backups are enabled
 else
-  if ['db_slave'].include?(node.dna['instance_role']) && node.dna['backup_window'] != 0
-    db_slave1_fqdn=node.dna['db_slaves'].first
-    encryption_command = @encryption_command
-
-    hostname = Mixlib::ShellOut.new("hostname")
-    hostname.run_command
-
-    cron "postgresql" do
-      command "eybackup -e postgresql #{encryption_command} >> /var/log/eybackup.log 2>&1"
-      month   '*'
-      weekday '*'
-      day     '*'
-      hour    node['backup_hour']       # this attribute is set by ey-base/attributes/snapshot_and_backup_intervals.rb
-      minute  node['backup_minute']
-      only_if {(node['ec2'] && node['ec2']['local_hostname'] ? node['ec2']['local_hostname'] : hostname.stdout)  == db_slave1_fqdn}
-    end
-  else
-    cron "postgresql" do
-      action :delete
-    end
+  cron 'postgresql' do
+    user   cronjob_user
+    action :delete
   end
 end


### PR DESCRIPTION
This fixes #218 .

# Forever cron

I also think that the old code included a "race"-condition.

If `node.dna['backup_window']` was at some point positive, and then turned off, the old cronjob was never deleted.

```ruby
if node.dna['backup_window'] != 0 && ['db_master','solo'].include?(node.dna['instance_role'])
  encryption_command = @encryption_command
  backup_command = "eybackup -e mysql #{encryption_command} >> /var/log/eybackup.log 2>&1"

  cron "mysql" do
    command backup_command
    month   '*'
    weekday '*'
    day     '*'
    hour    node['backup_hour']     # this attribute is set by ey-base/attributes/snapshot_and_backup_intervals.rb
    minute  node['backup_minute']
  end
end
```

# Postgresql

I also simplified the Postgresql code.

# Request for comments

Let me know what you think.