### PR TITLE
CC-1206: Add a check for zombie DJ workers

### DIFF
--- a/cookbooks/delayed_job4/templates/default/dj.erb
+++ b/cookbooks/delayed_job4/templates/default/dj.erb
@@ -50,9 +50,15 @@ lock(){
   RESULT=0
   if [ -e $LOCK_FILE ]; then
     LAST_LOCK_PID=`cat $LOCK_FILE`
+    # Test if the lock file does not match a running process
     if [ -n $LAST_LOCK_PID -a -z "`ps axo pid|grep $LAST_LOCK_PID`" -a -f $LOCK_FILE ];then
       sleep 1
       logger -t "monit-dj:$WORKER[$$]" "Removing stale lock file for $WORKER ($LAST_LOCK_PID)"
+      rm $LOCK_FILE 2>&1
+    # Test if the lock file matches a running process, but it's a zombie
+    elif [ -n $LAST_LOCK_PID ] && [ ! -z `ps aux | grep $LAST_LOCK_PID | awk '{print $8}' | grep Z` ];then
+      sleep 1
+      logger -t "monit-dj:$WORKER[$$]" "Removing stale lock file for zombie $WORKER ($LAST_LOCK_PID)"
       rm $LOCK_FILE 2>&1
     else
       logger -t "monit-dj:$WORKER[$$]" "Monit already messing with $WORKER ($LAST_LOCK_PID)"


### PR DESCRIPTION
## Description of your patch

Properly recover when a DelayedJob worker was terminated and is lingering as a zombie process.

There is a bug here: https://github.com/engineyard/ey-cookbooks-stable-v5/blob/7310e1b6d22d94a352aa6c011f1200284c394d4a/cookbooks/delayed_job4/templates/default/dj.erb#L51-L62

The test 

```
if [ -n $LAST_LOCK_PID -a -z " ps axo pid|grep $LAST_LOCK_PID" -a -f $LOCK_FILE ];then 
``` 

tests if $LAST_LOCK_PID is defined and there’s no running process with that pid, but there is a lock file. It goes to the "Monit already messing with..." block if there is a running process, even if it's a zombie process. 

This PR adds an additional test to check if the PID matches a running process but the process is a zombie.

## Recommended Release Notes

Updates the delayed_job4 recipe to properly handle zombie workers

## Estimated risk

Low

## Components involved

DelayedJob custom chef recipe

## Description of testing done

See QA instructions

## QA Instructions

NOTE: These are the same as the QA instructions for PR #224. This PR can be tested with #224.

Test on configuration A_dj

Configuration A
 rails_activejob_example (delayed_job branch) App 
 Unicorn
 Ruby 2.3
 RubyGems 2.6.5
 Postgres 9.5
 US East Virginia
 Solo

Boot the test environment under the QA stack
Enable the delayed_job recipe. 
Modify the recipe to install DelayedJob on the solo instance
Modify the recipe and set a very low worker memory limit (e.g. low enough to always trigger the memory limit even with zero workload, e.g. 10MB)
Run chef
Observe the delayed_job processes by running `ps -ef | grep elay`
Make sure:
  - monit is terminating the DelayedJob process
  - new workers are being started
  - no orphan processes are being left behind