### PR TITLE
Deprecate configure_cluster in favor of new variable is_elasticsearch_instance

### DIFF
--- a/cookbooks/elasticsearch/attributes/default.rb
+++ b/cookbooks/elasticsearch/attributes/default.rb
@@ -7,10 +7,6 @@ default['elasticsearch'].tap do |elasticsearch|
   # Not recommended for production environments
   #elasticsearch['is_elasticsearch_instance'] = ( ['solo', 'app_master'].include?(node['dna']['instance_role']) )
 
-  # Set this to true if you're running more than one elasticsearch instance
-  # Set to false if you're running on a solo or app_master
-  elasticsearch['configure_cluster'] = true
-
   # Where to download and extract the installer
   elasticsearch['tmp_dir'] = '/tmp'
 

--- a/cookbooks/elasticsearch/recipes/default.rb
+++ b/cookbooks/elasticsearch/recipes/default.rb
@@ -8,7 +8,7 @@ ES = node['elasticsearch']
 
 include_recipe 'elasticsearch::download'
 include_recipe 'elasticsearch::install'
-if ES['is_elasticsearch_instance'] && ES['configure_cluster']
+if ES['is_elasticsearch_instance']
   include_recipe 'elasticsearch::configure_cluster'
   unless ES['version'].match(/^2/)
     include_recipe 'elasticsearch::configure_limits'

--- a/custom-cookbooks/elasticsearch/cookbooks/custom-elasticsearch/attributes/default.rb
+++ b/custom-cookbooks/elasticsearch/cookbooks/custom-elasticsearch/attributes/default.rb
@@ -7,10 +7,6 @@ default['elasticsearch'].tap do |elasticsearch|
   # Not recommended for production environments
   #elasticsearch['is_elasticsearch_instance'] = ( ['solo', 'app_master'].include?(node['dna']['instance_role']) )
 
-  # Set this to true if you're running more than one elasticsearch instance
-  # Set to false if you're running on a solo or app_master
-  elasticsearch['configure_cluster'] = true
-
   # Where to download and extract the installer
   elasticsearch['tmp_dir'] = '/tmp'
 


### PR DESCRIPTION
I think we should use `is_elasticsearch_instance` as a primary way of configuring where we install elasticsearch servers. 

This recipe does not support running elasticsearch on `solo` or `app_master` instances because of the guards setup in `install.rb`:

```ruby
  elasticsearch_hosts = []
  node['dna']['utility_instances'].each do |instance|
    if instance['name'].include?("elasticsearch_")
      elasticsearch_hosts << "#{instance['hostname']}:9200"
    end
  end
```