### PR TITLE
Upgrade to Passenger 5.1.8

### DIFF
--- a/cookbooks/passenger5/attributes/passenger5.rb
+++ b/cookbooks/passenger5/attributes/passenger5.rb
@@ -1,2 +1,2 @@
-default['passenger5']['version'] = '5.0.29'
+default['passenger5']['version'] = '5.1.8'
 default['passenger5']['port'] = "8000"


### PR DESCRIPTION
## Description of your patch

Updates Passenger to version 5.1.8

## Recommended Release Notes

Updates Passenger to version 5.1.8. This version fixes a number of bugs, and is backwards-compatible with Passenger 5.0.29. If you need to stay on Passenger 5.0.29, you can override the Passenger version by following the instructions here: https://github.com/engineyard/ey-cookbooks-stable-v5/wiki/Customizing-Your-Environment-Using-Overlay-Chef-Recipes

## Estimated risk

Medium

## Components involved

Passenger5 recipe

## Description of testing done

See QA instructions

## QA Instructions

Boot a solo and a cluster environment running Passenger 5. Verify that there are no chef errors, and `passenger -v` returns 5.1.8 on the solo/app_master/app instances.