### PR TITLE
DelayedJob: Fix zombie worker test

### DIFF
--- a/cookbooks/delayed_job4/templates/default/dj.erb
+++ b/cookbooks/delayed_job4/templates/default/dj.erb
@@ -56,7 +56,7 @@ lock(){
       logger -t "monit-dj:$WORKER[$$]" "Removing stale lock file for $WORKER ($LAST_LOCK_PID)"
       rm $LOCK_FILE 2>&1
     # Test if the lock file matches a running process, but it's a zombie
-    elif [ -n $LAST_LOCK_PID ] && [ ! -z `ps aux | grep $LAST_LOCK_PID | awk '{print $8}' | grep Z` ];then
+    elif [ -n $LAST_LOCK_PID ] && [ ! -z "`ps aux | grep $LAST_LOCK_PID | awk '{print $8}' | grep Z`" ];then
       sleep 1
       logger -t "monit-dj:$WORKER[$$]" "Removing stale lock file for zombie $WORKER ($LAST_LOCK_PID)"
       rm $LOCK_FILE 2>&1


### PR DESCRIPTION
This fixes a typo in https://github.com/engineyard/ey-cookbooks-stable-v5/pull/251. Test scenarios should remain the same as in PR #251 