### PR TITLE
CC-1210: Create portage mirror file

### DIFF
--- a/cookbooks/emerge/files/default/portage-mirror
+++ b/cookbooks/emerge/files/default/portage-mirror
@@ -1,0 +1,1 @@
+local http://cloud.distfiles.eygl.engineyard.com/2016.06

--- a/cookbooks/emerge/recipes/default.rb
+++ b/cookbooks/emerge/recipes/default.rb
@@ -1,3 +1,4 @@
 include_recipe 'emerge::make'
+include_recipe 'emerge::ensure_mirror'
 include_recipe 'emerge::sync'
 include_recipe 'emerge::update_portage'

--- a/cookbooks/emerge/recipes/ensure_mirror.rb
+++ b/cookbooks/emerge/recipes/ensure_mirror.rb
@@ -1,0 +1,6 @@
+cookbook_file "/etc/portage/mirrors" do
+  owner "root"
+  group "root"
+  mode 0700
+  source "portage-mirror"
+end


### PR DESCRIPTION
## Description of your patch

Create the portage mirror file

## Recommended Release Notes

None.

## Estimated risk

Medium. eix-sync can break if there's a typo on the created mirror file

## Components involved

Portage

## Description of testing done

See QA instructions

## QA Instructions

This can be tested along with other test cases.

1) New environment scenario
- Boot a cluster environment under the QA stack. 
- On all instances, verify that the `/etc/portage/mirrors` file exists and has the content: `local http://cloud.distfiles.eygl.engineyard.com/2016.06`
- Verify that all the instances ran chef without errors
- Add a new app instance and verify that the new instance did not encounter a chef error
- Add a new utility instance and verify that the new instance did not encounter a chef error

2) Upgrade scenario
- Boot a cluster environment under the latest V5 stack.
- On all instances, verify that `/etc/portage/mirrors` does not exist, or does not contain `local http://cloud.distfiles.eygl.engineyard.com/2016.06`
- Upgrade to the QA stack
- On all instances, verify that the `/etc/portage/mirrors` file exists and has the content: `local http://cloud.distfiles.eygl.engineyard.com/2016.06`
- Verify that all the instances ran chef without errors
- Add a new app instance and verify that the new instance did not encounter a chef error
- Add a new utility instance and verify that the new instance did not encounter a chef error