### PR TITLE
[memcached] Set the default version

### DIFF
--- a/custom-cookbooks/memcached/cookbooks/custom-memcached/attributes/default.rb
+++ b/custom-cookbooks/memcached/cookbooks/custom-memcached/attributes/default.rb
@@ -15,8 +15,8 @@ default['memcached'].tap do |memcached|
   memcached['install_from_source'] = false
 
   # If you're installing from the portage tree, the latest available version is 1.4.25
-  memcached['version'] = '1.4.34'
-  memcached['download_url'] = 'https://memcached.org/files/memcached-1.4.34.tar.gz'
+  memcached['version'] = '1.4.25'
+  # memcached['download_url'] = 'https://memcached.org/files/memcached-1.4.39.tar.gz'
 
   # Install memcached on a utility instance named 'memcached'
   memcached['install_type'] = 'NAMED_UTILS'


### PR DESCRIPTION
- Set the default version to the latest valid version available on the portage tree
- Disable the download_url setting - this is only used if install_from_source is set to true