### PR TITLE
HTTP/2

### DIFF
--- a/cookbooks/haproxy/attributes/haproxy.rb
+++ b/cookbooks/haproxy/attributes/haproxy.rb
@@ -1,1 +1,2 @@
 node.default.haproxy_version = '1.6.5'
+node.default.http2 = false

--- a/cookbooks/haproxy/recipes/configure.rb
+++ b/cookbooks/haproxy/recipes/configure.rb
@@ -64,7 +64,8 @@ managed_template "/etc/haproxy.cfg" do
     :http_bind_port => haproxy_http_port,
     :https_bind_port => haproxy_https_port,
     :httpchk_host => haproxy_httpchk_host,
-    :httpchk_path => haproxy_httpchk_path
+    :httpchk_path => haproxy_httpchk_path,
+    :http2 => node.http2
   })
 
   # We need to reload to activate any changes to the config

--- a/cookbooks/haproxy/templates/default/haproxy.cfg.erb
+++ b/cookbooks/haproxy/templates/default/haproxy.cfg.erb
@@ -68,8 +68,10 @@ defaults
   # and will add one if missing.
   option httpclose
 
+<% if !@http2 %>
   # Insert the X-Forwarded-For header for requests sent to the backend.
   option forwardfor
+<% end %>
 
   # If sending a request to one worker fails, try to send it to another, 3 times
   # before aborting the request
@@ -121,33 +123,79 @@ defaults
 
 listen cluster
   bind *:<%= @http_bind_port %> mss 1422
-  reqadd X-Forwarded-Proto:\ http
-
-  <% if @backends.any? %>
-    <% @backends.each_with_index do |instance, i| %>
-  server app-<%= i %> <%= instance['private_hostname'] %>:8081 check inter 5000 fastinter 1000 fall 1 weight <%= (instance['role'] == 'app_master') ? @app_master_weight : 50 %> # <%= instance['id'] %>
-    <% end %>
-  <% else %>
-    # It must be a solo.
-    server solo 127.0.0.1:8081 check inter 5000 fastinter 1000 fall 1 weight 50
-  <% end %>
-
-<% if Dir['/etc/nginx/ssl/*.pem'].reject {|filename| filename =~ /dhparam/}.count > 0 %>
-    listen clusterssl
-    bind *:443 mss 1422 ssl <%= Dir['/etc/nginx/ssl/*.pem'].reject {|filename| filename =~ /dhparam/}.collect {|pem| "crt #{pem}"}.join(" ") %>
-    reqadd X-Forwarded-Proto:\ https
+<% if @http2 %>
+    #redirect http=>https
+    redirect scheme https code 301 if !{ ssl_fc }
+<% else %>
+    reqadd X-Forwarded-Proto:\ http
 
     <% if @backends.any? %>
-    <% @backends.each_with_index do |instance, i| %>
-      server app-<%= i %> <%= instance['private_hostname'] %>:8081 check inter 5000 fastinter 1000 fall 1 weight <%= (instance['role'] == 'app_master') ? @app_master_weight : 50 %> # <%= instance['id'] %>
-    <% end %>
-    <% else %>
-        # It must be a solo.
-        server solo 127.0.0.1:8081 check inter 5000 fastinter 1000 fall 1 weight 50
+      <% @backends.each_with_index do |instance, i| %>
+    server app-<%= i %> <%= instance['private_hostname'] %>:8081 check inter 5000 fastinter 1000 fall 1 weight <%= (instance['role'] == 'app_master') ? @app_master_weight : 50 %> # <%= instance['id'] %>
       <% end %>
+    <% else %>
+      # It must be a solo.
+      server solo 127.0.0.1:8081 check inter 5000 fastinter 1000 fall 1 weight 50
+    <% end %>
+<% end %>
+
+
+
+<% if @http2 %>
+
+    listen clusterssl
+    mode tcp
+    bind *:443 mss 1422 ssl <%= Dir['/etc/nginx/ssl/*.pem'].reject {|filename| filename =~ /dhparam/}.collect {|pem| "crt #{pem}"}.join(" ") %>  alpn h2
+
+
+    use_backend nodes-http2 if { ssl_fc_alpn -i h2 }
+    default_backend nodes-http
+
+
+  backend nodes-http
+     
+      <% if @backends.any? %>
+      <% @backends.each_with_index do |instance, i| %>
+        server app-<%= i %> <%= instance['private_hostname'] %>:8089 check inter 5000 fastinter 1000 fall 1 weight <%= (instance['role'] == 'app_master') ? @app_master_weight : 50 %> # <%= instance['id'] %>
+      <% end %>
+      <% else %>
+          # It must be a solo.
+          server solo 127.0.0.1:8089 check inter 5000 fastinter 1000 fall 1 weight 50
+        <% end %>
+
+ backend nodes-http2
+      mode tcp
+
+      <% if @backends.any? %>
+      <% @backends.each_with_index do |instance, i| %>
+        server app-<%= i %> <%= instance['private_hostname'] %>:8081 check inter 5000 fastinter 1000 fall 1 weight <%= (instance['role'] == 'app_master') ? @app_master_weight : 50 %> send-proxy # <%= instance['id'] %>
+      <% end %>
+      <% else %>
+          # It must be a solo.
+          server solo 127.0.0.1:8081 check inter 5000 fastinter 1000 fall 1 weight 50 send-proxy
+        <% end %>
+    
+
 <% else %>
+    <% if Dir['/etc/nginx/ssl/*.pem'].reject {|filename| filename =~ /dhparam/}.count > 0 %>
+        listen clusterssl
+        bind *:443 mss 1422 ssl <%= Dir['/etc/nginx/ssl/*.pem'].reject {|filename| filename =~ /dhparam/}.collect {|pem| "crt #{pem}"}.join(" ") %>
+        reqadd X-Forwarded-Proto:\ https
+
+        <% if @backends.any? %>
+        <% @backends.each_with_index do |instance, i| %>
+          server app-<%= i %> <%= instance['private_hostname'] %>:8081 check inter 5000 fastinter 1000 fall 1 weight <%= (instance['role'] == 'app_master') ? @app_master_weight : 50 %> # <%= instance['id'] %>
+        <% end %>
+        <% else %>
+            # It must be a solo.
+            server solo 127.0.0.1:8081 check inter 5000 fastinter 1000 fall 1 weight 50
+          <% end %>
+    <% else %>
+
+    <% end %>
 
 <% end %>
+
 # TODO: ELB configuration
 
 listen lbtoworkers

--- a/cookbooks/nginx/attributes/default.rb
+++ b/cookbooks/nginx/attributes/default.rb
@@ -2,6 +2,7 @@ action = node.engineyard.metadata(:nginx_action,:restart)
 using_openssl_101 = (node.engineyard.metadata('openssl_ebuild_version','1.0.1') =~ /1\.0\.1/)
 default['nginx']['version'] = node.engineyard.metadata('nginx_ebuild_version','1.8.1-r1')
 default['nginx']['action'] = action
+default['nginx']['http2'] = false
 
 
 Chef::Log.info("Version: #{nginx[:version]}, Passenger Gem:#{nginx[:passenger_gem]}\n")

--- a/cookbooks/nginx/recipes/default.rb
+++ b/cookbooks/nginx/recipes/default.rb
@@ -234,7 +234,8 @@ php_webroot = node.engineyard.environment.apps.first['components'].find {|compon
             :fcgi_pass_port => fcgi_service[:fcgi_pass_port],
             :fcgi_mem_limit => fcgi_service[:fcgi_mem_limit],
             :fcgi_instance_count => fcgi_service[:fcgi_instance_count],
-            :use_msec => use_msec
+            :use_msec => use_msec,
+			:http2 => node['nginx']['http2']
           }
         }
       )
@@ -255,7 +256,8 @@ php_webroot = node.engineyard.environment.apps.first['components'].find {|compon
         :http_bind_port => nginx_http_port,
         :server_names => app.vhosts.first.domain_name.empty? ? [] : [app.vhosts.first.domain_name],
         :webroot => php_webroot,
-        :env_name => node.engineyard.environment[:name]
+        :env_name => node.engineyard.environment[:name],
+		:http2 => node['nginx']['http2']
       })
       notifies node['nginx'][:action], resources(:service => "nginx"), :delayed
     end

--- a/cookbooks/nginx/templates/default/common.proxy.conf.erb
+++ b/cookbooks/nginx/templates/default/common.proxy.conf.erb
@@ -15,3 +15,10 @@ proxy_set_header  X-Queue-Start     't=$start_time';
 
 proxy_redirect off;
 proxy_max_temp_file_size 0;
+
+
+
+<% if @http2 %>
+proxy_set_header  X-Forwarded-Proto "https";
+proxy_headers_hash_bucket_size 128;
+<% end %>

--- a/cookbooks/nginx/templates/default/server.conf.erb
+++ b/cookbooks/nginx/templates/default/server.conf.erb
@@ -20,7 +20,14 @@ upstream upstream_<%= @app_name %> {
 # Directive assigns configuration for the virtual server.
 server {
 # The listen directive specifies the address and port accepted by the enclosing server {...} block. It is possible to specify only an address, only a port, or a server name as the address.
+
+<% if @http2 %>
+  listen <%= @http_bind_port %> http2 proxy_protocol;
+  listen 8089;
+  real_ip_header proxy_protocol;
+<% else %>
   listen <%= @http_bind_port %>;
+<% end %>
 
   #
   # Server Names

--- a/custom-cookbooks/http2/README.md
+++ b/custom-cookbooks/http2/README.md
@@ -1,0 +1,5 @@
+# HTTP/2
+
+This example contains a `cookbooks/` directory to consume the cron cookbook for the v5 stack.
+
+See [cookbooks/custom-http2](cookbooks/custom-http2/README.md) for complete instructions.

--- a/custom-cookbooks/http2/cookbooks/custom-http2/README.md
+++ b/custom-cookbooks/http2/cookbooks/custom-http2/README.md
@@ -1,0 +1,53 @@
+# HTTP/2
+
+This recipe enables support for HTTP/2 on `nginx` and `haproxy`.
+
+`Haproxy` is configured to terminate SSL connection and forward HTTP/2 traffic to `nginx`. Browsers that do not support HTTP/2 are also supported by falling back to HTTP/1.1
+
+
+## Prerequisites
+
+
+### Nginx version >=1.9.5
+
+As of October 2017, defaul `nginx` version under V5 stack is `1.8.1-r1` which is not HTTP/2 compatible. You can use an [overlay recipe](https://github.com/engineyard/ey-cookbooks-stable-v5/wiki/Customizing-Your-Environment-Using-Overlay-Chef-Recipes#nginx-version) to install `nginx 1.12.1` which is HTTP/2 enabled.
+
+### SSL certicate
+
+An SSL certificate is required. Instructions on how to obtain and install an SSL certificate can be found [here](https://support.cloud.engineyard.com/hc/en-us/articles/205407488-Obtain-and-Install-SSL-Certificates-for-Applications)
+
+## Installation
+
+For simplicity, we recommend that you create the cookbooks directory at the root of your application. If you prefer to keep the infrastructure code separate from application code, you can create a new repository.
+
+Our main recipes have the `nginx` and `haproxy` recipes they are included by default but HTTP/2 protocol is disabled. To enable HTTP/2 you should copy this recipe `custom-http2`. You should not copy the actual `nginx` and `haproxy` recipes. These are managed by Engine Yard.
+
+1. Edit `cookbooks/ey-custom/recipes/after-main.rb` and add
+
+      ```
+      include_recipe 'custom-http2'
+      ```
+
+2. Edit `cookbooks/ey-custom/metadata.rb` and add
+
+      ```
+      depends 'custom-http2'
+      ```
+
+3. Copy `custom-cookbooks/http2/cookbooks/custom-http2 ` to `cookbooks/`
+
+      ```
+      cd ~ # Change this to your preferred directory. Anywhere but inside the application
+
+      git clone https://github.com/engineyard/ey-cookbooks-stable-v5
+      cd ey-cookbooks-stable-v5
+      cp custom-cookbooks/http2/cookbooks/custom-http2 /path/to/app/cookbooks/
+      ```
+
+4. Download the ey-core gem on your local machine and upload the recipes
+
+  ```
+  gem install ey-core
+  ey-core recipes upload --environment=<nameofenvironment> --file=<pathtocookbooksfolder> --apply
+  ```
+

--- a/custom-cookbooks/http2/cookbooks/custom-http2/attributes/default.rb
+++ b/custom-cookbooks/http2/cookbooks/custom-http2/attributes/default.rb
@@ -1,0 +1,2 @@
+default['nginx']['http2'] = true
+default['haproxy']['http2'] = true

--- a/custom-cookbooks/http2/cookbooks/custom-http2/metadata.rb
+++ b/custom-cookbooks/http2/cookbooks/custom-http2/metadata.rb
@@ -1,0 +1,11 @@
+name 'custom-http2'
+description 'Configure haproxy/nginx to use http2 on Engine Yard'
+long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
+maintainer 'Engine Yard'
+maintainer_email 'support@engineyard.com'
+version '1.0'
+issues_url 'https://github.com/engineyard/ey-cookbooks-stable-v5/issues'
+source_url 'https://github.com/engineyard/ey-cookbooks-stable-v5'
+
+depends 'nginx'
+depends 'haproxy'

--- a/custom-cookbooks/http2/cookbooks/custom-http2/recipes/default.rb
+++ b/custom-cookbooks/http2/cookbooks/custom-http2/recipes/default.rb
@@ -1,0 +1,2 @@
+include_recipe 'nginx'
+include_recipe 'haproxy'

--- a/custom-cookbooks/http2/cookbooks/ey-custom/metadata.rb
+++ b/custom-cookbooks/http2/cookbooks/ey-custom/metadata.rb
@@ -1,0 +1,3 @@
+name "ey-custom"
+
+depends "custom-http2"

--- a/custom-cookbooks/http2/cookbooks/ey-custom/recipes/after-main.rb
+++ b/custom-cookbooks/http2/cookbooks/ey-custom/recipes/after-main.rb
@@ -1,0 +1,1 @@
+include_recipe "custom-http2"


### PR DESCRIPTION
#### Description of your patch
Adding HTTP/2 support on haproxy/nginx

#### Recommended Release Notes
This update adds HTTP/2 support under V5 platform.

#### Estimated risk
High (as it affects nginx/haproxy installation configuration)

#### Components involved
README

#### Description of testing done
See QA instructions

#### QA Instructions
1. Boot new environment under `to_do` app
2. Obtain and install an SSL certificate. Use https://www.sslforfree.com/ which is a wrapper for `Let's Encrypt`
3. Add `custom-http2` recipe
4. Browse to `to_do` app, use Chrome's "Inspect => Network" to verify that Protocol is set to "h2" (add Protocol column to your view)
