### PR TITLE
Remove application restarts

### DIFF
--- a/cookbooks/cdn_distribution/attributes/default.rb
+++ b/cookbooks/cdn_distribution/attributes/default.rb
@@ -1,12 +1,3 @@
 default['cdn_distribution'].tap do |e|
-
-  # If you want to restart the application during the chef run, set this to true
-  #
-  # NOTE: This will restart your application on ALL app instances at the same time
-  #
-  # A better way is schedule a maintenance window,
-  # during which you will iterate through all the application instances and run:
-  # /engineyard/bin/app_<application_name> restart
-  #
-  e['perform_restart'] = false
+  # Put configurable attributes for the recipe here
 end

--- a/cookbooks/cdn_distribution/recipes/default.rb
+++ b/cookbooks/cdn_distribution/recipes/default.rb
@@ -5,10 +5,8 @@
 
 if %w[solo app app_master].include?(node['dna']['instance_role'])
   ssh_username = node['dna']['engineyard']['environment']['ssh_username']
-  perform_restart = node['cdn_distribution']['perform_restart']
 
   node.engineyard.apps.each do |app|
-
     cdn_distribution = app.metadata('cdn_distribution', nil)
 
     if cdn_distribution
@@ -19,22 +17,13 @@ if %w[solo app app_master].include?(node['dna']['instance_role'])
         group ssh_username
         recursive true
       end
-      
+
       template "#{base_dir}/cdn.rb" do
         source "cdn.initializer.erb"
         owner ssh_username
         group ssh_username
         mode 0744
         variables(:asset_host => cdn_distribution['domain'])
-        if perform_restart
-          notifies :run, "execute[restart_#{app.name}]", :delayed
-        end
-      end
-
-      execute "restart_#{app.name}" do
-        command "if [ -d /data/#{app.name}/current ]; then /engineyard/bin/app_#{app.name} restart; fi"
-        user ssh_username
-        action :nothing
       end
     end
   end

--- a/cookbooks/env_vars/attributes/default.rb
+++ b/cookbooks/env_vars/attributes/default.rb
@@ -1,12 +1,3 @@
 default['env_vars'].tap do |e|
-
-  # If you want to restart the application during the chef run, set this to true
-  #
-  # NOTE: This will restart your application on ALL app instances at the same time
-  #
-  # A better way is schedule a maintenance window,
-  # during which you will iterate through all the application instances and run:
-  # /engineyard/bin/app_<application_name> restart
-  #
-  e['perform_restart'] = false
+  # Put configurable attributes for the recipe here
 end

--- a/cookbooks/env_vars/recipes/cloud.rb
+++ b/cookbooks/env_vars/recipes/cloud.rb
@@ -5,7 +5,6 @@
 
 if %w[solo app app_master util].include?(node['dna']['instance_role'])
   ssh_username = node['dna']['engineyard']['environment']['ssh_username']
-  perform_restart = node['env_vars']['perform_restart']
 
   node['dna']['engineyard']['environment']['apps'].each do |app_data|
     app_name = app_data['name']
@@ -17,15 +16,6 @@ if %w[solo app app_master util].include?(node['dna']['instance_role'])
       mode 0744
       variables(:environment_variables => fetch_environment_variables(app_data))
       helpers(EnvVars::Helper)
-
-      notifies :run, "execute[restart_#{app_name}]", :delayed
-    end
-
-    execute "restart_#{app_name}" do
-      command "/engineyard/bin/app_#{app_name} restart"
-      user ssh_username
-      action :nothing
-      only_if { perform_restart && ::File.exist?("/data/#{app_name}/current") && ::File.exist?("/engineyard/bin/app_#{app_name}")}
     end
   end
 end

--- a/cookbooks/env_vars/recipes/default.rb
+++ b/cookbooks/env_vars/recipes/default.rb
@@ -6,7 +6,6 @@
 if ['solo', 'app', 'app_master', 'util'].include?(node['dna']['instance_role'])
 
   ssh_username = node['dna']['engineyard']['environment']['ssh_username']
-  perform_restart = node['env_vars']['perform_restart']
 
   node['dna']['applications'].each do |app_name, data|
     cookbook_file "/data/#{app_name}/shared/config/env.custom" do
@@ -15,12 +14,6 @@ if ['solo', 'app', 'app_master', 'util'].include?(node['dna']['instance_role'])
       owner ssh_username
       group ssh_username
       mode 0744
-    end
-
-    execute "/engineyard/bin/app_#{app_name} restart" do
-      action :run
-      user ssh_username
-      only_if { perform_restart && ::File.exist?("/data/#{app_name}/current") && ::File.exist?("/engineyard/bin/app_#{app_name}")}
     end
   end
 

--- a/custom-cookbooks/env_vars/cookbooks/custom-env_vars/README.md
+++ b/custom-cookbooks/env_vars/cookbooks/custom-env_vars/README.md
@@ -46,10 +46,4 @@ All customizations go to `cookbooks/custom-env_vars/attributes/default.rb`.
 
 Every time you update `env.custom`, you need to restart the application. A Unicorn or Puma hot restart will not do; you need to start a new master process that has sourced the updated `env.custom` file.
 
-If you want to restart the application during the chef run, set `perform_restart` to true:
-
-```
-e['perform_restart'] = true
-```
-
-NOTE: We do not recommend using this for production environments. For production, you can cycle through the instances and run `/engineyard/bin/app_<application_name> restart` on each one.
+To restart the application, you can cycle through the application instances and run `/engineyard/bin/app_<application_name> restart` on each one.

--- a/custom-cookbooks/env_vars/cookbooks/custom-env_vars/attributes/default.rb
+++ b/custom-cookbooks/env_vars/cookbooks/custom-env_vars/attributes/default.rb
@@ -1,12 +1,3 @@
 default['env_vars'].tap do |e|
-
-  # If you want to restart the application during the chef run, set this to true
-  #
-  # NOTE: This will restart your application on ALL app instances at the same time
-  #
-  # A better way is schedule a maintenance window,
-  # during which you will iterate through all the application instances and run:
-  # /engineyard/bin/app_<application_name> restart
-  #
-  e['perform_restart'] = false
+  # Put configurable attributes for the recipe here
 end


### PR DESCRIPTION
Customers expect our chef runs to be "safe" and expect that in general there is no risk of causing a downtime when running chef. Doing the application restart in chef will do a near-simultaneous restart across all application instances, which will almost certainly cause downtime.

This PR removes the application restarts from the chef recipes. For recipes that need an application restart, e.g. env_vars and cdn_distribution, we should (1) clarify that a restart is needed for the change to take effect, and (2) provide instructions on how to do a staggered restart in the README.