### PR TITLE
CC-1189: Overlay ey-backup attributes to move MySQL backup to DB slave.

### DIFF
--- a/cookbooks/ey-backup/attributes/default.rb
+++ b/cookbooks/ey-backup/attributes/default.rb
@@ -1,0 +1,2 @@
+default['db_backup']['mysql']['backup_slave'] = false
+# default['db_backup']['mysql']['db_slave_name'] = 'backup'

--- a/cookbooks/ey-backup/recipes/mysql.rb
+++ b/cookbooks/ey-backup/recipes/mysql.rb
@@ -41,7 +41,13 @@ node.engineyard.environment['apps'].each do |app|
 	end
 end
 
-if node.dna['backup_window'] != 0 && ['db_master','solo'].include?(node.dna['instance_role'])
+is_backup_instance = if node['db_backup']['mysql']['backup_slave']
+  ['db_slave'].include?(node.dna['instance_role']) && node['db_backup']['mysql']['db_slave_name'] == node['dna']['name']
+else
+  ['db_master','solo'].include?(node.dna['instance_role'])
+end
+
+if node.dna['backup_window'] != 0 && is_backup_instance
   encryption_command = @encryption_command
   backup_command = "eybackup -e mysql #{encryption_command} >> /var/log/eybackup.log 2>&1"
 

--- a/custom-cookbooks/db-backup/README.md
+++ b/custom-cookbooks/db-backup/README.md
@@ -1,0 +1,3 @@
+# DB Backup in Slave (MySQL only)
+
+This example contains a complete `cookbooks/` directory that you can use on the stable-v5 stack that will override the backup location of MySQL, moving it from the DB Master to a DB Slave named "backup".

--- a/custom-cookbooks/db-backup/cookbooks/ey-backup/attributes/default.rb
+++ b/custom-cookbooks/db-backup/cookbooks/ey-backup/attributes/default.rb
@@ -1,0 +1,2 @@
+default['db_backup']['mysql']['backup_slave'] = true
+default['db_backup']['mysql']['db_slave_name'] = 'backup'


### PR DESCRIPTION
Description of your patch
-------------

Adds attributes/default.rb to the ey-backup cookbook that determines if the MySQL backup is setup on the master (default) or replica. A sample cookbook in custom-cookbooks is provided to move it to replica.

Recommended Release Notes
-------------

MySQL backup location is now configurable through attributes overlay.

Estimated risk
-------------

Medium - changes the ey-backup/recipes/mysql.rb that's used it many existing environments.

Components involved
-------------

MySQL backup

Description of testing done
-------------

I setup a test environment running stack stable-v5-3.0.32. I used the custom-cookbooks/db-backup/cookbooks/ey-backup as the base custom cookbook. Then, I had to copy cookbooks/ey-lib due to recent RDS-related changes that's not yet released in stable-v5-3.0.32. After running chef, MySQL backup cron job was removed from the master and added to the replica, as expected. Removing this custom cookbook reverted the change.

QA Instructions
-------------

TODO (after code review, in case there are major changes needed)
