### PR TITLE
DelayedJob4: Resolves #284

### DIFF
--- a/cookbooks/delayed_job4/templates/default/dj.monitrc.erb
+++ b/cookbooks/delayed_job4/templates/default/dj.monitrc.erb
@@ -1,6 +1,6 @@
 check process <%= @worker_name %>
   with pidfile /var/run/engineyard/dj/<%= @app_name %>/dj_<%= @worker_name %>.pid
-  start program = "/engineyard/custom/dj <%= @app_name %> start <%= @framework_env %> <%= @worker_name %>" with timeout 60 seconds
-  stop program = "/engineyard/custom/dj <%= @app_name %> stop <%= @framework_env %> <%= @worker_name %>" with timeout 60 seconds
+  start program = "/engineyard/custom/dj <%= @app_name %> start <%= @framework_env %> <%= @worker_name %>" with timeout 90 seconds
+  stop program = "/engineyard/custom/dj <%= @app_name %> stop <%= @framework_env %> <%= @worker_name %>" with timeout 90 seconds
   if totalmem is greater than <%= @worker_memory %> MB then restart # eating up memory?
   group dj_<%= @app_name %>


### PR DESCRIPTION
## Description of your patch

monit's default timeout of 60s for the DJ stop command is the same as the timeout used when terminating a dj worker. As a result, if the dj worker is unresponsive, monit's stop command times out and the worker does not get terminated. This patch updates the default monit timeout to make it higher than the worker timeout.

## Recommended Release Notes

Sets the monit stop timeout to a higher value to ensure that dj worker processes are terminated when they hit the monit memory limit.

## Estimated risk

Low

## Components involved

DelayedJob custom chef recipe

## Description of testing done

See QA instructions

## QA Instructions

Test on configuration A_dj

Configuration A
 rails_activejob_example (delayed_job branch) App 
 Unicorn
 Ruby 2.3
 RubyGems 2.6.5
 Postgres 9.5
 US East Virginia
 Solo

Boot the test environment under the current stable-v5 stack
Enable the delayed_job recipe
Modify the recipe to install DelayedJob on the solo instance
Create a worker class that executes a job that takes more than 1 minute
Populate the jobs database with hundreds of these jobs. This way when monit attempts to terminate DJ on the next step, the worker will be unresponsive
Modify the recipe and set a very low worker memory limit (e.g. low enough to always trigger the memory limit even with zero workload, e.g. 10MB)
Run chef
tail -f /var/log/syslog
Verify:
  - monit is attempting terminate the DelayedJob process
  - the worker does not get terminated as monit times out before the worker process is killed
Upgrade to the QA stack
Verify:
  - monit is attempting terminate the DelayedJob process
  - the worker gets killed before monit times out