### PR TITLE
CC-1188: Allow specifying instances to run for Papertrail.

### DIFF
--- a/cookbooks/papertrail/attributes/default.rb
+++ b/cookbooks/papertrail/attributes/default.rb
@@ -17,5 +17,7 @@ default['papertrail'].tap do |papertrail|
   papertrail['exclude_patterns']      = [  
     '400 0 "-" "-" "-', # seen in ssl access logs
   ]
+  # Install Papertrail to all instances by default
+  papertrail['is_papertrail_instance'] = true
 end
 

--- a/custom-cookbooks/papertrail/cookbooks/custom-papertrail/README.md
+++ b/custom-cookbooks/papertrail/cookbooks/custom-papertrail/README.md
@@ -51,6 +51,20 @@ If you do not have `cookbooks/ey-custom` on your app repository, you can copy
 
 All customizations go to `cookbooks/custom-papertrail/attributes/default.rb`.
 
+### Choose the instances that run the recipe
+
+By default, the papertrail recipe configures all instances in the environment. You can change this using `node['dna']['instance_role']` and `node['dna']['instance_role'] `.
+
+```ruby
+# this is the default
+default['papertrail']['is_papertrail_instance'] = true
+
+# run the recipe on a utility instance named papertrail (see comments in custom-papertrail/attributes/default.rb)
+default['papertrail']['is_papertrail_instance'] = (node['dna']['instance_role'] == 'util' && node['dna']['name'] == 'papertrail')
+
+# run the recipe on a solo instance
+default['papertrail']['is_papertrail_instance'] = (node['dna']['instance_role'] == 'solo')
+```
 
 ### Specify the logs to monitor
 

--- a/custom-cookbooks/papertrail/cookbooks/custom-papertrail/attributes/default.rb
+++ b/custom-cookbooks/papertrail/cookbooks/custom-papertrail/attributes/default.rb
@@ -3,3 +3,4 @@
 #
 # default['papertrail']['destination_host'] = 'host1.papertrailapp.com'
 # default['papertrail']['port'] = 1235
+# default['papertrail']['is_papertrail_instance'] = (node['dna']['instance_role'] == 'util' && node['dna']['name'] == 'papertrail')


### PR DESCRIPTION
Description of your patch
-------------

Add new attribute for Papertrail cookbook to specify instances where it will run. Update custom-papertrail README to explain this customization.

Fixes #217.

Recommended Release Notes
-------------

Papertrail cookbook can now be configured to only setup in certain instances.

Estimated risk
-------------

Low - only affects environments with papertrail enabled.

Components involved
-------------

Papertrail (syslog services)

Description of testing done
-------------

Setup a cluster (app master, db master, utility named "papertrail"), and enabled added custom-papertrail recipe. By default, Papertrail is setup in all instances.

Then, I manually updated cookbooks/papertrail for the new changes, and updated cookbooks/custom-papertrail to specify it to run only in a utility instance named "papertrail". For testing, additional logging was added to cookbooks/papertrail/recipes/default.rb, and an `else` condition was added with logging to confirm that the recipe is skipping the `if` block (the main content of the recipe).

QA Instructions
-------------

TODO
