### PR TITLE
CC-1217: Initial version of the New Relic Infra recipe

### DIFF
--- a/cookbooks/newrelic_infra/README.md
+++ b/cookbooks/newrelic_infra/README.md
@@ -1,0 +1,7 @@
+# New Relic Infrastructure
+
+This recipe is used to setup the New Relic Infrastructure agent on the stable-v5 stack.
+
+The newrelic_infra recipe is managed by Engine Yard. You should not copy this recipe to your repository but instead copy custom-newrelic_infra. Please check the [custom-newrelic_infra readme](../../custom-cookbooks/newrelic_infra/cookbooks/custom-newrelic_infra) for the complete instructions.
+
+We accept contributions for changes that can be used by all customers.

--- a/cookbooks/newrelic_infra/attributes/default.rb
+++ b/cookbooks/newrelic_infra/attributes/default.rb
@@ -1,0 +1,3 @@
+default['newrelic_infra']['license_key'] = "INSERT_NEW_RELIC_INFRA_KEY"
+default['newrelic_infra']['package_version'] = "1.0.785"
+default['newrelic_infra']['logfile'] = "/var/log/newrelic/newrelic-infra.log"

--- a/cookbooks/newrelic_infra/files/default/newrelic_infra.monitrc
+++ b/cookbooks/newrelic_infra/files/default/newrelic_infra.monitrc
@@ -1,0 +1,5 @@
+check process newrelic_infra
+  with pidfile /var/run/newrelic-infra.pid
+  start program = "/etc/init.d/newrelic-infra start"
+  stop program = "/etc/init.d/newrelic-infra stop"
+  group newrelic_infra

--- a/cookbooks/newrelic_infra/metadata.rb
+++ b/cookbooks/newrelic_infra/metadata.rb
@@ -1,0 +1,6 @@
+name 'newrelic_infra'
+maintainer 'Engine Yard'
+maintainer_email 'support@engineyard.com'
+version '1.0'
+source_url 'https://engineyard.com'
+issues_url 'https://support.engineyard.com'

--- a/cookbooks/newrelic_infra/recipes/default.rb
+++ b/cookbooks/newrelic_infra/recipes/default.rb
@@ -1,0 +1,79 @@
+#
+# Cookbook Name: newrelic_infra
+# Recipe:: default
+#
+
+package_version = node['newrelic_infra']['package_version']
+
+deb_file = "newrelic-infra_sysv_#{package_version}_amd64.deb"
+deb_url = "http://download.newrelic.com/infrastructure_agent/linux/apt/pool/main/n/newrelic-infra/#{deb_file}"
+data_file = "data.tar.gz"
+
+tmp_path = "/tmp"
+local_work_path = File.join(tmp_path, "newrelic_infra")
+local_deb_path = File.join(local_work_path, deb_file)
+local_tar_path = File.join(local_work_path, data_file)
+
+daemon_already_installed = "ls /usr/bin/newrelic-infra && /usr/bin/newrelic-infra -version | grep #{package_version}"
+
+directory local_work_path do
+  owner "root"
+  group "root"
+  mode 0755
+end
+
+remote_file local_deb_path do
+  source deb_url
+  mode 0644
+  not_if "ls #{local_deb_path}"
+end
+
+execute "Extract deb file" do
+  command "ar x #{deb_file}"
+  cwd local_work_path
+  user "root"
+  action :run
+  not_if daemon_already_installed
+end
+
+execute "Install data.tar.gz" do
+  command "tar zxvf #{local_tar_path} -C /"
+  cwd local_work_path
+  user "root"
+  action :run
+  not_if daemon_already_installed
+end
+
+template "/etc/init.d/newrelic-infra" do
+  source "newrelic-infra.erb"
+  owner "root"
+  group "root"
+  mode 0755
+  backup false
+  variables({
+    :logfile => node['newrelic_infra']['logfile']
+  })
+end
+
+template "/etc/newrelic-infra.yml" do
+  source "newrelic-infra.yml.erb"
+  owner "root"
+  group "root"
+  mode 0600
+  backup false
+  variables({
+    :license_key => node['newrelic_infra']['license_key']
+  })
+end
+
+cookbook_file "/etc/monit.d/newrelic_infra.monitrc" do
+  source "newrelic_infra.monitrc"
+  owner "root"
+  group "root"
+  mode "0644"
+  backup false
+end
+
+execute "monit reload" do
+  action :run
+end

--- a/cookbooks/newrelic_infra/templates/default/newrelic-infra.erb
+++ b/cookbooks/newrelic_infra/templates/default/newrelic-infra.erb
@@ -1,0 +1,34 @@
+#!/sbin/runscript
+#
+# Engine Yard sample init script for newrelic-infra
+# This script is created by the newrelic_infra recipe
+# This overwrites the original newrelic-infra init script from New Relic
+
+NAME=newrelic-infra
+PIDFILE="/var/run/$NAME.pid"
+DAEMON=/usr/bin/$NAME
+LOGFILE=<%= @logfile %>
+
+depend() {
+    use net
+}
+
+start() {
+    ebegin "Starting newrelic-infra"
+    start-stop-daemon --start \
+        --nicelevel 0 \
+        --quiet \
+        --background \
+        --exec $DAEMON \
+        --make-pidfile \
+        --pidfile $PIDFILE \
+        --stdout $LOGFILE \
+        --stderr $LOGFILE
+    eend $?
+}
+
+stop() {
+    ebegin "Stopping newrelic-infra"
+    start-stop-daemon --stop --pidfile $PIDFILE
+    eend $?
+}

--- a/cookbooks/newrelic_infra/templates/default/newrelic-infra.yml.erb
+++ b/cookbooks/newrelic_infra/templates/default/newrelic-infra.yml.erb
@@ -1,0 +1,1 @@
+license_key: <%= @license_key %>

--- a/custom-cookbooks/newrelic_infra/README.md
+++ b/custom-cookbooks/newrelic_infra/README.md
@@ -1,0 +1,5 @@
+# New Relic Infrastructure
+
+This example contains a complete cookbooks/ that you can use on the stable-v5 stack.
+
+See https://github.com/engineyard/ey-cookbooks-stable-v5/tree/next-release/custom-cookbooks/newrelic_infra/cookbooks/custom-newrelic_infra for complete instructions.

--- a/custom-cookbooks/newrelic_infra/cookbooks/custom-newrelic_infra/README.md
+++ b/custom-cookbooks/newrelic_infra/cookbooks/custom-newrelic_infra/README.md
@@ -1,0 +1,56 @@
+# Custom New Relic Infrastructure
+
+The newrelic_infra recipe sets up the New Relic Infrastructure agent and a monit config file. This will install the agent in all instances in the environment.
+
+## Installation
+
+For simplicity, we recommend that you create the cookbooks directory at the root of your application. If you prefer to keep the infrastructure code separate from application code, you can create a new repository.
+
+Our main recipes have the `newrelic_infra` recipe but it is not included by default. To use the `newrelic_infra` recipe, you should copy this recipe `custom-newrelic_infra`. You should not copy the actual `newrelic_infra` recipe. That is managed by Engine Yard.
+
+1. Edit `cookbooks/ey-custom/recipes/after-main.rb` and add
+
+      ```
+      include_recipe 'custom-newrelic_infra'
+      ```
+
+2. Edit `cookbooks/ey-custom/metadata.rb` and add
+
+      ```
+      depends 'custom-newrelic_infra'
+      ```
+
+3. Copy `custom-cookbooks/newrelic_infra/cookbooks/custom-newrelic_infra` to `cookbooks/`
+
+      ```
+      cd ~ # Change this to your preferred directory. Anywhere but inside the application
+
+      git clone https://github.com/engineyard/ey-cookbooks-stable-v5
+      cd ey-cookbooks-stable-v5
+      cp custom-cookbooks/newrelic_infra/cookbooks/custom-newrelic_infra /path/to/app/cookbooks/
+      ```
+
+If you do not have `cookbooks/ey-custom` on your app repository, you can copy `custom-cookbooks/newrelic_infra/cookbooks/ey-custom` to `/path/to/app/cookbooks`.
+
+## Customizations
+
+All customizations go to `cookbooks/custom-newrelic_infra/attributes/default.rb`.
+
+### License Key
+
+Please make sure to specify the license key in custom-newrelic_infra/attributes/default.rb:
+
+```ruby
+# Replace value with actual license key
+default['newrelic_infra']['license_key'] = "INSERT_NEW_RELIC_INFRA_KEY"
+```
+
+This will be used in generating /etc/newrelic-infra.yml.
+
+### Package Version
+
+The recipe downloads the New Relic Infrastructure .deb package version as specified in the attributes/default.rb. Please update the version number as necessary:
+
+```ruby
+default['newrelic_infra']['package_version'] = "1.0.785"
+```

--- a/custom-cookbooks/newrelic_infra/cookbooks/custom-newrelic_infra/attributes/default.rb
+++ b/custom-cookbooks/newrelic_infra/cookbooks/custom-newrelic_infra/attributes/default.rb
@@ -1,0 +1,5 @@
+# default['newrelic_infra']['license_key'] = "INSERT_NEW_RELIC_INFRA_KEY"
+# default['newrelic_infra']['package_version'] = "1.0.785"
+# default['newrelic_infra']['logfile'] = "/var/log/newrelic/newrelic-infra.log"
+
+default['newrelic_infra']['license_key'] = "STILL_NOT_A_LICENSE_KEY"

--- a/custom-cookbooks/newrelic_infra/cookbooks/custom-newrelic_infra/metadata.rb
+++ b/custom-cookbooks/newrelic_infra/cookbooks/custom-newrelic_infra/metadata.rb
@@ -1,0 +1,3 @@
+name 'custom-newrelic_infra'
+
+depends 'newrelic_infra'

--- a/custom-cookbooks/newrelic_infra/cookbooks/custom-newrelic_infra/recipes/default.rb
+++ b/custom-cookbooks/newrelic_infra/cookbooks/custom-newrelic_infra/recipes/default.rb
@@ -1,0 +1,1 @@
+include_recipe 'newrelic_infra'

--- a/custom-cookbooks/newrelic_infra/cookbooks/ey-custom/metadata.rb
+++ b/custom-cookbooks/newrelic_infra/cookbooks/ey-custom/metadata.rb
@@ -1,0 +1,3 @@
+name 'ey-custom'
+
+depends 'custom-newrelic_infra'

--- a/custom-cookbooks/newrelic_infra/cookbooks/ey-custom/recipes/after-main.rb
+++ b/custom-cookbooks/newrelic_infra/cookbooks/ey-custom/recipes/after-main.rb
@@ -1,0 +1,1 @@
+include_recipe 'custom-newrelic_infra'


### PR DESCRIPTION
Description of your patch
-------------

Initial version of the New Relic Infrastructure recipe. The recipe installs the New Relic Infrastructure agent in all the instances in the environment by downloading the .deb, extracting its contents, rewriting the init script, installing monit control file and reloading monit.

Recommended Release Notes
-------------

Adds a custom chef recipe to setup the New Relic Infrastructure agent.

Estimated risk
-------------

Low - only affects customers who enable the custom-newrelic_infra recipe.

Components involved
-------------

newrelic-infra

Description of testing done
-------------

Tested on a simple cluster: one app master, one db master. Verified the following:

* .deb file is downloaded and extracted
* Ran `/usr/bin/newrelic-infra` -version to report version of installed agent
* Reviewed the contents of /etc/init.d/newrelic-infra
* Check /etc/newrelic-infra.yml contains the license key (dummy) value in custom-newrelic_infra/attributes/default.rb.
* Check that the monit.d file is generated, and that monit is reloaded
* Because the license key is dummy, /var/log/newrelic/newrelic-infra.log contains an error message that license key is invalid.

QA testing should use a valid license key by starting a Trial period for New Relic Infrastructure.

QA Instructions
-------------

Have a New Relic account, and request for the Trial of New Relic Infrastructure.

TODO
