### PR TITLE
add configuration settings for timezone to Postgres replicas

### DIFF
--- a/cookbooks/postgresql/recipes/server_configure.rb
+++ b/cookbooks/postgresql/recipes/server_configure.rb
@@ -74,6 +74,10 @@ directory postgres_temp do
     recursive true
 end
 
+zone = "#{node.engineyard.environment['timezone']}"
+zonepath = "/usr/share/zoneinfo/#{zone}"
+timezone = (File.exists?(zonepath) and !zone.empty? ) ? zone : 'GMT'
+
 if ['solo', 'db_master'].include?(node.dna['instance_role'])
   ey_cloud_report "configuring postgresql 9" do
     message "processing postgresql #{postgres_version} configuration"
@@ -93,10 +97,6 @@ if ['solo', 'db_master'].include?(node.dna['instance_role'])
     user "postgres"
     not_if { FileTest.directory?("#{postgres_root}/#{postgres_version}/data") }
   end
-  
-  zone = "#{node.engineyard.environment['timezone']}"
-  zonepath = "/usr/share/zoneinfo/#{zone}"
-  timezone = (File.exists?(zonepath) and !zone.empty? ) ? zone : 'GMT'
 
   template "#{postgres_root}/#{postgres_version}/data/postgresql.conf" do
     source "postgresql.conf.erb"
@@ -180,7 +180,8 @@ if ['db_slave'].include?(node.dna['instance_role'])
       :postgres_root => postgres_root,
       :postgres_version => postgres_version,
       :hot_standby => "on",
-      :archive_timeout => '0'
+      :archive_timeout => '0',
+      :timezone => timezone
     )
   end
 


### PR DESCRIPTION
Description of your patch
--------------
Fixup default timezone setting for Postgres replicas.

Recommended Release Notes
--------------
Hotfix: corrects timezone controls for PostgreSQL replicas

Estimated risk
--------------

Low
- Nothing is changed if the timezone is unrecognized or not present.

Components involved
--------------

$ git diff next-release --name-only
cookbooks/postgresql9/recipes/server_configure.rb

Description of testing done
--------------
Under the 16.06 stack

- Provisioned a cluster using the updated stack
- Verified cookbooks completed successfully
- Created a replica database, and against the replica:
- Verified the current timezone with `psql -c 'show timezone'` showed a value of `GMT`
- Added an attribute `"timezone": "America/Anchorage"` in `/etc/chef/dna.json` under `"engineyard":"environment"`
- Ran chef cached using `PATH=/usr/local/ey_resin/bin ey-enzyme --cached --verbose --chef-bin /usr/local/ey_resin/bin/chef-solo`
- Verified the timezone with `psql -c 'show timezone'` showed a value of `America/Anchorage`
- Added an attribute `"timezone": "Gorgonzola"` in `/etc/chef/dna.json` under `"engineyard":"environment"`
- Ran chef cached using `PATH=/usr/local/ey_resin/bin/:$PATH /usr/local/ey_resin/bin/chef-solo -j /etc/chef/dna.json -c /etc/chef/solo.rb`
- Verified chef raised an exception indicating that `"Timezone 'Gorgonzola' not recognized."` and `psql -c 'show timezone'` showed a value of `America/Anchorage`

QA Instructions
--------------

Using the 16.06 stack boot a solo and repeat verify as above. For running chef with cached data you'll need to use the command `PATH=/usr/local/ey_resin/bin/:$PATH /usr/local/ey_resin/bin/chef-solo -j /etc/chef/dna.json -c /etc/chef/solo.rb`.