### PR TITLE
fixup to remove PGHOST entry from .bash_login; this can block replica promotions

### DIFF
--- a/cookbooks/postgresql/recipes/client_config.rb
+++ b/cookbooks/postgresql/recipes/client_config.rb
@@ -15,8 +15,15 @@ end
 
 update_file "add_PGUSER_to_root_bash_login" do
   path "/root/.bash_login"
-  body "export PGUSER='#{node.engineyard.environment['db_admin_username']}'\nexport PGHOST='#{node.dna['db_host']}'\nexport PGDATABASE=postgres"
+  body "export PGUSER='#{node.engineyard.environment['db_admin_username']}'\nexport PGDATABASE=postgres"
   not_if "grep 'PGDATABASE' /root/.bash_login"
+end
+
+# cleanup PGHOST entries if set, this was a bug introduced by stable-v5-3.0.33 (October 2017)
+  # these wouldn't have updated on a replica promotion or a db master hostname/ip change
+  # better way to approach these would be to write a .ey_login and then source it from .bash_login (to be addressed in v6)
+execute "remove PGHOST entries if present" do
+  command "sed -i '/^export PGHOST=.*/d' /root/.bash_login"
 end
 
 cookbook_file "/root/.psqlrc" do


### PR DESCRIPTION
Description of your patch
--------------
Fixup removes pg_host entry from .bash_login

Recommended Release Notes
--------------
Hotfix: removes environment variable that prevents Postgres replica promotions on stable-v5-3.0.33+

Estimated risk
--------------

Low
- Nothing depends on this environment variable at this time.

Components involved
--------------

$ git diff next-release --name-only
cookbooks/postgresql/recipes/client_config.rb

Description of testing done
--------------
Under the 16.06 stack

- Provisioned a cluster with PostgreSQL using the current stack
- add a replica database
- promote the replica database when healthy
- the promotion will fail
- try to access psql client on the replica, this will fail and suggest postgres may not be running on a given EC2 hostname
- terminate the failed replica
- update the environment stack
- add a new replica
- promote when healthy
- the replica will promote successfully

QA Instructions
--------------

Verify as above.