### PR TITLE
CC-1203 Updates dev-libs/libxml2 for security

### DIFF
--- a/cookbooks/security_updates/recipes/default.rb
+++ b/cookbooks/security_updates/recipes/default.rb
@@ -1,3 +1,9 @@
+
+# YT-CC-1203
+package 'dev-libs/libxml2' do
+  version '2.9.4'
+end
+
 # CC-1187
 package 'app-admin/sudo' do
   version '1.8.16-r1'


### PR DESCRIPTION
Verified the dev-libs/libxml2 has been upgraded to 2.9.4 from 2.9.3 for security purposes
Verified that fix has been tested and works accordingly. 

https://tickets.engineyard.com/issue/CC-1203