### PR TITLE
security update of package net-libs/gnutls to 3.3.28. Ticket: CC-924

### DIFF
--- a/cookbooks/security_updates/recipes/default.rb
+++ b/cookbooks/security_updates/recipes/default.rb
@@ -1,3 +1,8 @@
+# YT-CC-924
+package 'net-libs/gnutls' do
+  version '3.3.28'
+end
+
 # CC-1187
 package 'app-admin/sudo' do
   version '1.8.16-r1'


### PR DESCRIPTION
https://tickets.engineyard.com/issue/CC-924