### PR TITLE
default openssl version update for the openssl cookbook. Ticket: CC-1146

### DIFF
--- a/cookbooks/openssl/attributes/openssl.rb
+++ b/cookbooks/openssl/attributes/openssl.rb
@@ -1,2 +1,3 @@
 default.openssl.using_metadata = !!node.engineyard.metadata("openssl_ebuild_version",nil)
-default.openssl.version = node.engineyard.metadata('openssl_ebuild_version','1.0.2j')
+# YT-CC-1146
+default.openssl.version = node.engineyard.metadata('openssl_ebuild_version','1.0.2k')


### PR DESCRIPTION
https://tickets.engineyard.com/issue/CC-1146