### PR TITLE
CC-1219: Fix passenger-status path on v5 passenger_monitor cron job.

### DIFF
--- a/cookbooks/passenger5/files/default/passenger_monitor
+++ b/cookbooks/passenger5/files/default/passenger_monitor
@@ -100,7 +100,7 @@ for each in /tmp/passenger.*;do
 done
 
 ## Get a list of passenger workers.
-raw_stats=$(/usr/sbin/passenger-status 2>> /tmp/passenger_errors)
+raw_stats=$(passenger-status 2>> /tmp/passenger_errors)
 exit_code=$?
 
 ## Kill any passenger workers that are not in $pstats


### PR DESCRIPTION
Description of your patch
-------------

The newer Passenger 5.1.8 installs passenger-status on `/usr/local/bin/passenger-status`. The older version has it on `/usr/sbin/passenger-status`.

For customers who have upgraded to the v5 stack with Passenger 5.1.8, the orphan killer portion of passenger_monitor cron job is broken for hardcoding `/usr/sbin/passenger-status`.

The fix simply changes `/usr/sbin/passenger-status` to `passenger-status`.

Recommended Release Notes
-------------

Fixes passenger-status path in the passenger_monitor cron job.

Estimated risk
-------------

Low - very small change that only tries to fix the wrong passenger-status path, worst case scenario is it's still not fixed

Components involved
-------------

Passenger (passenger_monitor cron job)

Description of testing done
-------------

* Boot up an environment using the latest v5 stack, and Passenger.
* Verify that Passenger version is 5.1.8 using `passenger-status`.
* Check /engineyard/bin/passenger_monitor for its `/usr/sbin/passenger-status` call.
* Tail /tmp/passenger_errors (error gets logged every minute):

```
1. You customized the instance registry directory using Apache's PassengerInstanceRegistryDir option, Nginx's passenger_instance_registry_dir option, or Phusion Passenger Standalone's --instance-registry-dir command line argument. If so, please set the environment variable PASSENGER_INSTANCE_REGISTRY_DIR to that directory and run passenger-status again.
2. The instance directory has been removed by an operating system background service. Please set a different instance registry directory using Apache's PassengerInstanceRegistryDir option, Nginx's passenger_instance_registry_dir option, or Phusion Passenger Standalone's --instance-registry-dir command line argument.
```

* Change `/usr/sbin/passenger-status` to `passenger-status` in /engineyard/bin/passenger_monitor.
* Check that /tmp/passenger_errors hasn't been updated since passenger_monitor was changed.
* Check that Passenger is still running with `passenger-status`.

QA Instructions
-------------

* Boot up an environment using the latest v5 stack (not QA build), and Passenger.
* Verify that Passenger version is 5.1.8 using `passenger-status`.
* Tail /tmp/passenger_errors and verify that you're getting this error every minute:

```
1. You customized the instance registry directory using Apache's PassengerInstanceRegistryDir option, Nginx's passenger_instance_registry_dir option, or Phusion Passenger Standalone's --instance-registry-dir command line argument. If so, please set the environment variable PASSENGER_INSTANCE_REGISTRY_DIR to that directory and run passenger-status again.
2. The instance directory has been removed by an operating system background service. Please set a different instance registry directory using Apache's PassengerInstanceRegistryDir option, Nginx's passenger_instance_registry_dir option, or Phusion Passenger Standalone's --instance-registry-dir command line argument.
```

* Boot up an environment using the QA stack, and Passenger.
* Verify that Passenger version is 5.1.8 using `passenger-status`. Also make sure that workers are running.
* Verify that the error is not being logged every minute in /tmp/passenger_errors.
