### PR TITLE
Cc 629

### DIFF
--- a/cookbooks/elixir/templates/default/nginx_app.conf.erb
+++ b/cookbooks/elixir/templates/default/nginx_app.conf.erb
@@ -82,8 +82,11 @@ server {
   error_log /var/log/engineyard/nginx/<%= @vhost.app.name %>.error.log notice;
   <% end %>
 
+  # Adding CORS Header to the font files.
+  location ~* \.(eot|otf|ttf|woff|woff2|svg)$ {
+    add_header Access-Control-Allow-Origin *;
+  }
 
-  #
   # Expire header on assets. For more information on the reasoning behind
   # this please browse http://developer.yahoo.com/performance/rules.html#expires
   #

--- a/cookbooks/haproxy/templates/default/haproxy.cfg.erb
+++ b/cookbooks/haproxy/templates/default/haproxy.cfg.erb
@@ -64,9 +64,10 @@ defaults
   # request. HAProxy documentation has a long explanation for this option.
   option abortonclose
 
-  # Check if a "Connection: close" header is already set in each direction,
-  # and will add one if missing.
-  option httpclose
+  # [CC-629] httpclose replaced with http-server-close. Enabling Server Close (SCL) mode.
+  # More information about connection closing modes:
+  # https://www.haproxy.com/documentation/aloha/7-0/traffic-management/lb-layer7/http-modes
+  option http-server-close
 
 <% if !@http2 %>
   # Insert the X-Forwarded-For header for requests sent to the backend.

--- a/cookbooks/lb/templates/default/haproxy.cfg.erb
+++ b/cookbooks/lb/templates/default/haproxy.cfg.erb
@@ -36,9 +36,10 @@ defaults
   # request. HAProxy documentation has a long explanation for this option.
   option abortonclose
 
-  # Check if a "Connection: close" header is already set in each direction,
-  # and will add one if missing.
-  option httpclose
+  # [CC-629] httpclose replaced with http-server-close. Enabling Server Close (SCL) mode.
+  # More information about connection closing modes:
+  # https://www.haproxy.com/documentation/aloha/7-0/traffic-management/lb-layer7/http-modes
+  option http-server-close
 
   # Insert the X-Forwarded-For header for requests sent to the backend.
   option forwardfor

--- a/cookbooks/nginx/files/default/mime.types
+++ b/cookbooks/nginx/files/default/mime.types
@@ -52,7 +52,6 @@ types {
     application/octet-stream              bin exe dll;
     application/octet-stream              deb;
     application/octet-stream              dmg;
-    application/octet-stream              eot;
     application/octet-stream              iso img;
     application/octet-stream              msi msp msm;
 
@@ -68,4 +67,11 @@ types {
     video/x-ms-asf                        asx asf;
     video/x-ms-wmv                        wmv;
     video/x-msvideo                       avi;
+
+    application/vnd.ms-fontobject         eot;
+    application/font-sfnt                 otf;
+    application/font-sfnt                 ttf;
+    application/font-woff                 woff;
+    font/woff2                            woff2;
+
 }

--- a/cookbooks/nginx/templates/default/fpm-server.conf.erb
+++ b/cookbooks/nginx/templates/default/fpm-server.conf.erb
@@ -33,6 +33,11 @@ server {
 # Include additional location blocks.  File copied in via deploy hooks
 	include /etc/nginx/servers/<%= @app_name %>/additional_location_blocks.customer;
 
+  # Adding CORS Header to the font files.
+  location ~* \.(eot|otf|ttf|woff|woff2|svg)$ {
+    add_header Access-Control-Allow-Origin *;
+  }
+
   location / {
     try_files $uri $uri/ /index.php$is_args$args;
   }

--- a/cookbooks/nginx/templates/default/fpm-ssl.conf.erb
+++ b/cookbooks/nginx/templates/default/fpm-ssl.conf.erb
@@ -36,8 +36,13 @@ server {
     log_not_found  off;
   }
 
-	# Include additional location blocks.  File copied in via deploy hooks
-	include /etc/nginx/servers/<%= @app_name %>/additional_location_blocks.ssl.customer;
+  # Include additional location blocks.  File copied in via deploy hooks
+  include /etc/nginx/servers/<%= @app_name %>/additional_location_blocks.ssl.customer;
+
+  # Adding CORS Header to the font files.
+  location ~* \.(eot|otf|ttf|woff|woff2|svg)$ {
+    add_header Access-Control-Allow-Origin *;
+  }
 
   location / {
     try_files $uri $uri/ /index.php$is_args$args;

--- a/cookbooks/nginx/templates/default/server.conf.erb
+++ b/cookbooks/nginx/templates/default/server.conf.erb
@@ -68,6 +68,10 @@ server {
   proxy_pass http://upstream_<%= @app_name %>;
   }
 
+  # Adding CORS Header to the font files.
+  location ~* \.(eot|otf|ttf|woff|woff2|svg)$ {
+    add_header Access-Control-Allow-Origin *;
+  }
 
   # set Expire header on assets: see http://developer.yahoo.com/performance/rules.html#expires
   location ~ ^/(images|assets|javascripts|stylesheets)/ {

--- a/cookbooks/nginx/templates/default/ssl.conf.erb
+++ b/cookbooks/nginx/templates/default/ssl.conf.erb
@@ -71,6 +71,11 @@ server {
 
   location = /system/maintenance.html { }
 
+  # Adding CORS Header to the font files.
+  location ~* \.(eot|otf|ttf|woff|woff2|svg)$ {
+    add_header Access-Control-Allow-Origin *;
+  }
+
   # set Expire header on assets: see http://developer.yahoo.com/performance/rules.html#expires
   location ~ ^/(images|assets|javascripts|stylesheets)/ {
   try_files  $uri $uri/index.html /last_assets/$uri /last_assets/$uri.html @app_<%= @app_name %>ssl;

--- a/cookbooks/passenger5/templates/default/nginx_app.conf.erb
+++ b/cookbooks/passenger5/templates/default/nginx_app.conf.erb
@@ -88,7 +88,11 @@ server {
 
   rewrite ^/public/(.*) http://api.<%= domain %>/$1 permanent;
 
-  #
+  # Adding CORS Header to the font files.
+  location ~* \.(eot|otf|ttf|woff|woff2|svg)$ {
+    add_header Access-Control-Allow-Origin *;
+  }
+
   # Expire header on assets. For more information on the reasoning behind
   # this please browse http://developer.yahoo.com/performance/rules.html#expires
   #

--- a/cookbooks/puma/templates/default/nginx_app.conf.erb
+++ b/cookbooks/puma/templates/default/nginx_app.conf.erb
@@ -90,7 +90,11 @@ server {
   error_log /var/log/engineyard/nginx/<%= @vhost.app.name %>.error.log notice;
   <% end %>
 
-  #
+  # Adding CORS Header to the font files.
+  location ~* \.(eot|otf|ttf|woff|woff2|svg)$ {
+    add_header Access-Control-Allow-Origin *;
+  }
+
   # Expire header on assets. For more information on the reasoning behind
   # this please browse http://developer.yahoo.com/performance/rules.html#expires
   #


### PR DESCRIPTION
## Description of your patch

Changing httpclose parameter to the http-server-close for HAPROXY. This allows you to use keepalive connection on client side.
More about HAPROXy connection serving modes: https://www.haproxy.com/documentation/aloha/7-0/traffic-management/lb-layer7/http-modes

## Recommended Release Notes

None.

## Estimated risk

Low

## Components involved

HAPROXY

## Description of testing done

See QA instructions

## QA Instructions

1. Create simple Ruby application. Simple TO-DO app (https://github.com/engineyard/todo.git) can be used for this testing.
2. Boot the environment with the latest V5 stack version. Environment should be run with following parameters:
  * Application Server Stack - Passenger 5
  * Runtime - Ruby 2.3
  * Environment type - Single Instance.
3. Replace nginx cookbook with cookbook provided in current pool request.
3. SSH to the instance.
4. Run command `curl -I 127.0.0.1:80`
5. Ensure you don't have a parameter `Connection: close` set in the response header.