### PR TITLE
[CC-629] Change haproxy option value to http-server-close

### DIFF
--- a/cookbooks/haproxy/templates/default/haproxy.cfg.erb
+++ b/cookbooks/haproxy/templates/default/haproxy.cfg.erb
@@ -64,9 +64,10 @@ defaults
   # request. HAProxy documentation has a long explanation for this option.
   option abortonclose
 
-  # Check if a "Connection: close" header is already set in each direction,
-  # and will add one if missing.
-  option httpclose
+  # [YT-CC-629] httpclose replaced with http-server-close. Enabling Server Close (SCL) mode.
+  # More information about connection closing modes:
+  # https://www.haproxy.com/documentation/aloha/7-0/traffic-management/lb-layer7/http-modes
+  option http-server-close
 
 <% if !@http2 %>
   # Insert the X-Forwarded-For header for requests sent to the backend.

--- a/cookbooks/lb/templates/default/haproxy.cfg.erb
+++ b/cookbooks/lb/templates/default/haproxy.cfg.erb
@@ -36,9 +36,10 @@ defaults
   # request. HAProxy documentation has a long explanation for this option.
   option abortonclose
 
-  # Check if a "Connection: close" header is already set in each direction,
-  # and will add one if missing.
-  option httpclose
+  # [YT-CC-629] httpclose replaced with http-server-close. Enabling Server Close (SCL) mode.
+  # More information about connection closing modes:
+  # https://www.haproxy.com/documentation/aloha/7-0/traffic-management/lb-layer7/http-modes
+  option http-server-close
 
   # Insert the X-Forwarded-For header for requests sent to the backend.
   option forwardfor


### PR DESCRIPTION
## Description of your patch

Changing httpclose parameter to the http-server-close for HAPROXY. This allows you to use keepalive connection on client side.
More about HAPROXy connection serving modes: https://www.haproxy.com/documentation/aloha/7-0/traffic-management/lb-layer7/http-modes

## Recommended Release Notes

None.

## Estimated risk

Low

## Components involved

HAPROXY

## Description of testing done

See QA instructions

## QA Instructions

1. Create simple Ruby application. Simple TO-DO app (https://github.com/engineyard/todo.git) can be used for this testing.
2. Boot the environment with the latest V5 stack version. Environment should be run with following parameters:
  * Application Server Stack - Passenger 5
  * Runtime - Ruby 2.3
  * Environment type - Single Instance.
3. SSH to the instance.
4. Replace haproxy cookbook with cookbook provided in current pool request.
5. Run chef `PATH=/usr/local/ey_resin/bin:$PATH /home/ey/bin/chef-solo -j /etc/chef/dna.json -c /etc/chef/solo.rb`
6. Run command `curl -I 127.0.0.1:80`
7. Ensure you don't have parameter `Connection: close` set in the response header.