### PR TITLE
[CC-1023] httpoxy CGI vulnerability

### DIFF
--- a/cookbooks/nginx/templates/default/fpm-server.conf.erb
+++ b/cookbooks/nginx/templates/default/fpm-server.conf.erb
@@ -47,6 +47,8 @@ server {
     fastcgi_intercept_errors    off;
     fastcgi_param               SCRIPT_FILENAME $document_root$fastcgi_script_name;
     fastcgi_param               SERVER_NAME $hostname;
+    #YT-CC-1023 httpoxy CGI vulnerability (CVE-2016-5385) mitigation
+    fastcgi_param               HTTP_PROXY "";
     <% if  File.exists?("/etc/newrelic/newrelic.cfg") %>
     fastcgi_param               PHP_VALUE "newrelic.appname=<%= @env_name %> / <%= @app_name %>";
     <% end %>

--- a/cookbooks/nginx/templates/default/fpm-ssl.conf.erb
+++ b/cookbooks/nginx/templates/default/fpm-ssl.conf.erb
@@ -54,6 +54,8 @@ server {
     fastcgi_param               SCRIPT_FILENAME $document_root$fastcgi_script_name;
     fastcgi_param               HTTPS on;
     fastcgi_param               SERVER_NAME $hostname;
+    # YT-CC-1023 httpoxy CGI vulnerability (CVE-2016-5385) mitigation
+    fastcgi_param               HTTP_PROXY "";
     <% if  File.exists?("/etc/newrelic/newrelic.cfg") %>
     fastcgi_param               PHP_VALUE "newrelic.appname=<%= @env_name %> / <%= @app_name %>";
     <% end %>


### PR DESCRIPTION
## Description of your patch

httpoxy CGI vulnerability mitigation for FastCGI applications 

## Recommended Release Notes

None.

## Estimated risk

Low

## Components involved

Nginx

## Description of testing done

See QA instructions

## QA Instructions

1. Create simple PHP application. Simple TO-DO app (git://github.com/engineyard/howto.git) can be used for this testing.
2. Boot the environment with the latest V5 stack version. Environment should be run with following parameters:
  * Environment type - Single Instance.
3. SSH to the instance.
4. Run command `curl -H "Proxy: http://testingpoxy.com" 127.0.0.1/phpinfo.php | grep HTTP_PROXY`
5. Ensure you get the same URL in PHP variable HTTP_PROXY.
6. Replace nginx cookbook with cookbook provided in current pool request.
7. Run Chef `PATH=/usr/local/ey_resin/bin:$PATH /home/ey/bin/chef-solo -j /etc/chef/dna.json -c /etc/chef/solo.rb`
8. Run command `curl -H "Proxy: http://testingpoxy.com" 127.0.0.1/phpinfo.php | grep HTTP_PROXY` again
7. Ensure HTTP_PROXY variable dissapeared from the output