### PR TITLE
[CC-666] Add header HTTP_X_FORWARDED_PORT to haproxy

### DIFF
--- a/cookbooks/haproxy/templates/default/haproxy.cfg.erb
+++ b/cookbooks/haproxy/templates/default/haproxy.cfg.erb
@@ -127,7 +127,9 @@ listen cluster
     #redirect http=>https
     redirect scheme https code 301 if !{ ssl_fc }
 <% else %>
-    reqadd X-Forwarded-Proto:\ http
+# YT-CC-666 X-Forwarded-Port added
+  http-request add-header X-Forwarded-Proto http
+  http-request set-header X-Forwarded-Port %[dst_port]
 
     <% if @backends.any? %>
       <% @backends.each_with_index do |instance, i| %>
@@ -178,9 +180,11 @@ listen cluster
 
 <% else %>
     <% if Dir['/etc/nginx/ssl/*.pem'].reject {|filename| filename =~ /dhparam/}.count > 0 %>
-        listen clusterssl
-        bind *:443 mss 1422 ssl <%= Dir['/etc/nginx/ssl/*.pem'].reject {|filename| filename =~ /dhparam/}.collect {|pem| "crt #{pem}"}.join(" ") %>
-        reqadd X-Forwarded-Proto:\ https
+listen clusterssl
+  bind *:443 mss 1422 ssl <%= Dir['/etc/nginx/ssl/*.pem'].reject {|filename| filename =~ /dhparam/}.collect {|pem| "crt #{pem}"}.join(" ") %>
+# YT-CC-666 X-Forwarded-Port added
+  http-request add-header X-Forwarded-Proto https
+  http-request set-header X-Forwarded-Port %[dst_port]
 
         <% if @backends.any? %>
         <% @backends.each_with_index do |instance, i| %>

--- a/cookbooks/lb/templates/default/haproxy.cfg.erb
+++ b/cookbooks/lb/templates/default/haproxy.cfg.erb
@@ -97,7 +97,9 @@ listen cluster
   option httpchk HEAD <%= @httpchk_path %><% if @httpchk_host %> HTTP/1.1\r\nHost:\ <%= @httpchk_host %><% end %>
   http-check expect rstatus ((2|3)[0-9][0-9]|503)
 <% end -%>
-  reqadd X-Forwarded-Proto:\ http
+# YT-CC-666 X-Forwarded-Port added
+  http-request add-header X-Forwarded-Proto http
+  http-request set-header X-Forwarded-Port %[dst_port]
 
   <% @backends.each_with_index do |instance, i| %>
   server app-<%= i %> <%= instance['private_hostname'] %>:81 check inter 5000 fastinter 1000 fall 1 weight <%= (instance['role'] == 'app_master') ? @app_master_weight : 50 %> # <%= instance['id'] %>

--- a/cookbooks/nginx/templates/default/common.fcgi.conf.erb
+++ b/cookbooks/nginx/templates/default/common.fcgi.conf.erb
@@ -17,7 +17,8 @@ fastcgi_param  REMOTE_ADDR        $remote_addr;
 fastcgi_param  REMOTE_PORT        $remote_port;
 fastcgi_param  SERVER_ADDR        $server_addr;
 fastcgi_param  SERVER_PORT        $server_port;
-fastcgi_param  SERVER_NAME        $server_name;
+# [YT-CC-666] $server_port was changed to $http_x_forwarded_port
+fastcgi_param  SERVER_PORT        $http_x_forwarded_port;
 
 # PHP only, required if PHP was built with --enable-force-cgi-redirect
 fastcgi_param  REDIRECT_STATUS    200;


### PR DESCRIPTION
## Description of your patch

Adding header HTTP_X_FORWARDED_PORT to haproxy configuration to be able to use real request port for FastCGI applications

## Recommended Release Notes

None.

## Estimated risk

Low

## Components involved

HAPROXY, Nginx

## Description of testing done

See QA instructions

## QA Instructions

1. Create simple PHP application. Simple How-To app (git://github.com/engineyard/howto.git) can be used for this testing.
2. Boot the environment with the latest V5 stack version. Environment should be run with following parameters:
  * Environment type - Single Instance.
3. SSH to the instance.
4. Run command `curl 127.0.0.1/phpinfo.php | grep SERVER_PORT`
5. Ensure PHP SERVER_PORT variable is set to 8081.
6. Replace nginx and haproxy cookbooks with relevant cookbooks provided in current pull request.
7. Run Chef `PATH=/usr/local/ey_resin/bin:$PATH /home/ey/bin/chef-solo -j /etc/chef/dna.json -c /etc/chef/solo.rb`
8. Run command `curl 127.0.0.1/phpinfo.php | grep SERVER_PORT` again
7. Ensure PHP SERVER_PORT variable changed to 80