### PR TITLE
CC-1231: Fix typo in custom-fail2ban README.

### DIFF
--- a/custom-cookbooks/fail2ban/cookbooks/custom-fail2ban/README.md
+++ b/custom-cookbooks/fail2ban/cookbooks/custom-fail2ban/README.md
@@ -9,7 +9,7 @@ For simplicity, we recommend that you create the cookbooks directory at the root
 
 Our main recipes have the `fail2ban` recipe but it is not included by default. To use the `fail2ban ` recipe, you should copy this recipe `custom-fail2ban `. You should not copy the actual `fail2ban ` recipe. That is managed by Engine Yard.
 
-1. Edit `cookbooks/ey-custom/fail2ban/after-main.rb` and add
+1. Edit `cookbooks/ey-custom/recipes/after-main.rb` and add
 
       ```
       include_recipe 'custom-fail2ban'


### PR DESCRIPTION
Description of your patch
-------------

In the README of custom-fail2ban, installation suggests that you edit cookbooks/ey-custom/fail2ban/after-main.rb. This is a typo and should be cookbooks/ey-custom/recipes/after-main.rb.

Recommended Release Notes
-------------

Not Applicable. Customers will not get any changes on a stack upgrade because this is under custom-cookbooks.

Estimated risk
-------------

Low - Only updates README of a custom cookbook.

Components involved
-------------

Custom fail2ban.

Description of testing done
-------------

No testing needed. Just a README typo fix.

QA Instructions
-------------

No testing needed. Just a README typo fix.
