### PR TITLE
CC-1174: Passenger5 app_control improvements

### DIFF
--- a/cookbooks/passenger5/templates/default/app_control.erb
+++ b/cookbooks/passenger5/templates/default/app_control.erb
@@ -23,6 +23,23 @@ case "$1" in
     ;;
 
   start)
+    NGINX_PID=`sudo netstat -antp | grep <%= @port %> | grep LISTEN | awk '{split($7,a,"/"); print a[1]}'`
+    PASSENGER_PID=`sudo ps -ef | grep passenger-standalone | grep <%= @port %> | awk '{print $2};'`
+    PIDFILE='/data/<%= @app_name %>/shared/pids/passenger.<%= @port %>.pid'
+    if [ -n $NGINX_PID ]; then
+      if [ ! -z $PASSENGER_PID ]; then
+        if [ ! -f $PIDFILE ]; then
+          echo $PASSENGER_PID > $PIDFILE
+          echo "Passenger: PIDFILE $PIDFILE was recreated with PID $PASSENGER_PID"
+        fi
+      else
+        echo "Passenger: Nginx is running with PID $NGINX_PID, but the standalone Passenger process is missing."
+        echo "Passenger: Killing Nginx with PID $NGINX_PID"
+        sudo kill -9 $NGINX_PID
+      fi
+    fi
+
+    # Start Passenger
     /usr/local/bin/passenger start current --daemonize --port <%= @port %> --environment <%= @rails_env %> --max-pool-size <%= @worker_count %> --min-instances <%= @worker_count %> --pid-file /data/<%= @app_name %>/shared/pids/passenger.<%= @port %>.pid --log-file /data/<%= @app_name %>/shared/log/passenger.<%= @port %>.log
     ;;
 


### PR DESCRIPTION
## Description of your patch

This is a fix for the Passenger5 bug documented in CC-1174. 

Passenger Standalone has a bug. It creates a /tmp/passenger-standalone-xxxxxx directory whenever it starts. This is where it stores its temporary files. The bug is that this directory does not get cleaned up when Passenger fails to start.

We run monit to ensure that Passenger is started again when it dies. Our default monit cycle is 30 seconds. This means if monit thinks Passenger is dead, it will attempt to start Passenger every 30 seconds. If something is preventing Passenger from starting, then monit will end up repeatedly attempting to start Passenger. Over time this can accumulate into thousands of passenger-standalone directories. We've seen some app instances run out of inodes from this.

While it is not clear what causes Passenger to fail to start, we've been able to replicate the issue with either of these two techniques:

- delete the Passenger Standalone PID file
- terminate the Passenger process but not the Nginx process (the Nginx started by Passenger Standalone)

This fix puts in additional checks to handle the two cases above.

## Recommended Release Notes

Adds checks on the Passenger5 startup script to prevent it from repeatedly creating /tmp/passenger-standalone.* directories

## Estimated risk

High. This changes the Passenger5 app control script. If this is broken then the application may fail to start.

## Components involved

Passenger5 recipe

## Description of testing done

See QA instructions

## QA Instructions

Boot a cluster environment on the latest V5 (not QA) stack, running the Passenger5 stack. Use the todo application. You only need the app_master instance at the start of the test.

### Review the current behavior
1) When the PID file is deleted
- delete the passenger-standalone PID file 
`rm /data/todo/shared/pids/passenger.8000.pid`
- run `watch cat /data/todo/shared/pids/passenger.8000.pid` and wait a few minutes - observe if Passenger can start successfully and write out the PID
- after a few minutes run `ls -lah /tmp` and count the new passenger-standalone.* directories. You'll see about one directory every minute since you deleted the PID file

To help the instance recover from this, recreate the PID file. You can get the Passenger PID by running `ps ax | grep [P]assengerAgent`. The first column of the output is the PID. After getting the PID, run `echo <PID> > /data/todo/shared/pids/passenger.8000.pid`

2) When the Passenger process is terminated but not the Nginx process

- Get the passenger PID and terminate it with `sudo kill -9 <PID>`
- run `watch cat /data/todo/shared/pids/passenger.8000.pid` and wait a few minutes - observe if Passenger can start successfully and write out the PID
- after a few minutes run `ls -lah /tmp` and count the new passenger-standalone.* directories. You'll see about one directory every minute since you killed the Passenger Standalone process

To help the instance recover, terminate the Nginx process. Run `ps aux | grep nginx | grep passenger` - the first column of the result is the Nginx PID. Then kill this process with `kill -9 <PID>`.

### Upgrade to the QA stack and verify that the bug is fixed

After the upgrade, test the new behavior, following the same procedure as above:
  
1) When the PID file is deleted
2) When the Passenger process is terminated but not the Nginx process

For both cases, you should no longer see passenger-standalone.* directories accumulating in `/tmp`. After at most 5 minutes you should no longer see new passenger-standalone directories being created in `/tmp`.

### Verify that previous functionality still works

1) Deployment
run `passenger-status` as root. Note down the PIDs of the passenger workers.
Deploy
After deploy has finished, run `passenger-status` again. You should see new PIDs for the passenger workers.

2) Booting new app instances
Boot a new app instance. 
ssh to the app instance after it has finished provisioning.
Verify that Passenger is running and processing HTTP requests: 
- run `passenger-status` and check the 'Processed' counts of the workers
- hit the application URL multiple times to increase the chances that at least one of the requests will hit the new app instance
- run `passenger-status` again and check the 'Processed' count of the workers