### PR TITLE
[CC-1179] Hide passenger version on X-Powered-By header

### DIFF
--- a/cookbooks/nginx/templates/default/server.conf.erb
+++ b/cookbooks/nginx/templates/default/server.conf.erb
@@ -66,6 +66,7 @@ server {
   location @app_<%= @app_name %> {
   include /etc/nginx/common/proxy.conf;
   proxy_pass http://upstream_<%= @app_name %>;
+  proxy_hide_header X-Powered-By;
   }
 
 

--- a/cookbooks/nginx/templates/default/ssl.conf.erb
+++ b/cookbooks/nginx/templates/default/ssl.conf.erb
@@ -67,6 +67,7 @@ server {
     include /etc/nginx/common/proxy.conf;
     proxy_set_header        X-Forwarded-Proto https;
     proxy_pass http://upstream_<%= @app_name %>ssl;
+    proxy_hide_header X-Powered-By;
   }
 
   location = /system/maintenance.html { }

--- a/cookbooks/passenger5/templates/default/nginx_app.conf.erb
+++ b/cookbooks/passenger5/templates/default/nginx_app.conf.erb
@@ -127,11 +127,13 @@ server {
   include /etc/nginx/common/proxy.conf;
   proxy_set_header        X-Forwarded-Proto https;
   proxy_pass http://<%= @vhost.app.name %>ssl_upstream;
+  proxy_hide_header X-Powered-By;
   }
   <% else %>
   location @app_<%=@vhost.app.name%> {
   include /etc/nginx/common/proxy.conf;
   proxy_pass http://<%= @vhost.app.name %>_upstream;
+  proxy_hide_header X-Powered-By;
   }
   <% end %>
 


### PR DESCRIPTION
## Description of your patch

Adding nginx configuration changes to hide the X-Powered-By header

## Recommended Release Notes

None.

## Estimated risk

Low

## Components involved

Nginx

## Description of testing done

See QA instructions

## QA Instructions

1. Create simple Ruby application. Simple TO-DO app (https://github.com/engineyard/todo.git) can be used for this testing.
2. Boot the environment with the latest V5 stack version. Environment should be run with following parameters:
  * Application Server Stack - Passenger 5
  * Environment type - Single Instance.
3. SSH to the instance.
4. Replace nginx and passenger5 cookbook with cookbook provided in current pool request.
5. Run command `curl -I 127.0.0.1`
6. Ensure X-Powered-By header is provided in reply.
5. Run chef `PATH=/usr/local/ey_resin/bin:$PATH /home/ey/bin/chef-solo -j /etc/chef/dna.json -c /etc/chef/solo.rb`
6. Run command `curl -I 127.0.0.1`
7. Ensure X-Powered-By header disappeared.