### PR TITLE
db-ssl timeouts and corrections

### DIFF
--- a/cookbooks/db-ssl/templates/default/remote_key_copy.sh.erb
+++ b/cookbooks/db-ssl/templates/default/remote_key_copy.sh.erb
@@ -7,7 +7,7 @@ keyname=<%= @keyname %>
 instances='<%= @instances %>'
 replicas='<%= @replicas %>'
 keypath="${dbroot}/keygen/${user}/"
-ssh_options='ssh -i /root/.ssh/internal -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null'
+ssh_options='ssh -i /root/.ssh/internal -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=10'
 
 function usage {
   echo "Usage: $0 user"
@@ -17,13 +17,20 @@ function usage {
 }
 
 function push_keys {
+  local target=${1}
+
   if [[ "$user" != 'mysql' ]]
   then
-    eval ${ssh_options} ${instance} "mkdir -p ${user_home}/.${keyname}"
-    rsync -a -e "${ssh_options}" ${keyname}.crt ${instance}:${user_home}/.${keyname}/
-    rsync -a -e "${ssh_options}" ${keyname}.key ${instance}:${user_home}/.${keyname}/
-    rsync -a -e "${ssh_options}" root.crt ${instance}:${user_home}/.${keyname}/
+    eval ${ssh_options} ${target} "mkdir -p ${user_home}/.${keyname}"
+    rsync -a -e "${ssh_options}" ${keyname}.crt ${target}:${user_home}/.${keyname}/
+    rsync -a -e "${ssh_options}" ${keyname}.key ${target}:${user_home}/.${keyname}/
+    rsync -a -e "${ssh_options}" root.crt ${target}:${user_home}/.${keyname}/
   fi
+}
+
+function is_up() {
+  eval ${ssh_options} -o ConnectTimeout=10 $1 'date'
+  [[ $? -eq 0 ]]
 }
 
 if [[ -z $user ]]
@@ -37,14 +44,18 @@ cd ${keypath}
 # copy keys to other instances
 for instance in ${instances}
 do
-  push_keys
+  if is_up ${instance}
+  then
+    push_keys ${instance}
+  else
+    echo "Instance ${instance} is not available. Skipping."
+  fi
 done
 
 # Copy keys to replicas
 for replica in ${replicas}
 do
-  eval ${ssh_options} ${replica} 'date'
-  if [[ $? -eq 0 ]]
+  if is_up ${replica}
   then
     # Copy Server Keys to replica data dir
     cd ${datadir}
@@ -60,7 +71,7 @@ do
     
     # Copy User Keys to replica Users
     cd ${keypath}
-    push_keys
+    push_keys ${replica}
   else
     echo 'Replica DB not accessible, skipping.'
   fi

--- a/cookbooks/db-ssl/templates/default/remote_key_copy.sh.erb
+++ b/cookbooks/db-ssl/templates/default/remote_key_copy.sh.erb
@@ -29,7 +29,7 @@ function push_keys {
 }
 
 function is_up() {
-  eval ${ssh_options} -o ConnectTimeout=10 $1 'date'
+  eval ${ssh_options} $1 'date'
   [[ $? -eq 0 ]]
 }
 


### PR DESCRIPTION
The `remote_key_copy.sh` script that is generated, when there are
stopped instances in the environment, causes chef runs to take
upwards of nine extra minutes per stopped instance. This is because
the `push_keys` function in this script, which uses `rsync` to copy
a few key files to each instance in the environment, and the
connection timeout is around 3 minutes by default.

Additionally, the `push_keys` function is used (contextually) to
copy those same files to the db replicas in the environment, but
this is not actually happening due to the use of global variables.

Changes:

* Defined an `is_up` function that takes an instance as an argument.
  It then attempts to ssh to the instance and run `date`. If this
  should fail, it returns false. Otherwise, it is true. Either way
  it has a hard-coded ten-second connection timeout.
* Modified `push_keys` to take an instance argument, treating it
  as the target for the `rsync` calls.
* Modified all `push_keys` and raw `rsync` invocations to first
  check to ensure that the instance in question `is_up`.