### PR TITLE
[YT-CC-1204] Adds orphan monitoring to the sidekiq recipe

### DIFF
--- a/cookbooks/sidekiq/attributes/default.rb
+++ b/cookbooks/sidekiq/attributes/default.rb
@@ -4,19 +4,19 @@
 #
 
 default['sidekiq'].tap do |sidekiq|
-  
+
   # Sidekiq will be installed on to application/solo instances,
   # unless a utility name is set, in which case, Sidekiq will
   # only be installed on to a utility instance that matches
   # the name
   sidekiq['is_sidekiq_instance'] = true
-  
+
   # Number of workers (not threads)
   sidekiq['workers'] = 1
-  
+
   # Concurrency
   sidekiq['concurrency'] = 25
-  
+
   # Queues
   sidekiq['queues'] = {
     # :queue_name => priority
@@ -25,7 +25,19 @@ default['sidekiq'].tap do |sidekiq|
 
   # Memory limit
   sidekiq['worker_memory'] = 400 # MB
-  
+
   # Verbose
   sidekiq['verbose'] = false
+
+  # Setting this to true installs a cron job that
+  # regularly terminates sidekiq workers that aren't being monitored by monit,
+  # and terminates those workers
+  #
+  # default: false
+  sidekiq['orphan_monitor_enabled'] = false
+
+  # sidekiq_orphan_monitor cron schedule
+  #
+  # default: every 5 minutes
+  sidekiq['orphan_monitor_cron_schedule'] = "*/5 * * * *"
 end

--- a/cookbooks/sidekiq/files/default/sidekiq_orphan_monitor
+++ b/cookbooks/sidekiq/files/default/sidekiq_orphan_monitor
@@ -1,0 +1,30 @@
+containsElement () {
+  local e match="$1"
+  shift
+  for e; do [[ "$e" == "$match" ]] && return 0; done
+  return 1
+}
+
+app_name=$1
+sidekiq_pids=`cat /var/run/engineyard/sidekiq/$app_name/sidekiq_*.pid`
+
+sidekiq_parent_pids=()
+for sidekiq_pid in $sidekiq_pids; do
+  parent_pid="$(ps -o ppid= $sidekiq_pid | tr -d '[:space:]')"
+  sidekiq_parent_pids+="$parent_pid "
+done
+
+running_sidekiqs="$(ps -ef | grep [s]idekiq | awk '{print $2}')"
+echo "Running sidekiqs: $running_sidekiqs"
+echo "Monit PIDs: $sidekiq_pids"
+echo "Parent PIDs: $sidekiq_parent_pids"
+for sidekiq in $running_sidekiqs; do
+  if (containsElement $sidekiq $sidekiq_pids); then
+    echo "Not terminating $sidekiq - it is being monitored by monit"
+  elif (containsElement $sidekiq $sidekiq_parent_pids); then
+    echo "Not terminating $sidekiq - it is a parent of a monit sidekiq process"
+  else
+    echo "Terminating $sidekiq"
+    sudo kill $sidekiq
+  fi
+done

--- a/cookbooks/sidekiq/recipes/setup.rb
+++ b/cookbooks/sidekiq/recipes/setup.rb
@@ -23,21 +23,21 @@ if node['sidekiq']['is_sidekiq_instance']
       command "monit reload && sleep 10 && monit restart all -g #{app_name}_sidekiq"
       action :nothing
     end
-    
+
     # monit
-    template "/etc/monit.d/sidekiq_#{app_name}.monitrc" do 
-      mode 0644 
-      source "sidekiq.monitrc.erb" 
+    template "/etc/monit.d/sidekiq_#{app_name}.monitrc" do
+      mode 0644
+      source "sidekiq.monitrc.erb"
       backup false
-      variables({ 
-        :app_name => app_name, 
+      variables({
+        :app_name => app_name,
         :workers => node['sidekiq']['workers'],
         :rails_env => node.dna['environment']['framework_env'],
         :memory_limit => node['sidekiq']['worker_memory']
       })
       notifies :run, "execute[restart-sidekiq-for-#{app_name}]"
     end
-    
+
     # database.yml
     execute "update-database-yml-pg-pool-for-#{app_name}" do
       db_yaml_file = "/data/#{app_name}/shared/config/database.yml"
@@ -68,5 +68,28 @@ if node['sidekiq']['is_sidekiq_instance']
         action :touch
       end
     end
-  end 
+
+    # setup orphan_monitor, if enabled
+    if node[:sidekiq][:orphan_monitor_enabled]
+      cookbook_file '/engineyard/bin/sidekiq_orphan_monitor' do
+        source 'sidekiq_orphan_monitor'
+        owner node[:owner_name]
+        group node[:owner_name]
+        mode 0755
+        backup false
+        action :create
+      end
+
+      cron 'sidekiq_orphan_monitor' do
+        user    node[:owner_name]
+        action  :create
+        minute  node[:sidekiq][:orphan_monitor_cron_schedule].split[0]
+        hour    node[:sidekiq][:orphan_monitor_cron_schedule].split[1]
+        day     node[:sidekiq][:orphan_monitor_cron_schedule].split[2]
+        month   node[:sidekiq][:orphan_monitor_cron_schedule].split[3]
+        weekday node[:sidekiq][:orphan_monitor_cron_schedule].split[4]
+        command "/engineyard/bin/sidekiq_orphan_monitor #{app_name}"
+      end
+    end
+  end
 end


### PR DESCRIPTION
Github note: This closes issue #279 

## Description of your patch

Adds orphan monitoring to the sidekiq recipe

## Recommended Release Notes

Adds orphan monitoring to the sidekiq recipe

## Estimated risk

Low. Only the sidekiq recipe is changed. The new feature is disabled by default.

## Components involved

sidekiq custom chef recipe

## Description of testing done

Tested the unit tests on a solo environment with redis and sidekiq utility instances

## QA Instructions

Enable both the redis and the sidekiq recipes. 
Modify `custom-sidekiq/attributes/default.rb` and set `sidekiq['orphan_monitor_enabled']` to true
Upload the chef recipe before booting the environment.

Boot a new cluster environment for the rails_activejob_example application
- Unicorn
- Ruby 2.3
- Rubygems 2.6.3
- Postgres 9.4
- any region
- QA stack

The cluster should have the following instances:
- 1 app_master
- 1 redis
- 1 sidekiq
- 1 db_master

On the sidekiq instance: 
- verify that the file `/engineyard/bin/sidekiq_orphan_monitor` exists
- run `crontab -l` for the deploy user. Verify that a cron job was created to periodically run `/engineyard/bin/sidekiq_orphan_monitor`

On all the other instances:
- verify that the file `/engineyard/bin/sidekiq_orphan_monitor` does not exist
- run `crontab -l` for the deploy user. There should be no cron job for `/engineyard/bin/sidekiq_orphan_monitor`