### PR TITLE
[YT-CC-1217] credits section, support license key from NR add-on and display name

### DIFF
--- a/cookbooks/newrelic_infra/attributes/default.rb
+++ b/cookbooks/newrelic_infra/attributes/default.rb
@@ -1,3 +1,5 @@
+default['newrelic_infra']['use_newrelic_addon'] = false
 default['newrelic_infra']['license_key'] = "INSERT_NEW_RELIC_INFRA_KEY"
 default['newrelic_infra']['package_version'] = "1.0.785"
 default['newrelic_infra']['logfile'] = "/var/log/newrelic/newrelic-infra.log"
+default['newrelic_infra']['display_name'] = nil

--- a/cookbooks/newrelic_infra/metadata.rb
+++ b/cookbooks/newrelic_infra/metadata.rb
@@ -4,3 +4,5 @@ maintainer_email 'support@engineyard.com'
 version '1.0'
 source_url 'https://engineyard.com'
 issues_url 'https://support.engineyard.com'
+
+depends 'newrelic'

--- a/cookbooks/newrelic_infra/recipes/default.rb
+++ b/cookbooks/newrelic_infra/recipes/default.rb
@@ -3,6 +3,10 @@
 # Recipe:: default
 #
 
+class Chef::Recipe
+  include NewrelicHelpers
+end
+
 package_version = node['newrelic_infra']['package_version']
 
 deb_file = "newrelic-infra_sysv_#{package_version}_amd64.deb"
@@ -55,6 +59,14 @@ template "/etc/init.d/newrelic-infra" do
   })
 end
 
+if node['newrelic_infra']['use_newrelic_addon']
+  license_key = newrelic_license_key
+else
+  license_key = node['newrelic_infra']['license_key']
+end
+
+display_name = node['newrelic_infra']['display_name']
+
 template "/etc/newrelic-infra.yml" do
   source "newrelic-infra.yml.erb"
   owner "root"
@@ -62,7 +74,8 @@ template "/etc/newrelic-infra.yml" do
   mode 0600
   backup false
   variables({
-    :license_key => node['newrelic_infra']['license_key']
+    :license_key => license_key,
+    :display_name => display_name
   })
 end
 

--- a/cookbooks/newrelic_infra/templates/default/newrelic-infra.yml.erb
+++ b/cookbooks/newrelic_infra/templates/default/newrelic-infra.yml.erb
@@ -1,1 +1,4 @@
 license_key: <%= @license_key %>
+<% if @display_name %>
+display_name: <%= @display_name %>
+<% end %>

--- a/custom-cookbooks/newrelic_infra/cookbooks/custom-newrelic_infra/README.md
+++ b/custom-cookbooks/newrelic_infra/cookbooks/custom-newrelic_infra/README.md
@@ -38,7 +38,7 @@ All customizations go to `cookbooks/custom-newrelic_infra/attributes/default.rb`
 
 ### License Key
 
-Please make sure to specify the license key in custom-newrelic_infra/attributes/default.rb:
+Please make sure to specify the license key in `custom-newrelic_infra/attributes/default.rb`:
 
 ```ruby
 # Replace value with actual license key
@@ -47,10 +47,41 @@ default['newrelic_infra']['license_key'] = "INSERT_NEW_RELIC_INFRA_KEY"
 
 This will be used in generating /etc/newrelic-infra.yml.
 
+If you are using the New Relic account from the New Relic add-on, you can avoid specifying the license key in the attributes file. Please uncomment the following line in `custom-newrelic_infra/attributes/default.rb` to reuse the license key from the add-on:
+
+```ruby
+# To use the license key from the New Relic addon, please uncomment the line below:
+default['newrelic_infra']['use_newrelic_addon'] = true
+```
+
 ### Package Version
 
-The recipe downloads the New Relic Infrastructure .deb package version as specified in the attributes/default.rb. Please update the version number as necessary:
+The recipe downloads the New Relic Infrastructure .deb package version as specified in the `attributes/default.rb`. Please update the version number as necessary:
 
 ```ruby
 default['newrelic_infra']['package_version'] = "1.0.785"
 ```
+
+### Display Name
+
+New Relic Infrastructure uses the hostname as the unique identifier for each host. If you prefer to override the auto-generated hostname for reporting, you can specify your own `display_name` in `custom-newrelic_infra/attributes/default.rb`:
+
+```ruby
+default['newrelic_infra']['display_name'] = "DISPLAY_NAME"
+```
+
+You can dynamically build the display name by using attributes like:
+
+* `node['dna']['instance_role']` - instance role (e.g. "app_master" or "db_slave" or "util")
+* `node['dna']['name']` - name of the instance (e.g. "redis" utility instance)
+* `node['dna']['environment']['name']` - name of the environment
+
+Please refer to the New Relic Infrastructure configuration documentation:
+
+https://docs.newrelic.com/docs/infrastructure/new-relic-infrastructure/configuration/configure-infrastructure-agent
+
+## Credits
+
+Thanks to [Aviram Radai][1] for showing their recipe on how they installed the New Relic Infrastructure agent in their environment.
+
+[1]: https://github.com/aviramradai

--- a/custom-cookbooks/newrelic_infra/cookbooks/custom-newrelic_infra/attributes/default.rb
+++ b/custom-cookbooks/newrelic_infra/cookbooks/custom-newrelic_infra/attributes/default.rb
@@ -1,5 +1,8 @@
-# default['newrelic_infra']['license_key'] = "INSERT_NEW_RELIC_INFRA_KEY"
 # default['newrelic_infra']['package_version'] = "1.0.785"
 # default['newrelic_infra']['logfile'] = "/var/log/newrelic/newrelic-infra.log"
+# default['newrelic_infra']['display_name'] = nil
 
-default['newrelic_infra']['license_key'] = "STILL_NOT_A_LICENSE_KEY"
+default['newrelic_infra']['license_key'] = "INSERT_NEW_RELIC_INFRA_KEY"
+
+# To use the license key from the New Relic addon, please uncomment the line below:
+# default['newrelic_infra']['use_newrelic_addon'] = true


### PR DESCRIPTION
Description of your patch
-------------

The update adds two new attributes:

* `default['newrelic_infra']['use_newrelic_addon']` - set to `true` to indicate that you want to use the license key from the New Relic add-on. When using this, there's no need to specify the license key with `default['newrelic_infra']['license_key']`.
* `default['newrelic_infra']['display_name']` - sets the `display_name` New Relic Infra configuration setting (see https://docs.newrelic.com/docs/infrastructure/new-relic-infrastructure/configuration/configure-infrastructure-agent).

The README has been updated to describe these new attributes, and a Credits section was also added.

Recommended Release Notes
-------------

New Relic Infrastructure custom chef recipe adds new attributes to support using license key from New Relic add-on, and a custom display name for the hosts.

Estimated risk
-------------

Low - only affects customers who enable custom-newrelic_infra recipe.

Components involved
-------------

newrelic-infra

Description of testing done
-------------

Tested on a simple cluster: one app master, one db master.

The following cases were tested for the attribute `use_newrelic_addon`:

* Don't set `use_newrelic_addon`, /etc/newrelic-infra.yml contains license key set in attributes.rb
* Set `use_newrelic_addon` to `true`:
  * NR add-on is not activated on the environment. The /etc/newrelic-infra.yml contains a blank license key, even if you set the `license_key` attribute.
  * NR add-on is activated on the environment. The /etc/newrelic-infra.yml contains the license key from the NR account of the NR add-on.

Test cases for `display_name`:

* Don't set `display_name`. The /etc/newrelic-infra.yml should not have a `display_name` configuration.
* Set `dispaly_name` to a hardcoded value. The value must show in /etc/newrelic-infra.yml.
* Set `display_name` to dynamic value, `"#{node['dna']['environment']['name']}-#{node['dna']['instance_role']}"`. The /etc/newrelic-infra.yml must contain the display_name with a value that's a concatenation of the environment name and the instance role.

QA Instructions
-------------

TODO
