### PR TITLE
[CC-1150] Handle crashed ntpd processes gracefully.

### DIFF
--- a/cookbooks/ntp/templates/default/ey-ntp-check.erb
+++ b/cookbooks/ntp/templates/default/ey-ntp-check.erb
@@ -1,12 +1,18 @@
 #!/bin/bash
 
-set -euo pipefail
+restart_ntpd() {
+    logger -t 'ntp_check' "EY: ntpd ${1}; restarting ntpd"
+    /etc/init.d/ntpd restart
+    [[ $? -ne 0 ]] && logger -t 'ntp_check' "EY: /etc/init.d/ntpd restart exited non-zero!"
+}
 
 # field 5 is the time since we last spoke to a peer
 # the first two lines of ntpq are a header with labels for the various fields
 # skipping the first two lines gives us just peers, independent of how many there are
+if ntpq -pn | tail -n+3 | awk '{print $5}' | grep -q '\([2-9][0-9]h\|[0-9]\+d\)' ; then
+    restart_ntpd "stale NTP peers detected"
+fi
 
-if ntpq -pn | tail -n+3 | awk '{print $5}' | grep '\([2-9][0-9]h\|[0-9]\+d\)' || ! /etc/init.d/ntpd -q status ; then
-    logger -t 'ntp_check' "EY: ntpd crashed or stale NTP peers detected; restarting NTP"
-    /etc/init.d/ntpd restart
+if ! /etc/init.d/ntpd -q status ; then
+    restart_ntpd "status check failed"
 fi


### PR DESCRIPTION
Description of your patch
-------------
Check separately to see if ntpd is running and restart it if not. This resolves an issue where the test for stale peers failed silently without ntpd being restarted if the ntpd process itself was not running.

Recommended Release Notes
-------------
Resolves an issue with detecting a crashed ntpd process.

Estimated risk
-------------
Low - we monitor separately for ntpd failures, this change is intended to fix one failure mode that isn't currently handled automatically.

Components involved
-------------
`/engineyard/bin/ey-ntp-check` - a script which is called from cron.

Description of testing done
-------------
Booted an instance, copied in the modified script and then tested that the script successfully detects and corrects both a stopped and a crashed ntpd process.

QA Instructions
-------------

Boot a new instance.

* Verify that ntpd is running, by running `ntpq -pn` (output should be similar to the sample below, with no errors):

```
# ntpq -pn
     remote           refid      st t when poll reach   delay   offset  jitter
==============================================================================
*195.21.152.161  195.66.241.2     2 u    9   64    1   66.188    2.326   2.924
+69.196.158.106  10.132.226.26    3 u   12   64    1   53.072    8.783   2.764
+173.255.206.154 112.230.30.243   3 u   12   64    1   31.632   -0.796   3.375
```

* Verify that the check script succeeds, returning an exit status of 0 when ntpd is running:

```
ip-10-229-154-13 ~ # /engineyard/bin/ey-ntp-check 
ip-10-229-154-13 ~ # echo $?
0
```

* Stop the `ntpd` process gracefully by running `/etc/init.d/ntpd stop`

* Run the check script, and verify that ntpd is restarted:

```
# /engineyard/bin/ey-ntp-check 
ntpq: read: Connection refused * Starting ntpd ...                                                                [ ok ]
```

* Stop the `ntpd` process ungracefully by running:

```
kill -9 `pgrep ntpd`
```

* Run the check script again:

```
# /engineyard/bin/ey-ntp-check 
ntpq: read: Connection refused * status: crashed
 * Stopping ntpd ...
 * start-stop-daemon: no matching processes found                                                                 [ ok ]
 * Starting ntpd ...                                                                                              [ ok ]
```
