### PR TITLE
[YT-CC-1236] Rewrite candidate_version determination for increased speed and reduced complexity/error-chance

### DIFF
--- a/cookbooks/ey-base/recipes/chef_patches.rb
+++ b/cookbooks/ey-base/recipes/chef_patches.rb
@@ -1,17 +1,67 @@
+#
+# Changes for Chef 12.7.2 and 12.10.24:
+# YT-CC-1236: Rewrite candidate_version determination for increased speed and reduced complexity/error-chance.
+#
+
 require 'chef/provider/package/portage'
 
 ChefPatches = {
-  '12.7.2' => [:install_package],
-  '12.10.24' => [:install_package]
+  '12.7.2' => [:candidate_version, :install_package],
+  '12.10.24' => [:candidate_version, :install_package]
 }
 
 unless ChefPatches.has_key?(Chef::VERSION)
   raise Chef::Exceptions::Package, "This version of Chef (#{Chef::VERSION}) may not correctly handle explicit portage categories -- see cookbooks/ey-base/recipes/chef_patches.rb"
 end
 
-if ChefPatches[Chef::VERSION].include? :install_package
-
+if ChefPatches[Chef::VERSION].include? :candidate_version
   class Chef::Provider::Package::Portage
+
+    def raise_error_for_query(msg)
+      raise Chef::Exceptions::Package, "Query for '#{@new_resource.package_name}' #{msg}"
+    end
+
+    def candidate_version
+      return @candidate_version if @candidate_version
+
+      pkginfo = shell_out("portageq best_visible / #{@new_resource.package_name}")
+
+      if pkginfo.exitstatus != 0
+        pkginfo.stderr.each_line do |line|
+          if line =~ /[Uu]nqualified atom .*match.* multiple/
+            raise_error_for_query("matched multiple packages (please specify a category):\n#{pkginfo.inspect}")
+          end
+        end
+
+        if pkginfo.stdout.strip.empty?
+          raise_error_for_query("did not find a matching package:\n#{pkginfo.inspect}")
+        end
+
+        raise_error_for_query("resulted in an unknown error:\n#{pkginfo.inspect}")
+      end
+
+      if pkginfo.stdout.lines.count > 1
+        raise_error_for_query("produced unexpected output (multiple lines):\n#{pkginfo.inspect}")
+      end
+
+      pkginfo.stdout.chomp!
+      if pkginfo.stdout =~ /-r[[:digit:]]+$/
+        # Latest/Best version of the package is a revision (-rX).
+        @candidate_version = pkginfo.stdout.split(/(?<=-)/).last(2).join
+      else
+        # Latest/Best version of the package is NOT a revision (-rX).
+        @candidate_version = pkginfo.stdout.split('-').last
+      end
+
+      @candidate_version
+    end
+
+  end
+end
+
+if ChefPatches[Chef::VERSION].include? :install_package
+  class Chef::Provider::Package::Portage
+
     def install_package(name, version)
       pkg = "=#{name}-#{version}"
 
@@ -22,5 +72,6 @@ if ChefPatches[Chef::VERSION].include? :install_package
 
       shell_out_with_timeout!( "emerge -g -n --color n --nospinner --quiet#{expand_options(@new_resource.options)} #{pkg}" )
     end
+
   end
 end

--- a/cookbooks/ey-base/recipes/chef_patches.rb
+++ b/cookbooks/ey-base/recipes/chef_patches.rb
@@ -45,12 +45,12 @@ if ChefPatches[Chef::VERSION].include? :candidate_version
       end
 
       pkginfo.stdout.chomp!
-      if pkginfo.stdout =~ /-r[[:digit:]]+$/
+      if pkginfo.stdout =~ /-r\d+$/
         # Latest/Best version of the package is a revision (-rX).
         @candidate_version = pkginfo.stdout.split(/(?<=-)/).last(2).join
       else
         # Latest/Best version of the package is NOT a revision (-rX).
-        @candidate_version = pkginfo.stdout.split('-').last
+        @candidate_version = pkginfo.stdout.split("-").last
       end
 
       @candidate_version


### PR DESCRIPTION
Currently Chef determines this by parsing 'emerge', which is time consuming and error prone. This PR/change results in a large speed increase for Gentoo-based systems and Engine Yard's cookbooks.

Description of your patch
-------------
Rewrites candidate_version determination in Chef's Chef::Provider::Package::Portage class for increased speed and reduced complexity/error-chance.

Recommended Release Notes
-------------
Speed improvements to the execution of Chef cookbooks package resource.

Estimated risk
-------------
Touches sensitive/low-level chef interfaces to the OS packaging manager for Gentoo systems. So potentially high risk. However, the changes have been tested thoroughly and best efforts have been made to be a fully-compatible drop-in replacement.

Components involved
-------------
Chef and EYGL

Description of testing done
-------------
Beyond the scope of this PR really. Tested from every angle I could imagine with variety of ebuild+version string possibilities. Tapped the inputs and output for observation, etc.

QA Instructions
-------------
Create a full testing stack and boot fresh environment. All "package" resource actions should be successful/same as before and without error. Just much faster.