### PR TITLE
[YT-CC-1241] Collectd cookbook calls Nginx upgrade on every Chef run

### DIFF
--- a/cookbooks/collectd/attributes/defaults.rb
+++ b/cookbooks/collectd/attributes/defaults.rb
@@ -6,5 +6,5 @@ default['swap_warn_threshold'] = "0.50"
 default['swap_crit_threshold'] = "0.70"
 default['swap_warning_total'] = node['swap_total_bytes'] * node['swap_warn_threshold'].to_f
 default['swap_critical_total'] = node['swap_total_bytes'] * node['swap_crit_threshold'].to_f
-
+default['collectd']['nginx']['version'] = node.engineyard.metadata('nginx_ebuild_version','1.12.1')
 default['collectd']['version'] = "5.4.1-r3"

--- a/cookbooks/collectd/templates/default/collectd_nginx_version.conf.erb
+++ b/cookbooks/collectd/templates/default/collectd_nginx_version.conf.erb
@@ -1,0 +1,1 @@
+# Last Version: <%= @version %>


### PR DESCRIPTION
## Description of your patch

This patch allows to reduce Chef running time on working environment by ~10 seconds. 

## Recommended Release Notes

None

## Estimated risk

Low

## Components involved

Collectd Nginx service

## Description of testing done

See QA instructions

## QA Instructions

1. Create a simple Ruby application.  (https://github.com/engineyard/todo.git) can be used for this testing.
2. Boot the environment with QA stack created from the PR282_improvement branch. Environment should be run with following parameters:
  * Environment type - Single Instance.
  * Application Server Stack - Passenger5.
4. Replace collectd cookbook with cookbook provided from this pull request branch. 
5. Run Chef `PATH=/usr/local/ey_resin/bin:$PATH /home/ey/bin/chef-solo -j /etc/chef/dna.json -c /etc/chef/solo.rb`. Fix the Chef running time.
6. Run Chef again. Ensure Chef took ~10 seconds less to run.
7. Run command `monit summary`. Ensure 	`collectd_httpd` service is in `running` state.