### PR TITLE
[YT-CC-1244] Fix load_current_resource to correctly read version strings ending in a lower-case alpha character

### DIFF
--- a/cookbooks/ey-base/recipes/chef_patches.rb
+++ b/cookbooks/ey-base/recipes/chef_patches.rb
@@ -1,17 +1,53 @@
 #
 # Changes for Chef 12.7.2 and 12.10.24:
 # YT-CC-1236: Rewrite candidate_version determination for increased speed and reduced complexity/error-chance.
+# YT-CC-1244: Fix load_current_resource to correctly read version strings ending in a lower-case alpha character.
 #
 
 require 'chef/provider/package/portage'
 
 ChefPatches = {
-  '12.7.2' => [:candidate_version, :install_package],
-  '12.10.24' => [:candidate_version, :install_package]
+  '12.7.2' => [:candidate_version, :install_package, :load_current_resource],
+  '12.10.24' => [:candidate_version, :install_package, :load_current_resource]
 }
 
 unless ChefPatches.has_key?(Chef::VERSION)
   raise Chef::Exceptions::Package, "This version of Chef (#{Chef::VERSION}) may not correctly handle explicit portage categories -- see cookbooks/ey-base/recipes/chef_patches.rb"
+end
+
+if ChefPatches[Chef::VERSION].include? :load_current_resource
+  class Chef::Provider::Package::Portage
+
+    def load_current_resource
+      @current_resource = Chef::Resource::Package.new(@new_resource.name)
+      @current_resource.package_name(@new_resource.package_name)
+
+      category, pkg = %r{^#{PACKAGE_NAME_PATTERN}$}.match(@new_resource.package_name)[1, 2]
+
+      globsafe_category = category ? Chef::Util::PathHelper.escape_glob_dir(category) : nil
+      globsafe_pkg = Chef::Util::PathHelper.escape_glob_dir(pkg)
+      possibilities = Dir["/var/db/pkg/#{globsafe_category || "*"}/#{globsafe_pkg}-*"].map { |d| d.sub(%r{/var/db/pkg/}, "") }
+      versions = possibilities.map do |entry|
+	if entry =~ %r{[^/]+/#{Regexp.escape(pkg)}\-(\d[\.\d]*[a-z]?((_(alpha|beta|pre|rc|p)\d*)*)?(-r\d+)?)}
+          [$&, $1]
+        end
+      end.compact
+
+      if versions.size > 1
+        atoms = versions.map { |v| v.first }.sort
+        categories = atoms.map { |v| v.split("/")[0] }.uniq
+        if !category && categories.size > 1
+          raise Chef::Exceptions::Package, "Multiple packages found for #{@new_resource.package_name}: #{atoms.join(" ")}. Specify a category."
+        end
+      elsif versions.size == 1
+        @current_resource.version(versions.first.last)
+        Chef::Log.debug("#{@new_resource} current version #{$1}")
+      end
+
+      @current_resource
+    end
+
+  end
 end
 
 if ChefPatches[Chef::VERSION].include? :candidate_version


### PR DESCRIPTION
Description of the issue (copied from YT-CC-1244)
-------------

The load_current_resource method within the Chef version(s) we use for stable-v5 and below cannot correctly detect versions of packages with an alpha character to end the version string. This is a valid and acceptable version format within Gentoo. A couple examples of packages that are versioned like this and referenced within our cookbooks are:
=sys-libs/timezone-data-2016c
=dev-libs/openssl-1.0.2k

When chef inspects the system to see what is already installed, it believes the version is "2016" instead of "2016c" or "1.0.2" instead of "1.0.2k" and thus triggers an "upgrade" of the package on every Chef run. Really the same exact package/version is triggered for re-install. Our install_package resource redefinition includes the -n/–noreplace option to emerge, so some of the cost is already bypassed. But this is the very last action in the chain, so much processing is done before getting to this point. That means wasted/useless time in the Chef run.

Upstream Chef already has the fix for this, so future EY stacks will not need a patch:
https://github.com/chef/chef/blob/master/lib/chef/provider/package/portage.rb#L43

However, we should add this fix ourselves for stable-v4 and stable-v5.

Description of your patch
-------------
Fix load_current_resource to correctly read version strings ending in a lower-case alpha character. Copied the load_current_resource function from Chef 12.10.24 (the Chef used in stable-v5) and changed the version detection line to match current upstream Chef.

Recommended Release Notes
-------------
Speed improvements to the execution of Chef cookbooks package resource.

Estimated risk
-------------
Touches sensitive/low-level chef interfaces to the OS packaging manager for Gentoo systems. So potentially high risk. However, the changes have been tested thoroughly and best efforts have been made to be a fully-compatible drop-in replacement.

Components involved
-------------
Chef and EYGL

Description of testing done
-------------
Tested with variety of ebuild+version string possibilities. Tapped the inputs and output for observation, etc. This patch shaves 19 seconds off Chef runs (both initial and re-runs) on our current stable-v5 cookbooks on an m3.large. Will save more if more packages ending in a version string are ever added or referenced by cookbooks in the future.

QA Instructions
-------------
Create a full testing stack and boot fresh environment, make sure everything works upon provisioning of a fresh environment. Any re-runs of chef should not trigger upgrades or re-installs of packages that are already installed/latest version where the version string ends in a lower-case alpha character.