### PR TITLE
Add Symlink for lsmod for agent compatibility

### DIFF
--- a/cookbooks/newrelic_infra/recipes/default.rb
+++ b/cookbooks/newrelic_infra/recipes/default.rb
@@ -74,6 +74,12 @@ cookbook_file "/etc/monit.d/newrelic_infra.monitrc" do
   backup false
 end
 
+execute "Symlink lsmod" do
+   command "ln -s /bin/lsmod /sbin/lsmod"
+   not_if "test -f /sbin/lsmod"
+end
+
+
 execute "monit reload" do
   action :run
 end


### PR DESCRIPTION
Agents look for lsmod in different path