### PR TITLE
Restart at NewRelic Infra is more reliable

### DIFF
--- a/cookbooks/newrelic_infra/files/default/newrelic_infra.monitrc
+++ b/cookbooks/newrelic_infra/files/default/newrelic_infra.monitrc
@@ -1,5 +1,5 @@
 check process newrelic_infra
   with pidfile /var/run/newrelic-infra.pid
-  start program = "/etc/init.d/newrelic-infra start"
+  start program = "/etc/init.d/newrelic-infra restart"
   stop program = "/etc/init.d/newrelic-infra stop"
   group newrelic_infra


### PR DESCRIPTION
Once crashed the restart as start command is more reliable.
Tested with kill -9