### PR TITLE
Upgrade installed yarn to 0.27.5

### DIFF
--- a/cookbooks/node/recipes/common.rb
+++ b/cookbooks/node/recipes/common.rb
@@ -132,7 +132,7 @@ end
 
 # Install yarn. YT-CC-1132.
 package 'sys-apps/yarn' do
-  version '0.21.3-r1'
+  version '0.27.5'
 end
 
 if node.engineyard.environment.component?('nodejs')


### PR DESCRIPTION
## Description of your patch

Upgrade yarn to 0.27.5.  Versions of yarn > 0.25 are required for Webpacker apps.

## Recommended Release Notes

Upgrade yarn to 0.27.5, for compatibility with deploying Webpacker apps.

## Estimated risk

Low

## Components involved

Yarn binaries

## Description of testing done

See QA instructions

## QA Instructions

Boot a solo and a cluster environment running any stack. Verify that there are no Chef errors, and `yarn -v` returns 0.27.5 on the solo/app_master/app instances.