### PR TITLE
Use graceful restart in unicorn

### DIFF
--- a/cookbooks/unicorn/templates/default/unicorn.rb.erb
+++ b/cookbooks/unicorn/templates/default/unicorn.rb.erb
@@ -87,7 +87,7 @@ before_fork do |server, worker|
 
   if File.exists?(old_pid) && server.pid != old_pid
     begin
-      sig = (worker.nr + 1) >= server.worker_processes ? :TERM : :TTOU
+      sig = (worker.nr + 1) >= server.worker_processes ? :QUIT : :TTOU
       Process.kill(sig, File.read(old_pid).to_i)
     rescue Errno::ENOENT, Errno::ESRCH
       # someone else did our job for us


### PR DESCRIPTION
Description of your patch
-------------

The comment above says `QUIT`, but the code does `TERM`.

According to documentation: https://bogomips.org/unicorn/SIGNALS.html

TERM - quick shutdown, kills all workers immediately
QUIT - graceful shutdown, give workers some time to finish their current request before finishing.

Therefore, usual safe scenario of restarting unicorn during deployment involves using `QUIT`.

Recommended Release Notes
-------------

Deployment of application using unicorn use graceful restarting, which prevents requests to be killed without giving them chance to finish.

Estimated risk
-------------
low

Components involved
-------------
unicorn

Description of testing done
-------------
Deployed the same fix to our application.

QA Instructions
-------------