### PR TITLE
[CC-1250] Support for PHP 7.2

### DIFF
--- a/cookbooks/php/attributes/php.rb
+++ b/cookbooks/php/attributes/php.rb
@@ -6,7 +6,9 @@ default['php']['version'] = case attribute['dna']['engineyard']['environment']['
   when 'php_7'
     '7.0.11'
   when 'php_71'
-      '7.1.0'
+    '7.1.0'
+  when 'php_72'
+    '7.2.8'
   else
    '5.6.30'
 end


### PR DESCRIPTION
# Description of your patch
Add support for PHP 7.2.

# Recommended Release Notes
Support for PHP 7.2.

# Estimated risk
High. Changes are made to the php recipes which are a central part of the stack.

# Components involved
PHP chef recipes.

# Description of testing done
1. Created a development stack (based on stable-v5 3.0) with this branch and booted a solo environment (howto app) with "PHP 7.2" selected.
  Verified that the app can be deployed successfully.
  Verified that the expected php package (=dev-lang/php-7.2.8) was installed and selected by default.
2. Created a stable-v5 solo environment (howto app) with "PHP 7.1" (sic!) selected.
  Verified that the app can be deployed successfully.
  Then, edited the environment and upgraded to the development stack with this branch.
  Applied the upgrade and checked if the app still works.
  Edited the environment again and selected "PHP 7.2".
  Applied and tested for functionality.

# QA Instructions
See above.