### PR TITLE
[CC-1252] Enable support for node.js series 8.x, 9.x, and 10.x

### DIFF
--- a/cookbooks/node/attributes/node.rb
+++ b/cookbooks/node/attributes/node.rb
@@ -14,6 +14,12 @@ fuzzy_version = begin
                 end
 
 fallback_nodejs_version = case (fuzzy_version || hard_version)
+                           when 'nodejs_10'
+                             '10.10.0'
+                           when 'nodejs_9'
+                             '9.11.2'
+                           when 'nodejs_8'
+                             '8.12.0'
                            when 'nodejs_6'
                              '6.9.5'
                            when 'nodejs_5'
@@ -31,7 +37,10 @@ default['nodejs']['available_versions'] = [
   '5.11.0', # net-libs/nodejs-5.11.0
   '6.4.0', # net-libs/nodejs-6.4.0
   '6.7.0', # net-libs/nodejs-6.7.0
-  '6.9.5' # net-libs/nodejs-6.9.5
+  '6.9.5', # net-libs/nodejs-6.9.5
+  '8.12.0', # net-libs/nodejs-bin-8.12.0
+  '9.11.2', # net-libs/nodejs-bin-9.11.2
+  '10.10.0' # net-libs/nodejs-bin-10.10.0
 ]
 
 if (node.engineyard.metadata('openssl_ebuild_version','1.0.1') =~ /1\.0\.1/)
@@ -42,8 +51,10 @@ if (node.engineyard.metadata('openssl_ebuild_version','1.0.1') =~ /1\.0\.1/)
     '5.11.0', # net-libs/nodejs-5.11.0
     '6.4.0', # net-libs/nodejs-6.4.0
     '6.7.0', # net-libs/nodejs-6.7.0
-    '6.9.5' # net-libs/nodejs-6.9.5
-
+    '6.9.5', # net-libs/nodejs-6.9.5
+    '8.12.0', # net-libs/nodejs-bin-8.12.0
+    '9.11.2', # net-libs/nodejs-bin-9.11.2
+    '10.10.0' # net-libs/nodejs-bin-10.10.0
   ])
 end
 

--- a/cookbooks/node/recipes/common.rb
+++ b/cookbooks/node/recipes/common.rb
@@ -1,5 +1,8 @@
 get_package_name = {
   '4.4.5' => 'net-libs/nodejs',
+  '8.12.0' => 'net-libs/nodejs-bin',
+  '9.11.2' => 'net-libs/nodejs-bin',
+  '10.10.0' => 'net-libs/nodejs-bin'
 }
 get_package_name.default = 'net-libs/nodejs'
 


### PR DESCRIPTION
Description of your patch
-------------
This enables support for node.js series 8.x, 9.x, and 10.x in stable-v5. It will use the EYGL net-libs/nodejs-bin packages.

Recommended Release Notes
-------------
Support for node.js 8.x, 9.x, and 10.x.

Estimated risk
-------------
Medium. We only add new versions of node.js. Nevertheless, this is a core recipe which is used for node.js apps and for ruby apps (asset compilation) as well.

Components involved
-------------
node recipes

Description of testing done
-------------
- Create a ruby app with selected node 8 on the QA stack. Boot the environment, deploy, check if it works.
- Create a ruby app with default node on stable-v5. Boot the environment, deploy, check if it works.
  - Upgrade to the QA stack with this PR. Apply, deploy, check if it works.
  - Upgrade the node version to 8. Apply, deploy, check if it works.
- Create a node app with selected node 8 on the QA stack and PM2. Boot the environment, deploy, check if it works.
- Create a node app with default node on stable-v5 and PM2. Boot the environment, deploy, check if it works.
  - Upgrade to the QA stack with this PR. Apply, deploy, check if it works.
  - Upgrade the node version to 8. Apply, deploy, check if it works.
- Create a node app with default node on stable-v5 and nginx. Boot the environment, deploy, check if it works.
  - Upgrade to the QA stack with this PR. Apply, deploy, check if it works.
  - Upgrade the node version to 8. Apply, deploy, check if it works.

QA Instructions
-------------
See above.