### PR TITLE
[CC 1249] Support for PostgreSQL 10

### DIFF
--- a/cookbooks/postgresql/attributes/extension_details.rb
+++ b/cookbooks/postgresql/attributes/extension_details.rb
@@ -26,13 +26,18 @@ default[:pg_ext_details] = {
 # postgis version details
 case attribute.dna.engineyard.environment.db_stack_name
 when "postgres9_6"
-  default[:postgis_version] = '2.3.3'
+  default[:postgis_version] = "2.3.3"
   # separating these in case we decide to bump them later
   default[:proj_version] = "4.8.0"
   default[:geos_version] = "3.5.0-r2"
   default[:gdal_version] = "1.11.1"
+when "postgres10"
+  default[:postgis_version] = "2.4.4"
+  default[:proj_version] = "4.8.0"
+  default[:geos_version] = "3.6.2"
+  default[:gdal_version] = "1.11.1-r3"
 else
-  default[:postgis_version] = '2.2.2'
+  default[:postgis_version] = "2.2.2"
   default[:proj_version] = "4.8.0"
   default[:geos_version] = "3.5.0-r2"
   default[:gdal_version] = "1.11.1"

--- a/cookbooks/postgresql/attributes/version.rb
+++ b/cookbooks/postgresql/attributes/version.rb
@@ -8,6 +8,9 @@ when "postgres9_5"
 when "postgres9_6"
   default['postgresql']['latest_version'] = '9.6.3'
   default['postgresql']['short_version'] = '9.6'
+when "postgres10"
+  default['postgresql']['latest_version'] = '10.4'
+  default['postgresql']['short_version'] = '10'
 end
 default['postgresql']['datadir'] = "/db/postgresql/#{node['postgresql']['short_version']}/data/"
 default['postgresql']['dbroot'] = '/db/postgresql/'

--- a/cookbooks/postgresql/libraries/helpers.rb
+++ b/cookbooks/postgresql/libraries/helpers.rb
@@ -31,6 +31,28 @@ module PostgreSQL
         %x{echo "shared_preload_libraries = '#{lib}'" >> #{custom_conf}}
       end
     end
+
+    def postgres_version_cmp(lhs_version, rhs_version)
+      lhs_version_components = lhs_version
+        .split('.')
+        .map { |c| c.to_i }
+      rhs_version_components = rhs_version
+        .split('.')
+        .map { |c| c.to_i }
+      lhs_version_components <=> rhs_version_components
+    end
+
+    def postgres_version_gte?(compare_version)
+      postgres_version_cmp(node[:postgresql][:short_version], compare_version) >= 0
+    end
+
+    def postgres_version_gt?(compare_version)
+      postgres_version_cmp(node[:postgresql][:short_version], compare_version) > 0
+    end
+
+    def postgres_version_lt?(compare_version)
+      not postgres_version_gte?(compare_version)
+    end
   end
 end
 

--- a/cookbooks/postgresql/recipes/server_configure.rb
+++ b/cookbooks/postgresql/recipes/server_configure.rb
@@ -184,6 +184,7 @@ if ['db_slave'].include?(node.dna['instance_role'])
       :archive_timeout => '0',
       :timezone => timezone
     )
+    helpers(PostgreSQL::Helper)
   end
 
   template "#{postgres_root}/#{postgres_version}/data/recovery.conf" do

--- a/cookbooks/postgresql/recipes/server_install.rb
+++ b/cookbooks/postgresql/recipes/server_install.rb
@@ -46,7 +46,7 @@ ruby_block 'check lock version' do
       %x{ grep -q "=dev-db/postgresql-#{package_version}" /etc/portage/package.keywords/local || echo "=dev-db/postgresql-#{package_version}" >> /etc/portage/package.keywords/local}
       run_context.resource_collection.find(:package => "dev-db/postgresql").version package_version
     end
-    if package_version >= '9.3'
+    if postgres_version_cmp(package_version, '9.3') >= 0
       %x{ grep -q "=dev-python/python-exec-0.2" /etc/portage/package.keywords/local || echo "=dev-python/python-exec-0.2" >> /etc/portage/package.keywords/local}
     end
   end

--- a/cookbooks/postgresql/recipes/server_install.rb
+++ b/cookbooks/postgresql/recipes/server_install.rb
@@ -4,6 +4,7 @@ known_ebuild_versions = %w[
   9.4.8   9.4.11  9.4.12
   9.5.3   9.5.6   9.5.7
   9.6.3
+  10.4
 ]
 
 execute "dropping lock version file" do

--- a/cookbooks/postgresql/resources/pg_extension.rb
+++ b/cookbooks/postgresql/resources/pg_extension.rb
@@ -21,7 +21,7 @@ action :install do
 
       db_names.each do |db_name|
         # bail with a log message if the extension isn't supported for the active Postgres major version
-        if (!ext_details[:min_pg_version].nil? and postgres_version < ext_details[:min_pg_version]) || (!ext_details[:max_pg_version].nil? and postgres_version > ext_details[:max_pg_version])
+        if (!ext_details[:min_pg_version].nil? and postgres_version_lt?(ext_details[:min_pg_version])) || (!ext_details[:max_pg_version].nil? and postgres_version_gt?(ext_details[:max_pg_version]))
           Chef::Log.info "PostgreSQL extension #{ext_name} is only supported on versions #{ext_details[:min_pg_version]} #{!ext_details[:max_pg_version].nil? ? "to " + ext_details[:max_pg_version].to_s : "and higher"}. Currently installed version: #{postgres_version}."
           break
         end

--- a/cookbooks/postgresql/templates/default/postgresql.conf.erb
+++ b/cookbooks/postgresql/templates/default/postgresql.conf.erb
@@ -76,7 +76,7 @@ ssl = on				# (change requires restart)
 ssl_ca_file = 'root.crt'
 #ssl_ciphers = 'ALL:!ADH:!LOW:!EXP:!MD5:@STRENGTH'	# allowed SSL ciphers
 					# (change requires restart)
-<% if @postgres_version < "9.5" %>
+<% if postgres_version_lt?("9.5") %>
 ssl_renegotiation_limit = 0	# amount of data between renegotiations
 <% end %>
 #password_encryption = on
@@ -168,7 +168,7 @@ wal_writer_delay = <%= @wal_writer_delay %>		# 1-10000 milliseconds
 
 # - Checkpoints -
 
-<% if @postgres_version >= "9.5" %>
+<% if postgres_version_gte?("9.5") %>
 max_wal_size = 4800MB
 min_wal_size = 80MB
 <% else %>

--- a/cookbooks/postgresql/templates/default/recovery.conf.erb
+++ b/cookbooks/postgresql/templates/default/recovery.conf.erb
@@ -1,7 +1,7 @@
 standby_mode = '<%= @standby_mode %>'
-primary_conninfo = 'host=<%= @primary_host %> port=<%= @primary_port %> user=<%= @primary_user %> password=<%= @primary_password %> <% if @postgres_version >= "9.1" %>application_name=<%= @conn_app_name %><% end %>'
+primary_conninfo = 'host=<%= @primary_host %> port=<%= @primary_port %> user=<%= @primary_user %> password=<%= @primary_password %> <% if postgres_version_gte?("9.1") %>application_name=<%= @conn_app_name %><% end %>'
 trigger_file = '<%= @trigger_file %>'
 restore_command = 'cp /db/postgresql/<%= @postgres_version %>/wal/%f %p'
 archive_cleanup_command = 'pg_archivecleanup /db/postgresql/<%= @postgres_version %>/wal %r'
-<% if @postgres_version >= "9.1" %>recovery_target_timeline = latest<% end %>
+<% if postgres_version_gte?("9.1") %>recovery_target_timeline = latest<% end %>
   

--- a/manifest/Gemfile
+++ b/manifest/Gemfile
@@ -8,5 +8,5 @@ end
 
 source 'https://nextgem.engineyard.com/' do
   gem 'ey_enzyme',              '2.0.5'
-  gem 'ey_snaplock',            '2.0.3'
+  gem 'ey_snaplock',            '2.0.4'
 end

--- a/manifest/Gemfile.lock
+++ b/manifest/Gemfile.lock
@@ -189,7 +189,7 @@ DEPENDENCIES
   ey_cloud_server (= 1.4.61)!
   ey_enzyme (= 2.0.5)!
   ey_services_setup (= 0.0.7)!
-  ey_snaplock (= 2.0.3)!
+  ey_snaplock (= 2.0.4)!
   right_aws (~> 3.1.0)!
 
 BUNDLED WITH

--- a/manifest/Gemfile.lock
+++ b/manifest/Gemfile.lock
@@ -63,7 +63,7 @@ GEM
     ey_services_setup (0.0.7)
       ey_instance_api_client (= 0.1.11)
       json (~> 1.0)
-    ey_snaplock (2.0.3)
+    ey_snaplock (2.0.4)
       addressable (~> 2.3)
       rack
     ffi (1.9.10)


### PR DESCRIPTION
Description of your patch
-------------
This adds support for PostgreSQL 10.x.

Recommended Release Notes
-------------
Add support for PostgreSQL 10.

Estimated risk
-------------
High. PostgreSQL is a central component of the stack and very complex.

Components involved
-------------
The postgresql recipes, ey_snaplock (primer resins are updated)

Description of testing done
-------------
Booted production environments on a testing stack with the cookbooks changes (and updated resins) with PostgreSQL 9.5 and PostgreSQL 10.
Performed a master takeover on each environment.
After completed takeover, added a new db slave to the environment.
During those steps, tested if the application can be deployed and works.
@johndalton also did testing with this.

QA Instructions
-------------
See above. Consult with @johndalton on important test cases.