### PR TITLE
Get default user fix.

### DIFF
--- a/cookbooks/prompt/recipes/default.rb
+++ b/cookbooks/prompt/recipes/default.rb
@@ -14,7 +14,10 @@ public_ip_address = Net::HTTP.get(
   URI('http://169.254.169.254/latest/meta-data/public-ipv4')
 )
 # Specify the users you want to have this prompt in this array.
-users = ["deploy"]
+#users = [""]
+
+users = Array.new
+users << node.engineyard.environment.ssh_username
 
 # This recipe needs to be in a ruby_block because Chef is running in an
 # indeterminate order. Don't know which piece runs when, and notifies just


### PR DESCRIPTION
#### Description of your patch
Correcting default user on prompt cookbook, this will save time and the need to modify the prompt chef recipe.

#### Recommended Release Notes
N/A

#### Estimated risk
Low

#### Components involved
/cookbooks/prompt/recipes/default.rb
/cookbooks/prompt/*

#### Description of testing done
See QA instructions

#### QA Instructions

Run the chef recipe on the v5 stack.

1st. Download the changes.
2nd. Perform chef overlay.
3rd. Create a test environment with a user not deploy
4th. Upload the custom recipe to the environment.
5th. SSH into the test instance with the custom user created.