### PR TITLE
Update install.rb

### DIFF
--- a/cookbooks/memcached/recipes/install.rb
+++ b/cookbooks/memcached/recipes/install.rb
@@ -40,6 +40,32 @@ if is_memcached_instance
       :misc_opts => node['memcached']['misc_opts']
   end
 
+  if !Dir.exist?("/data/monit.d")
+
+
+bash "migrate-monit.d-dir" do
+  code %Q{
+    mv /etc/monit.d /data/
+    ln -nfs /data/monit.d /etc/monit.d
+  }
+
+  not_if 'file /etc/monit.d | grep "symbolic link"'
+end
+
+directory "/data/monit.d" do
+  owner "root"
+  group "root"
+  mode 0755
+end
+
+enddirectory "/data/monit.d" do
+  owner "root"
+  group "root"
+  mode 0755
+end
+
+end
+  
   template '/data/monit.d/memcached.monitrc' do
     source 'memcached.monitrc'
     owner 'root'

--- a/cookbooks/memcached/recipes/install.rb
+++ b/cookbooks/memcached/recipes/install.rb
@@ -58,12 +58,6 @@ directory "/data/monit.d" do
   mode 0755
 end
 
-enddirectory "/data/monit.d" do
-  owner "root"
-  group "root"
-  mode 0755
-end
-
 end
   
   template '/data/monit.d/memcached.monitrc' do


### PR DESCRIPTION
Description of your patch
Correcting missing monit.d on chef run.

Recommended Release Notes
N/A

Estimated risk
Medium

Components involved
/cookbooks/memcached/recipes/install.rb
/cookbooks/memcached/*

Description of testing done
See QA instructions

QA Instructions
Run the chef recipe on the v5 stack.

1st. Download the changes.
2nd. Perform chef overlay.
3rd. Create a test environment with a utility instance named memcached
4th. Upload the custom recipe to the environment.
5th. Check first chef run
6th. SSH into instance with memcached and remove /data/monit.d
7th. trying another chef run.