### PR TITLE
adding db-ssl cookbook on quick chef run

### DIFF
--- a/cookbooks/ey-init/recipes/integrate.rb
+++ b/cookbooks/ey-init/recipes/integrate.rb
@@ -8,5 +8,7 @@ when /^db/
   if node.engineyard.environment['db_stack_name'][/^postgres/]
     include_recipe 'ey-backup::postgres'
   end
+  is_db_master = ['db_master'].include?(node.dna['instance_role'])
+  include_recipe "db-ssl::setup" if is_db_master
 end
 include_recipe "ssh_keys" # CC-691 - update ssh whitelist after takeovers


### PR DESCRIPTION
#### Description of your patch
Fixing SSL keys distribution on instance addition

#### Recommended Release Notes
Fixing SSL keys distribution on instance addition

#### Estimated risk
Low

#### Components involved
ey-init/integrate recipe

#### Description of testing done
See QA instructions

#### QA Instructions
- Boot a multi-instance env using the QA stack (without util instance)
- Add util instance
- Verify that the following is no longer an issue:```The .mysql folder doesn't exist on the new instance and it throws an error during integration```

