### PR TITLE
[CC-1325] Update ey_enzyme gem

### DIFF
--- a/manifest/Gemfile
+++ b/manifest/Gemfile
@@ -7,6 +7,6 @@ source 'https://rubygems.org/' do
 end
 
 source 'https://nextgem.engineyard.com/' do
-  gem 'ey_enzyme',              '2.0.5'
+  gem 'ey_enzyme',              '2.0.6'
   gem 'ey_snaplock',            '2.0.4'
 end

--- a/manifest/Gemfile.lock
+++ b/manifest/Gemfile.lock
@@ -54,7 +54,7 @@ GEM
       mime-types (>= 1.16, < 3.0)
       nokogiri (>= 1.6.6.2, <= 1.6.8.1)
       open4 (~> 1.3.0)
-    ey_enzyme (2.0.5)
+    ey_enzyme (2.0.6)
       json (~> 1.8, >= 1.8.3)
       rest-client (~> 1.8, >= 1.8.0)
     ey_instance_api_client (0.1.11)

--- a/manifest/Gemfile.lock
+++ b/manifest/Gemfile.lock
@@ -187,7 +187,7 @@ DEPENDENCIES
   chef (~> 12.7)!
   engineyard-serverside (~> 2.6.6)!
   ey_cloud_server (= 1.4.61)!
-  ey_enzyme (= 2.0.5)!
+  ey_enzyme (= 2.0.6)!
   ey_services_setup (= 0.0.7)!
   ey_snaplock (= 2.0.4)!
   right_aws (~> 3.1.0)!


### PR DESCRIPTION
Description of your patch
-------------
Update the version of the ey_enzyme gem to 2.0.6. This fixes a bug where ohai does not properly populate the ec2 metadata object.

Recommended Release Notes
-------------
Fix populating the `node['ec2']` object.

Estimated risk
-------------
High. The ey_enzyme gem is responsible for running chef when performing an "Apply".

Components involved
-------------
ey_enzyme gem, primer

Description of testing done
-------------
Created a testing stack.
Uploaded custom chef recipes for each environment which install and configure sidekiq (thereby accessing the node['ec2'] object).
Booted a new environment with the testing stack and deployed the `dummy-sidekiq` branch of the todo app. Tested if cookbook run is successful and sidekiq workers are started.
Booted a stable-v5-3.0 environment and observed the error while running cookbooks. Then updated the environment to the testing stack, applied, and deployed the `dummy-sidekiq` branch of the todo app. Tested if cookbook run is successful and sidekiq workers are started.

QA Instructions
-------------
Test different upgrade paths from current stable-v5-3.0.51.