### PR TITLE
reverting PR #343

### DIFF
--- a/cookbooks/delayed_job4/templates/default/dj.erb
+++ b/cookbooks/delayed_job4/templates/default/dj.erb
@@ -126,7 +126,7 @@ if [ -d $RAILS_ROOT ]; then
       # E.g. '--one=one --two=two' > ['--one=one', '--two=two']
       OPTIONS_ARGS="['${OPTIONS// /', '}']"
 
-      RUNNER_COMMAND="require 'delayed/command';Delayed::Worker.before_fork;Delayed::Command.new($OPTIONS_ARGS).run(nil, options = {queues: ['$QUEUES',]})"
+      RUNNER_COMMAND="require 'delayed/command';Delayed::Worker.before_fork;Delayed::Command.new($OPTIONS_ARGS).run"
       COMMAND="$BUNDLER_COMMAND $RAILS_SCRIPTS/$RUNNER -e $RAILS_ENV \"$RUNNER_COMMAND\""
       logger -t "monit-dj:$WORKER[$$]" "DJ Worker starting from $PPID"
       if [ -f $PID_FILE ]; then


### PR DESCRIPTION
#### Description of your patch
Reverting pull request https://github.com/engineyard/ey-cookbooks-stable-v5/pull/343 as introduced a buggy behavior on customers not running named queues.

#### Recommended Release Notes
Reverting pull request https://github.com/engineyard/ey-cookbooks-stable-v5/pull/343 as introduced a buggy behavior on customers not running named queues.

#### Estimated risk
Low

#### Components involved
templates/default/dj.erb

#### Description of testing done
See QA instructions

#### QA Instructions
QA performed on customers' environments
