### PR TITLE
Τune cron recipe to allow cronjob installation on app master only

### DIFF
--- a/cookbooks/cron/recipes/default.rb
+++ b/cookbooks/cron/recipes/default.rb
@@ -18,6 +18,9 @@ all_crons = node[:custom_crons].find_all {|c| c[:instance_name] == 'all' }
 # Find all cron jobs for Database instances
 db_crons = node[:custom_crons].find_all {|c| c[:instance_name] == 'db' }
 
+# Find all cron jobs for App_Master
+appmaster_crons = node[:custom_crons].find_all {|c| c[:instance_name] == 'app_master' }
+
 crons = all_crons + named_crons
 
 
@@ -31,6 +34,10 @@ end
 
 if node['dna']['instance_role'] == 'db_master' || node['dna']['instance_role'] == 'db_slave'
     crons = crons + db_crons
+end
+
+if node['dna']['instance_role'] == 'app_master'
+    crons = crons + appmaster_crons
 end
 
 crons.each do |cron|

--- a/custom-cookbooks/cron/cookbooks/custom-cron/README.md
+++ b/custom-cookbooks/cron/cookbooks/custom-cron/README.md
@@ -55,7 +55,7 @@ Yard.
 All customizations go to `cookbooks/custom-cron/attributes/default.rb`.
 
 Add your cron jobs as an array of hashes in `default[:custom_crons]` You must
-specify a name, time, command and instance name or instance type. They following arguments are valid: `app`, `db`, `util`, `all`, or "instance_name".  The time value must be the
+specify a name, time, command and instance name or instance type. The following arguments are valid: `app`,`app_master`, `db`, `util`, `all`, or "instance_name".  The time value must be the
 full string containing minute, hour, day, month and weekday separated by spaces
 (eg: '* * * * *').
 


### PR DESCRIPTION
#### Description of your patch
Adding the "app_master" option on cron recipe allowing installation of cronjobs on app_master instance (exclusively)

#### Recommended Release Notes
Adding the "app_master" option on cron recipe allowing installation of cronjobs on app_master instance (exclusively)

#### Estimated risk
Low

#### Components involved
custom-cron/README.md
cron/recipes/default.rb

#### Description of testing done
See QA instructions

#### QA Instructions
- Boot environment with app_master + app instance
- Configure `custom-cron` recipe to install cronjob on app_master only
- Confirm cronjob installation on app_master (only)