### PR TITLE
Calculate DJ workers on Gen5 instances 

### DIFF
--- a/cookbooks/delayed_job4/attributes/default.rb
+++ b/cookbooks/delayed_job4/attributes/default.rb
@@ -43,7 +43,7 @@ worker_count = if node[:dna][:instance_role] == 'solo'
                  when 't3.medium' then 2
                  when 't3.large' then 2
                  when 't3.xlarge' then 4
-                 when 't3.2xlarge' then 4
+                 when 't3.2xlarge' then 8
                  when 'm5.large' then 2
                  when 'm5.xlarge' then 4
                  when 'm5.2xlarge' then 8

--- a/cookbooks/delayed_job4/attributes/default.rb
+++ b/cookbooks/delayed_job4/attributes/default.rb
@@ -36,6 +36,70 @@ worker_count = if node[:dna][:instance_role] == 'solo'
                  when 'r4.4xlarge' then 32
                  when 'r4.8xlarge' then 64
                  when 'r4.16xlarge' then 128
+
+                 #gen5 instances
+                 when 't3.micro' then 2
+                 when 't3.small' then 2
+                 when 't3.medium' then 2
+                 when 't3.large' then 2
+                 when 't3.xlarge' then 4
+                 when 't3.2xlarge' then 4
+                 when 'm5.large' then 2
+                 when 'm5.xlarge' then 4
+                 when 'm5.2xlarge' then 8
+                 when 'm5.4xlarge' then 16
+                 when 'm5.12xlarge' then 48
+                 when 'm5.24xlarge' then 96
+                 when 'm5a.large' then 2
+                 when 'm5a.xlarge' then 4
+                 when 'm5a.2xlarge' then 8
+                 when 'm5a.4xlarge' then 16
+                 when 'm5a.12xlarge' then 48
+                 when 'm5a.24xlarge' then 96
+                 when 'm5d.large' then 2
+                 when 'm5d.xlarge' then 4
+                 when 'm5d.2xlarge' then 8
+                 when 'm5d.4xlarge' then 16
+                 when 'm5d.12xlarge' then 48
+                 when 'm5d.24xlarge' then 96
+                 when 'c5.large' then 2
+                 when 'c5.xlarge' then 4
+                 when 'c5.2xlarge' then 8
+                 when 'c5.4xlarge' then 16
+                 when 'c5.9xlarge' then 36
+                 when 'c5.18xlarge' then 72
+                 when 'c5d.large' then 2
+                 when 'c5d.xlarge' then 4
+                 when 'c5d.2xlarge' then 8
+                 when 'c5d.4xlarge' then 16
+                 when 'c5d.9xlarge' then 36
+                 when 'c5d.18xlarge' then 72
+                 when 'r5.large' then 2
+                 when 'r5.xlarge' then 4
+                 when 'r5.2xlarge' then 8
+                 when 'r5.4xlarge' then 16
+                 when 'r5.12xlarge' then 48
+                 when 'r5.24xlarge' then 96
+                 when 'r5a.large' then 2
+                 when 'r5a.xlarge' then 4
+                 when 'r5a.2xlarge' then 8
+                 when 'r5a.4xlarge' then 16
+                 when 'r5a.12xlarge' then 48
+                 when 'r5a.24xlarge' then 96
+                 when 'r5d.large' then 2
+                 when 'r5d.xlarge' then 4
+                 when 'r5d.2xlarge' then 8
+                 when 'r5d.4xlarge' then 16
+                 when 'r5d.12xlarge' then 48
+                 when 'r5d.24xlarge' then 96
+                 when 'i3.large' then 2
+                 when 'i3.xlarge' then 4
+                 when 'i3.2xlarge' then 8
+                 when 'i3.4xlarge' then 16
+                 when 'i3.8xlarge' then 32
+                 when 'i3.16xlarge' then 64
+
+
                  else # default
                    2
                  end


### PR DESCRIPTION
#### Description of your patch
Update DelayedJob recipe to calculate the number of workers on Gen5 EC2 instances

#### Recommended Release Notes
Update DelayedJob recipe to calculate the number of workers on Gen5 EC2 instances

#### Estimated risk
Low

#### Components involved
attributes/default.rb

#### Description of testing done
See QA instructions

#### QA Instructions
- Enable DJ recipe
- Boot various gen5 instances
- Confirm that the number of workers is dynamically calculated based on instance type
