### PR TITLE
Update PID file based on memcached version

### DIFF
--- a/cookbooks/memcached/recipes/install.rb
+++ b/cookbooks/memcached/recipes/install.rb
@@ -43,28 +43,38 @@ if is_memcached_instance
   if !Dir.exist?("/data/monit.d")
 
 
-bash "migrate-monit.d-dir" do
-  code %Q{
-    mv /etc/monit.d /data/
-    ln -nfs /data/monit.d /etc/monit.d
-  }
+   bash "migrate-monit.d-dir" do
+    code %Q{
+      mv /etc/monit.d /data/
+      ln -nfs /data/monit.d /etc/monit.d
+    }
 
-  not_if 'file /etc/monit.d | grep "symbolic link"'
-end
+    not_if 'file /etc/monit.d | grep "symbolic link"'
+   end
 
-directory "/data/monit.d" do
-  owner "root"
-  group "root"
-  mode 0755
-end
+   directory "/data/monit.d" do
+    owner "root"
+    group "root"
+    mode 0755
+   end
 
-end
-  
+  end
+
+
+  if memcached_version < "1.4.39"
+    pid = "/var/run/memcached.pid"
+  else
+    pid = "/var/run/memcached-11211.pid"
+  end
+
   template '/data/monit.d/memcached.monitrc' do
     source 'memcached.monitrc'
     owner 'root'
     group 'root'
     mode 0644
+    variables({
+        :pid => pid
+    })
     notifies :run, 'execute[restart-monit]', :delayed
   end
 end

--- a/cookbooks/memcached/templates/default/memcached.monitrc
+++ b/cookbooks/memcached/templates/default/memcached.monitrc
@@ -1,5 +1,5 @@
 check process memcached
-  with pidfile /var/run/memcached.pid
+  with pidfile <%= @pid %>
   start program = "/etc/init.d/memcached restart"
   stop program = "/etc/init.d/memcached stop"
   group memcached


### PR DESCRIPTION
#### Description of your patch
Update PID file that monit tracks based on memcached version

#### Recommended Release Notes
Fixes `monit` configuration file for `memcached` version > 1.4.39

#### Estimated risk
Low

#### Components involved
install.rm

#### Description of testing done
See QA instructions

#### QA Instructions
Boot env with memcached version <  1.4.39
Confirm that memcached PID file is _/var/run/memcached.pid_ and `monit` keeps track of process

Boot env with memcached version >=  1.4.39
Confirm that memcached PID file is _/var/run/memcached-11211.pid_ and `monit` keeps track of process
