### PR TITLE
Add --no-document on /root/.gemrc

### DIFF
--- a/cookbooks/ey-dynamic/recipes/rubygems.rb
+++ b/cookbooks/ey-dynamic/recipes/rubygems.rb
@@ -16,7 +16,7 @@ end
 ruby_block "gems to install" do
   block do
     node.dna['gems_to_install'].each do |pkg|
-      command = "gem install #{pkg[:name]} --no-ri --no-rdoc"
+      command = "gem install #{pkg[:name]}"
       command << " -v #{pkg[:version]}" if pkg[:version]
 
       Array(pkg[:source]).each do |source|

--- a/cookbooks/passenger5/recipes/install.rb
+++ b/cookbooks/passenger5/recipes/install.rb
@@ -12,7 +12,7 @@
   # Install gems required by Passenger standalone
   ruby_block "gems to install" do
     block do
-      system("gem install daemon_controller rack:1.6.4 --no-ri --no-rdoc")
+      system("gem install daemon_controller rack:1.6.4")
     end
   end
 

--- a/cookbooks/ruby/files/default/gemrc
+++ b/cookbooks/ruby/files/default/gemrc
@@ -1,2 +1,2 @@
 ---
-gem: --no-ri --no-rdoc
+gem: --no-ri --no-rdoc --no-document

--- a/cookbooks/ruby/recipes/install.rb
+++ b/cookbooks/ruby/recipes/install.rb
@@ -21,6 +21,11 @@ cookbook_file "/etc/gemrc" do
   source "gemrc"
 end
 
+# Add gemrc for the root user
+cookbook_file "/root/.gemrc" do
+  source "gemrc"
+end
+
 #
 # Require the right recipe to install the right flavor of ruby
 #

--- a/cookbooks/ruby/recipes/rubygems.rb
+++ b/cookbooks/ruby/recipes/rubygems.rb
@@ -35,7 +35,7 @@ def ensure_rubygems_version
              end
           end
         else
-          Mixlib::ShellOut.new('gem install rubygems-update -v #{rubygems} --no-ri --no-rdoc')
+          Mixlib::ShellOut.new('gem install rubygems-update -v #{rubygems}')
         end
       end
     end
@@ -45,7 +45,7 @@ def ensure_rubygems_version
     end
 
     execute "install rubygems #{rubygems}" do
-      command "gem install rubygems-update -v #{rubygems} --no-ri --no-rdoc"
+      command "gem install rubygems-update -v #{rubygems}"
     end
 
     execute "update rubygems to >= #{rubygems}" do

--- a/cookbooks/ruby/recipes/rubygems.rb
+++ b/cookbooks/ruby/recipes/rubygems.rb
@@ -79,4 +79,10 @@ if node.engineyard.environment.ruby?
   else
     ensure_rubygems_version
   end
+
+  # removing packaged bundler prevents the error "You must use Bundler 2 or greater with this lockfile"
+  # engineyard-serverside installs bundler during deploys
+  execute "remove bundler installed by rubygems" do
+    command "rm -rf /usr/lib64/ruby/site_ruby/*/bundler{,.rb} && rm -f /usr/local/lib64/ruby/gems/*/specifications/default/bundler*gemspec"
+  end
 end


### PR DESCRIPTION
(This PR also includes #394. I can rebase after #394 is merged if necessary)

Remove --no-ri --no-rdoc 
Add /root/.gemrc with --no-ri --no-rdoc --no-document
Note: .gemrc having `--no-ri --no-rdoc` on rubgyems 3 and `--no-document` on rubygems 2 is not a problem. `gem` commands won't fail.  `gem install` will only fail with `--no-ri --no-rdoc` on rubygems 3 if you use the flags on the command line *NOT* on .gemrc