### PR TITLE
Add certificates variable and lazy load it

### DIFF
--- a/cookbooks/haproxy/recipes/configure.rb
+++ b/cookbooks/haproxy/recipes/configure.rb
@@ -57,8 +57,8 @@ managed_template "/etc/haproxy.cfg" do
   mode 0644
   source "haproxy.cfg.erb"
   members = node.dna[:members] || []
-  variables({
-    :backends => node.engineyard.environment.app_servers,
+  variables( lazy{
+    {:backends => node.engineyard.environment.app_servers,
     :app_master_weight => members.size < 51 ? (50 - (members.size - 1)) : 0,
     :haproxy_user => node.dna[:haproxy][:username],
     :haproxy_pass => node.dna[:haproxy][:password],
@@ -66,7 +66,8 @@ managed_template "/etc/haproxy.cfg" do
     :https_bind_port => haproxy_https_port,
     :httpchk_host => haproxy_httpchk_host,
     :httpchk_path => haproxy_httpchk_path,
-    :http2 => use_http2
+    :http2 => use_http2,
+    :certificates => Dir['/etc/nginx/ssl/*.pem'].reject {|filename| filename =~ /dhparam/}}
   })
 
   # We need to reload to activate any changes to the config

--- a/cookbooks/haproxy/templates/default/haproxy.cfg.erb
+++ b/cookbooks/haproxy/templates/default/haproxy.cfg.erb
@@ -151,7 +151,7 @@ listen cluster
 
     listen clusterssl
     mode tcp
-    bind *:443 mss 1422 ssl <%= Dir['/etc/nginx/ssl/*.pem'].reject {|filename| filename =~ /dhparam/}.collect {|pem| "crt #{pem}"}.join(" ") %>  alpn h2
+    bind *:443 mss 1422 ssl <%= @certificates.collect {|pem| "crt #{pem}"}.join(" ") %>  alpn h2
 
 
     use_backend nodes-http2 if { ssl_fc_alpn -i h2 }
@@ -187,9 +187,9 @@ listen cluster
     
 
 <% else %>
-    <% if Dir['/etc/nginx/ssl/*.pem'].reject {|filename| filename =~ /dhparam/}.count > 0 %>
+    <% if @certificates.count > 0 %>
 listen clusterssl
-  bind *:443 mss 1422 ssl <%= Dir['/etc/nginx/ssl/*.pem'].reject {|filename| filename =~ /dhparam/}.collect {|pem| "crt #{pem}"}.join(" ") %>
+  bind *:443 mss 1422 ssl <%= @certificates.collect {|pem| "crt #{pem}"}.join(" ") %>
 # YT-CC-666 X-Forwarded-Port added
   http-request add-header X-Forwarded-Proto https
   http-request set-header X-Forwarded-Port %[dst_port]


### PR DESCRIPTION
Changes the handling of the certificates variable. Should make no difference for general usage, but prevents the need to overlay the haproxy recipe for the custom-haproxy-ssls custom recipe.