### PR TITLE
[CC-1351] Prevent package downgrades

### DIFF
--- a/cookbooks/monit/attributes/monit.rb
+++ b/cookbooks/monit/attributes/monit.rb
@@ -1,1 +1,3 @@
-default['monit']['version'] = '5.17.1'
+# YT-CC-1351
+# YT-CC-1349
+default['monit']['version'] = '5.17.1-r1'

--- a/cookbooks/security_updates/recipes/default.rb
+++ b/cookbooks/security_updates/recipes/default.rb
@@ -4,13 +4,17 @@ package 'net-libs/gnutls' do
 end
 
 # YT-CC-1182
+# YT-CC-1351
+# YT-CC-1338
 package 'media-libs/tiff' do
-  version '4.0.8'
+  version '4.0.8-r1'
 end
 
 # YT-CC-1254
+# YT-CC-1351
+# YT-CC-1285
 package 'net-misc/curl' do
-  version '7.50.3-r2'
+  version '7.50.3-r3'
 end
 
 # YT-CC-1254


### PR DESCRIPTION
Description of your patch
-------------
Update the hard-coded versions of `media-libs/tiff`, `net-misc/curl`, and `app-admin/monit` to the latest stable versions with the most recent security fixes.

Recommended Release Notes
-------------
Update OS packages to the latest versions.

Estimated risk
-------------
Medium. All updates are minor, only introducing fixes for security vulnerabilities. However, monit is a major component.

Components involved
-------------
`security_updates` cookbook and `monit` cookbook

Description of testing done
-------------
Booted a solo env with a testing stack that includes this PR (Ruby todo app).
Made sure the environment boots successfully, deploys the app, and the app works.
Logged into the instance and verified that the updated package versions got installed.
Ran `monit summary` to check if it works.

QA Instructions
-------------
QA should perform test-cases around monit to make sure none of the important use-cases break.