### PR TITLE
[FB-462] Support for Ruby 2.6

### DIFF
--- a/cookbooks/ey-lib/libraries/ey-environment.rb
+++ b/cookbooks/ey-lib/libraries/ey-environment.rb
@@ -145,6 +145,7 @@ class Chef
           :ruby_230   => "2.3.8",
           :ruby_240   => "2.4.5",
           :ruby_250   => "2.5.3",
+          :ruby_260   => "2.6.3",
         }
         if versions.has_key?(ruby_archtype.to_sym)
           version = versions[ruby_archtype.to_sym]

--- a/cookbooks/ruby/attributes/versions.rb
+++ b/cookbooks/ruby/attributes/versions.rb
@@ -65,4 +65,21 @@ elsif ruby2x?(5, ruby_version)
     "dev-ruby/xmlrpc"       => "0.3.0",
     "virtual/rubygems"      => "13",
   }
+elsif ruby2x?(6, ruby_version)
+  default[:ruby_dependencies] = {
+    "dev-ruby/bundler"      => "1.17.3",
+    "dev-ruby/json"         => "2.0.3-r2",
+    "dev-ruby/racc"         => "1.4.14-r3",
+    "dev-ruby/rake"         => "12.3.2",
+    "dev-ruby/rdoc"         => "6.0.3-r1",
+    "dev-ruby/rubygems"     => "3.0.3",
+    "dev-ruby/did_you_mean" => "1.3.0",
+    "dev-ruby/minitest"     => "5.11.3",
+    "dev-ruby/net-telnet"   => "0.2.0",
+    "dev-ruby/power_assert" => "1.1.4",
+    "dev-ruby/test-unit"    => "3.2.9",
+    "dev-ruby/xmlrpc"       => "0.3.0-r1",
+    "dev-ruby/kpeg"         => "1.1.0-r2",
+    "virtual/rubygems"      => "14",
+  }
 end

--- a/cookbooks/ruby/recipes/rubygems.rb
+++ b/cookbooks/ruby/recipes/rubygems.rb
@@ -3,6 +3,10 @@ if node.engineyard.environment.ruby?
 
   # removing packaged bundler prevents the error "You must use Bundler 2 or greater with this lockfile"
   # engineyard-serverside installs bundler during deploys
+  package "remove bundler OS package" do
+    package_name "dev-ruby/bundler"
+    action :remove
+  end
   execute "remove bundler installed by rubygems" do
     command "rm -rf /usr/lib64/ruby/site_ruby/*/bundler{,.rb} && rm -f /usr/local/lib64/ruby/gems/*/specifications/default/bundler*gemspec"
   end


### PR DESCRIPTION
Description of your patch
-------------
Add support for Ruby 2.6.

Recommended Release Notes
-------------
Add support for Ruby 2.6.

Estimated risk
-------------
Medium. Existing (non-Ruby 2.6) environments should not be affected by the change.

Components involved
-------------
Ruby recipes
ey-environment library

Description of testing done
-------------
0. Created a testing stack with this PR and https://github.com/engineyard/ey-cookbooks-stable-v5/pull/402.
1. Booted a solo environment with Ruby 2.5 [sic].
2. On the instance, synced the Ruby 2.6 ebuilds.
3. Updated the environment to Ruby 2.6 and lock serverside version to 2.6.19.
4. Checked if it applies correctly and deploys successfully.
5. Downgraded to Ruby 2.5 and checked if it works.

QA Instructions
-------------
This PR must be merged **after** https://github.com/engineyard/ey-cookbooks-stable-v5/pull/402 and https://github.com/engineyard/ey-cookbooks-stable-v5/pull/403.
QA testing can only take place **after** the OS packages have been made available.