### PR TITLE
[FB-548] Bump percona-server versions for 5.6 and 5.7

### DIFF
--- a/cookbooks/mysql/attributes/version.rb
+++ b/cookbooks/mysql/attributes/version.rb
@@ -2,8 +2,8 @@ lock_major_version = %x{[[ -f "/db/.lock_db_version" ]] && grep -E -o '^[0-9]+\.
 db_stack = lock_major_version == '' ? attribute.dna['engineyard']['environment']['db_stack_name'] :  "mysql#{lock_major_version.gsub(/\./, '_').strip}"
 
 default['latest_version_55'] = '5.5.49'
-default['latest_version_56'] = '5.6.37'
-default['latest_version_57'] = '5.7.19'
+default['latest_version_56'] = '5.6.44'
+default['latest_version_57'] = '5.7.26'
 major_version=''
 
 case db_stack

--- a/cookbooks/mysql/recipes/install.rb
+++ b/cookbooks/mysql/recipes/install.rb
@@ -6,7 +6,7 @@ db_running = %x{mysql -N -e "select 1;" 2> /dev/null}.strip == '1'
 known_versions = {
   # Note: mysql 5.5 is a limited access feature on this stack; use 5.6 or higher if possible.
   'dev-db/mysql' => ['5.5.49'],
-  'dev-db/percona-server' => ['5.6.28.76.1', '5.6.29.76.2-r1', '5.6.32.78.1', '5.6.35.81.0', '5.6.37.82.2', '5.7.13.6', '5.7.14.8', '5.7.17.13', '5.7.19.17']
+  'dev-db/percona-server' => ['5.6.28.76.1', '5.6.29.76.2-r1', '5.6.32.78.1', '5.6.35.81.0', '5.6.37.82.2', '5.6.44.86.0', '5.7.13.6', '5.7.14.8', '5.7.17.13', '5.7.19.17', '5.7.26.29']
 }
 
 if node.dna['instance_role'][/^(db|solo)/]


### PR DESCRIPTION
Description of your patch
-------------
This PR enables the latest versions for the `dev-db/percona-server` packages.

Recommended Release Notes
-------------
Support for the latest available Percona Server patch versions.

Estimated risk
-------------
Medium. Changes to the cookbooks are very small, but compatibility and upgrade paths between versions need to be thoroughly tested.

Components involved
-------------
mysql recipes

Description of testing done
-------------
Created a testing stack with the changes in this PR
**Scenario 1**
1. Booted a staging env (Ruby app, MySQL 5.6.x) and deployed the app.
2. Verified it works.
3. Logged into the database master and application master instances and verified that the latest available version of `dev-db/percona-server` in the 5.6 series was installed.
**Scenario 2**
1. Booted a staging env (Ruby app, MySQL 5.7.x) and deployed the app.
2. Verified it works.
3. Logged into the database master and application master instances and verified that the latest available version of `dev-db/percona-server` in the 5.7 series was installed.
**Scenario 3**
1. Booted a solo env (Ruby app, MySQL 5.7.x, stack stable-v5 (**not** the testing stack), prevent db version changes).
2. Verified it works.
3. Logged into the instance and noted the installed `dev-db/percona-server` package version.
4. Edited the environment and selected the testing stack.
5. Applied the changes.
6. Logged into the instance and verified that the version `dev-db/percona-server` was the same as in step 3.
7. Edited the environment and deactivated "Prevent DB version changes".
8. Applied the changes.
9. Logged into the database master and application master instances and verified that the latest available version of `dev-db/percona-server` in the 5.7 series was installed.
10. Verified that the deployed app works.

QA Instructions
-------------
Test with a PHP app.
Test different configurations and upgrade paths.