### PR TITLE
[FB-573] Update PostgreSQL versions

### DIFF
--- a/cookbooks/postgresql/attributes/version.rb
+++ b/cookbooks/postgresql/attributes/version.rb
@@ -1,15 +1,15 @@
 case attribute.dna.engineyard.environment.db_stack_name
 when "postgres9_4"
-  default['postgresql']['latest_version'] = '9.4.12'
+  default['postgresql']['latest_version'] = '9.4.22'
   default['postgresql']['short_version'] = '9.4'
 when "postgres9_5"
-  default['postgresql']['latest_version'] = '9.5.7'
+  default['postgresql']['latest_version'] = '9.5.17'
   default['postgresql']['short_version'] = '9.5'
 when "postgres9_6"
-  default['postgresql']['latest_version'] = '9.6.3'
+  default['postgresql']['latest_version'] = '9.6.13'
   default['postgresql']['short_version'] = '9.6'
 when "postgres10"
-  default['postgresql']['latest_version'] = '10.4'
+  default['postgresql']['latest_version'] = '10.8'
   default['postgresql']['short_version'] = '10'
 end
 default['postgresql']['datadir'] = "/db/postgresql/#{node['postgresql']['short_version']}/data/"

--- a/cookbooks/postgresql/recipes/server_install.rb
+++ b/cookbooks/postgresql/recipes/server_install.rb
@@ -1,10 +1,10 @@
 postgres_version = node['postgresql']['short_version']
 
 known_ebuild_versions = %w[
-  9.4.8   9.4.11  9.4.12
-  9.5.3   9.5.6   9.5.7
-  9.6.3
-  10.4
+  9.4.8   9.4.11  9.4.12  9.4.22
+  9.5.3   9.5.6   9.5.7   9.5.17
+  9.6.3   9.6.13
+  10.4    10.8
 ]
 
 execute "dropping lock version file" do


### PR DESCRIPTION
Description of your patch
-------------
This PR updates our `dev-db/postgresql` packages to the latest available versions.

Recommended Release Notes
-------------
Update PostgreSQL to the latest available patch versions.

Estimated risk
-------------
Medium. The changes to the recipes are small. However we need to thoroughly test compatibility between the patch versions and upgrade paths.

Components involved
-------------
postgresql recipes

Description of testing done
-------------
0. Created a testing stack with the changes of this PR.
1. Tested booting+deployment of an env (Ruby app) with PostgreSQL versions 9.4.x, 9.5.x, 9.6.x, and 10.x. Verified that the latest respective version got installed and used.
2. Tested upgrade from stable-v5 to the testing stack. Verified that the `dev-db/postgresql` packages got updated to the latest available versions (no db lock).

QA Instructions
-------------
Test a PHP application.
Test different environment configurations and upgrade paths.