### PR TITLE
[FB-547] Bump PHP versions

### DIFF
--- a/cookbooks/php/attributes/php.rb
+++ b/cookbooks/php/attributes/php.rb
@@ -2,15 +2,15 @@ default['php']['full_atom'] = "dev-lang/php"
 
 default['php']['version'] = case attribute['dna']['engineyard']['environment']['components'].map(&:values).flatten.find(/^php_/).first
   when 'php_56'
-    '5.6.30'
+    '5.6.40'
   when 'php_7'
-    '7.0.11'
+    '7.0.33'
   when 'php_71'
-    '7.1.0'
+    '7.1.30'
   when 'php_72'
-    '7.2.8'
+    '7.2.19'
   else
-   '5.6.30'
+   '5.6.40'
 end
  
 default['php']['minor_version'] =  default['php']['version'].split(".").first(2).join(".")


### PR DESCRIPTION
Description of your patch
-------------
Bump the `dev-lang/php` packages to the latest available patch versions.

Recommended Release Notes
-------------
Update to the latest available PHP patch versions.

Estimated risk
-------------
Low. Only the PHP package versions have been updated. PHP keeps compatibility within patch versions.

Components involved
-------------
php recipes

Description of testing done
-------------
1. Created a testing stack with the changes in this PR.
2. Booted a stable-v5 solo env (PHP app, PHP 5.6.x) and deployed.
3. Checked everything works. Logged into the instance and verified that an older PHP patch version was used.
4. Updated to the testing stack and applied changes.
5. Checked everything works. Logged into the instance and verified that the latest PHP patch version was used.
6. Updated the environment, selected PHP 7.2.x., and applied the changes.
7. Checked everything works. Logged into the instance and verified that the latest PHP 7.2 patch version was used.

QA Instructions
-------------
Test a Ruby application.
Test different configurations and upgrade paths.