### PR TITLE
[FB-549] Package security updates

### DIFF
--- a/cookbooks/security_updates/recipes/default.rb
+++ b/cookbooks/security_updates/recipes/default.rb
@@ -1,6 +1,7 @@
 # YT-CC-924
+# FB-549
 package 'net-libs/gnutls' do
-  version '3.3.28'
+  version '3.3.30'
 end
 
 # YT-CC-1182
@@ -13,8 +14,9 @@ end
 # YT-CC-1254
 # YT-CC-1351
 # YT-CC-1285
+# FB-549
 package 'net-misc/curl' do
-  version '7.50.3-r3'
+  version '7.50.3-r4'
 end
 
 # YT-CC-1254


### PR DESCRIPTION
Description of your patch
-------------
This PR updates the `net-misc/curl` and `dev-libs/gnutls` packages to the latest versions.

Recommended Release Notes
-------------
Apply the latest security updates to curl and gnutls.

Estimated risk
-------------
Low. Just minor version bumps. Package updates are backwards compatible.

Components involved
-------------
security_updates recipes

Description of testing done
-------------
1. Created a testing stack with the changes in this PR.
2. Booted a solo env (Ruby app) and checked (through `emerge -upDN1 world`) that curl and gnutls have updates available.
3. Updated the env to the testing stack and ran Apply.
4. Checked that curl and gnutls were on the latest available stable versions.

QA Instructions
-------------
Test a PHP application.
Test different environment configurations.