### PR TITLE
[FB-656] Security Updates for openssh vulnerabilities

### DIFF
--- a/cookbooks/security_updates/recipes/default.rb
+++ b/cookbooks/security_updates/recipes/default.rb
@@ -42,7 +42,6 @@ end
 # YT-CC-1308
 # FB-656
 package 'net-misc/openssh' do
-  action :nothing
   version '7.5_p1-r3'
   notifies :restart, 'service[sshd]'
 end

--- a/cookbooks/security_updates/recipes/default.rb
+++ b/cookbooks/security_updates/recipes/default.rb
@@ -38,3 +38,9 @@ end
 package 'dev-libs/libyaml' do
   version '0.1.7'
 end
+
+# YT-CC-1308
+# FB-656
+package 'net-misc/openssh' do
+  version '7.5_p1-r3'
+end

--- a/cookbooks/security_updates/recipes/default.rb
+++ b/cookbooks/security_updates/recipes/default.rb
@@ -42,5 +42,7 @@ end
 # YT-CC-1308
 # FB-656
 package 'net-misc/openssh' do
+  action :nothing
   version '7.5_p1-r3'
+  notifies :restart, 'service[sshd]'
 end


### PR DESCRIPTION
Description of your patch
-------------
This PR updates 'net-misc/openssh` to it's latest version.

Recommended Release Notes
-------------
Apply latest security updates to `openssh`

Estimated risk
-------------
Medium

Components involved
-------------
security updates recipe

Description of testing done
-------------

- Booted a solo env (Ruby app) and checked (through `emerge -upDN1 world` ) that `openssh` have updates available.
- Updated the local chef recipes(In the instance) with the changes in this PR.
- Executed `/home/ey/bin/chef-solo -j /etc/chef/dna.json -c /etc/chef/solo.rb`
- Checked `openssh` is updated to the latest version available (eix net-misc/openssh) .

QA Instructions
-------------
- Test a PHP application
- Test different environment configurations
