### PR TITLE
[FB-655] Update openssl

### DIFF
--- a/cookbooks/openssl/attributes/openssl.rb
+++ b/cookbooks/openssl/attributes/openssl.rb
@@ -1,2 +1,6 @@
 default.openssl.using_metadata = !!node.engineyard.metadata("openssl_ebuild_version",nil)
-default.openssl.version = node.engineyard.metadata('openssl_ebuild_version','1.0.2k')
+
+# Openssl version updated from 1.0.2k to 1.0.2r
+# YT-CC-1266
+# FB-655
+default.openssl.version = node.engineyard.metadata('openssl_ebuild_version','1.0.2r')

--- a/cookbooks/security_updates/recipes/default.rb
+++ b/cookbooks/security_updates/recipes/default.rb
@@ -38,3 +38,9 @@ end
 package 'dev-libs/libyaml' do
   version '0.1.7'
 end
+
+# YT-CC-1266
+# FB-655
+package 'dev-libs/openssl' do
+  version '1.0.2r'
+end

--- a/cookbooks/security_updates/recipes/default.rb
+++ b/cookbooks/security_updates/recipes/default.rb
@@ -38,9 +38,3 @@ end
 package 'dev-libs/libyaml' do
   version '0.1.7'
 end
-
-# YT-CC-1266
-# FB-655
-package 'dev-libs/openssl' do
-  version '1.0.2r'
-end


### PR DESCRIPTION
Description of your patch
-------------
This PR updates 'dev-libs/openssl` to it's latest version.

Recommended Release Notes
-------------
Apply latest security updates to `openssl`

Estimated risk
-------------
Medium

Components involved
-------------
openssl cookbook(`attributes/openssl.rb`)

Description of testing done
-------------
- Booted a solo env (Ruby app) and checked (through emerge -upDN1 world ) that `openssl` have updates available.
- Updated the local chef recipes(In the instance) with the changes in this PR.
- Executed `/home/ey/bin/chef-solo -j /etc/chef/dna.json -c /etc/chef/solo.rb`
- Checked openssl is updated to the latest version available (`dev-libs/openssl`) .

QA Instructions
-------------
- Test a PHP application
- Test different environment configurations