### PR TITLE
[FB-846] Update PHP version

### DIFF
--- a/cookbooks/php/attributes/php.rb
+++ b/cookbooks/php/attributes/php.rb
@@ -6,9 +6,9 @@ default['php']['version'] = case attribute['dna']['engineyard']['environment']['
   when 'php_7'
     '7.0.33'
   when 'php_71'
-    '7.1.30'
+    '7.1.31'
   when 'php_72'
-    '7.2.19'
+    '7.2.21'
   else
    '5.6.40'
 end


### PR DESCRIPTION
Description of your patch
-------------
This updates the default PHP versions of PHP71 and PHP72 to v7.1.31 and v7.2.21 respectively.

Recommended Release Notes
-------------
This performs an upgrade to the latest installed versions of PHP under the relevant stack.

Estimated risk
-------------

Components involved
-------------
PHP Cookbook

Description of testing done
-------------
1. Boot a PHP environment with PHP versions  5.5, 5.6, 7.0, 7.1 and 7.2 respectively and check if the following versions of PHP is installed.

- PHP4 => '5.6.40'
- PHP5.5 => '5.6.40'
- PHP5.6 => '5.6.40'
- PHP7.0 =>  '7.0.33'
- PHP7.1 => '7.1.31'
- PHP7.2 => '7.2.21'

2. Boot a PHP environment and then upgrade the stack to a later version. Set apply for the whole environment and Change the Stack version of the environment of the PHP versions PHP71 and PHP72 to check whether they are upgraded to the latest(The new stack must have latest versions defined in it).

QA Instructions
-------------
1. Check version upgrades under a solo environment.
2. Check version upgrades under environment with multiple instances.
