### PR TITLE
Adds application log LE following to custom attributes

### DIFF
--- a/cookbooks/le/attributes/default.rb
+++ b/cookbooks/le/attributes/default.rb
@@ -1,2 +1,3 @@
 default['le']['le_api_key'] = 'YOUR_API_KEY_HERE'
+default['le']['follow_paths'] = []
 default['le']['follow_app_paths'] = []

--- a/cookbooks/le/attributes/default.rb
+++ b/cookbooks/le/attributes/default.rb
@@ -1,1 +1,2 @@
 default['le']['le_api_key'] = 'YOUR_API_KEY_HERE'
+default['le']['follow_app_paths'] = []

--- a/cookbooks/le/recipes/configure.rb
+++ b/cookbooks/le/recipes/configure.rb
@@ -26,3 +26,14 @@ follow_paths.each do |path|
     not_if "le followed #{path}"
   end
 end
+
+node['le']['follow_app_paths'].each do |app_path|
+  parser = app_path.match(/\/data\/(\w+)\/shared\/log\/(\w+\.log)/)
+  log_name = "#{parser[1]}-#{parser[2]}"
+  execute "le follow #{app_path}" do
+    command "le follow #{app_path} --name #{log_name}"
+    ignore_failure true
+    action :run
+    not_if "le followed #{app_path}"
+  end
+end

--- a/cookbooks/le/recipes/configure.rb
+++ b/cookbooks/le/recipes/configure.rb
@@ -9,16 +9,7 @@ execute "le register --account-key" do
   not_if { File.exists?('/etc/le/config') }
 end
 
-follow_paths = [
-  "/var/log/syslog",
-  "/var/log/auth.log",
-  "/var/log/daemon.log"
-]
-(node['dna']['applications'] || []).each do |app_name, app_info|
-  follow_paths << "/var/log/nginx/#{app_name}.access.log"
-end
-
-follow_paths.each do |path|
+node['le']['follow_paths'].each do |path|
   execute "le follow #{path}" do
     command "le follow #{path}"
     ignore_failure true

--- a/custom-cookbooks/le/cookbooks/custom-le/README.md
+++ b/custom-cookbooks/le/cookbooks/custom-le/README.md
@@ -42,3 +42,7 @@ Edit this line:
 default['le']['le_api_key'] = 'YOUR_API_KEY_HERE'
 ```
 
+### Specify the specific application logs to follow
+
+By default system and Nginx logs are sent to Logentries. Application specific logs (e.g. application server and background job logs) can be added by either uncommenting or appending the `default['le']['follow_app_paths']` lines with the relevant log filenames. `#{app_name}` is a variable and should not be hard-coded, just left to handle multiple applications' logs if present.
+

--- a/custom-cookbooks/le/cookbooks/custom-le/README.md
+++ b/custom-cookbooks/le/cookbooks/custom-le/README.md
@@ -42,7 +42,15 @@ Edit this line:
 default['le']['le_api_key'] = 'YOUR_API_KEY_HERE'
 ```
 
-### Specify the specific application logs to follow
+### Specify the logs to follow
+
+The logs to follow are defined in three blocks:
+
+1. System logs - these are server logs, typically found in `/var/log` or logs in other locations which are unique, with only a single log per instance regardless of the number of applications running.
+2. Nginx logs - these are the Nginx logs, found in `/var/log/nginx`. Additional logs can be added for instances logging https connections to `ssl` Nginx logs.
+3. Application logs - these are the per application logs. Only logs stored in the `logs` directory of your application should be added here, as it uses the application name in the path to create a unique name for the log at LogEntries in order to prevent different applications' logs of the same name being logged to the same location at LE.
+
+To add or remove logs please add/un-comment or delete/comment-out the log file path in the relevent block. `#{app_name}` is a variable and should not be hard-coded, just left to handle multiple applications' logs if present.
 
 By default system and Nginx logs are sent to Logentries. Application specific logs (e.g. application server and background job logs) can be added by either uncommenting or appending the `default['le']['follow_app_paths']` lines with the relevant log filenames. `#{app_name}` is a variable and should not be hard-coded, just left to handle multiple applications' logs if present.
 

--- a/custom-cookbooks/le/cookbooks/custom-le/README.md
+++ b/custom-cookbooks/le/cookbooks/custom-le/README.md
@@ -46,11 +46,10 @@ default['le']['le_api_key'] = 'YOUR_API_KEY_HERE'
 
 The logs to follow are defined in three blocks:
 
-1. System logs - these are server logs, typically found in `/var/log` or logs in other locations which are unique, with only a single log per instance regardless of the number of applications running.
+1. System logs - these are server logs, typically found in `/var/log` or unique logs in other locations, meaning only a single log per instance regardless of the number of applications running.
 2. Nginx logs - these are the Nginx logs, found in `/var/log/nginx`. Additional logs can be added for instances logging https connections to `ssl` Nginx logs.
 3. Application logs - these are the per application logs. Only logs stored in the `logs` directory of your application should be added here, as it uses the application name in the path to create a unique name for the log at LogEntries in order to prevent different applications' logs of the same name being logged to the same location at LE.
 
-To add or remove logs please add/un-comment or delete/comment-out the log file path in the relevent block. `#{app_name}` is a variable and should not be hard-coded, just left to handle multiple applications' logs if present.
+To add or remove logs please add/un-comment or delete/comment-out the log file path in the relevent block.
 
-By default system and Nginx logs are sent to Logentries. Application specific logs (e.g. application server and background job logs) can be added by either uncommenting or appending the `default['le']['follow_app_paths']` lines with the relevant log filenames. `#{app_name}` is a variable and should not be hard-coded, just left to handle multiple applications' logs if present.
-
+`#{app_name}` is a variable and should not be hard-coded, just left to handle multiple applications' logs if present.

--- a/custom-cookbooks/le/cookbooks/custom-le/attributes/default.rb
+++ b/custom-cookbooks/le/cookbooks/custom-le/attributes/default.rb
@@ -17,10 +17,10 @@ default['le']['follow_paths'] = [
 end
 
 #APPLICATION LEVEL LOGS TO FOLLOW SHOULD BE DEFINED HERE
-framework = node['dna']['environment']['framework_env']
+framework_env = node['dna']['environment']['framework_env']
 default['le']['follow_app_paths'] = []
 (node['dna']['applications'] || []).each do |app_name, app_info|
-  default['le']['follow_app_paths'] << "/data/#{app_name}/shared/log/#{framework}.log"
+  default['le']['follow_app_paths'] << "/data/#{app_name}/shared/log/#{framework_env}.log"
 #  default['le']['follow_app_paths'] << "/data/#{app_name}/shared/log/unicorn.log"
 #  default['le']['follow_app_paths'] << "/data/#{app_name}/shared/log/passenger.8000.log"
 #  default['le']['follow_app_paths'] << "/data/#{app_name}/shared/log/delayed_job.log"

--- a/custom-cookbooks/le/cookbooks/custom-le/attributes/default.rb
+++ b/custom-cookbooks/le/cookbooks/custom-le/attributes/default.rb
@@ -1,1 +1,8 @@
 default['le']['le_api_key'] = 'YOUR_API_KEY_HERE'
+
+default['le']['follow_app_paths'] = []
+(node['dna']['applications'] || []).each do |app_name, app_info|
+#  default['le']['follow_app_paths'] << "/data/#{app_name}/shared/log/production.log"
+#  default['le']['follow_app_paths'] << "/data/#{app_name}/shared/log/unicorn.log"
+#  default['le']['follow_app_paths'] << "/data/#{app_name}/shared/log/delayed_job.log"
+end

--- a/custom-cookbooks/le/cookbooks/custom-le/attributes/default.rb
+++ b/custom-cookbooks/le/cookbooks/custom-le/attributes/default.rb
@@ -1,8 +1,27 @@
+#LE API KEY SHOULD BE SET HERE, IT CAN BE FOUND IN THE EY ADD-ONS PORTOL
 default['le']['le_api_key'] = 'YOUR_API_KEY_HERE'
 
+#SYSTEM LOGS TO FOLLOW SHOULD BE DEFINED HERE
+default['le']['follow_paths'] = [
+  "/var/log/syslog",
+  "/var/log/auth.log",
+  "/var/log/daemon.log"
+]
+
+#NGINX LOGS TO FOLLOW SHOULD BE DEFINED HERE
+(node['dna']['applications'] || []).each do |app_name, app_info|
+  default['le']['follow_paths'] << "/var/log/nginx/#{app_name}.access.log"
+#  default['le']['follow_paths'] << "/var/log/nginx/#{app_name}.error.log"
+#  default['le']['follow_paths'] << "/var/log/nginx/#{app_name}.access.ssl.log"
+#  default['le']['follow_paths'] << "/var/log/nginx/#{app_name}.error.ssl.log"
+end
+
+#APPLICATION LEVEL LOGS TO FOLLOW SHOULD BE DEFINED HERE
+framework = node['dna']['environment']['framework_env']
 default['le']['follow_app_paths'] = []
 (node['dna']['applications'] || []).each do |app_name, app_info|
-#  default['le']['follow_app_paths'] << "/data/#{app_name}/shared/log/production.log"
+  default['le']['follow_app_paths'] << "/data/#{app_name}/shared/log/#{framework}.log"
 #  default['le']['follow_app_paths'] << "/data/#{app_name}/shared/log/unicorn.log"
+#  default['le']['follow_app_paths'] << "/data/#{app_name}/shared/log/passenger.8000.log"
 #  default['le']['follow_app_paths'] << "/data/#{app_name}/shared/log/delayed_job.log"
 end


### PR DESCRIPTION
Description of your patch
-------------

Adds functionality to allow customers to specify application logs for Logentries to follow in the custom recipe's attributes.

Recommended Release Notes
-------------

Updated Logentries recipe to allow application logs to be easily added.

Estimated risk
-------------
Low - main recipe has had attributes updated too in order to set new variable required, so will continue to work even if custom recipe not updated by the customer.

Components involved
-------------

All customers will get new main recipe, only customers who update custom recipe will see new functionality.

Description of testing done
-------------

Booted environment with LE enabled. Tested adding new logs to custom attributes, they were added by LE. Also tested with individual logs commented out, the whole `follow_app_paths` block commented out and the entire custom recipe disabled to ensure that main recipe changes did not break anything.

QA Instructions
-------------

Boot env, enable Logentries add-on. Add extra logs to custom attributes file and run chef, then check `le whoami` on the instance and check LE dashboard to check logs are added. Also check with a multi-instance env and ensure that overlapping logs like production.log are named for each app in the LE dashboard.