### PR TITLE
Bumping Percona Toolkit version to 2.2.20

### DIFF
--- a/cookbooks/db_admin_tools/recipes/percona_toolkit.rb
+++ b/cookbooks/db_admin_tools/recipes/percona_toolkit.rb
@@ -1,4 +1,4 @@
-toolkit_version = '2.2.17'
+toolkit_version = '2.2.20'
 
 unmask_package "dev-db/percona-toolkit" do
   version toolkit_version


### PR DESCRIPTION
#### Description of your patch
Bumping percona toolkit version

#### Recommended Release Notes
Bump percona toolkit version to 2.2.20

#### Estimated risk
Low

#### Components involved
DB admin tools

#### Description of testing done
See QA instructions

#### QA Instructions
Boot QA stack. 
Verify that version 2.2.20 of perkona toolkit is installed
