### PR TITLE
[FB-1619] Update sudo to the latest version

### DIFF
--- a/cookbooks/security_updates/recipes/default.rb
+++ b/cookbooks/security_updates/recipes/default.rb
@@ -30,8 +30,9 @@ package 'dev-libs/libgcrypt' do
 end
 
 # CC-1187
+# FB-1619
 package 'app-admin/sudo' do
-  version '1.8.16-r1'
+  version '1.8.16-r2'
 end
 
 # YT-CC-1225


### PR DESCRIPTION
Description of your patch
-------------
This PR updates the sudo package to the latest available version which fixes CVE-2019-14287.

Recommended Release Notes
-------------
Fixes CVE-2019-14287 in the sudo package.

Estimated risk
-------------
Low - only a minor package version bump

Components involved
-------------
security_updates recipes

Description of testing done
-------------
1. Booted a v5 environment with the current release.
2. Updated to a testing stack with this PR.
3. Checked if deploy and app works.
4. Checked if latest sudo version got installed.

QA Instructions
-------------
Test with a PHP application.
Test booting a new environment directly with this change.