### PR TITLE
Replace 127.0.0.1 with private hostname on solo instances

### DIFF
--- a/cookbooks/haproxy/recipes/configure.rb
+++ b/cookbooks/haproxy/recipes/configure.rb
@@ -51,6 +51,11 @@ unless haproxy_httpchk_path
 end
 
 use_http2 = node['haproxy'] && node['haproxy']['http2']
+
+
+solo = node.engineyard.environment.instances.select{ |i| 'solo' == i.role }.map{ |i| i.private_hostname}.first
+
+
 managed_template "/etc/haproxy.cfg" do
   owner 'root'
   group 'root'
@@ -67,7 +72,8 @@ managed_template "/etc/haproxy.cfg" do
     :httpchk_host => haproxy_httpchk_host,
     :httpchk_path => haproxy_httpchk_path,
     :http2 => use_http2,
-    :certificates => Dir['/etc/nginx/ssl/*.pem'].reject {|filename| filename =~ /dhparam/}}
+    :certificates => Dir['/etc/nginx/ssl/*.pem'].reject {|filename| filename =~ /dhparam/},
+    :solo => solo}
   })
 
   # We need to reload to activate any changes to the config

--- a/cookbooks/haproxy/templates/default/haproxy.cfg.erb
+++ b/cookbooks/haproxy/templates/default/haproxy.cfg.erb
@@ -23,7 +23,7 @@ global
   maxconn 65535
 
   # Logging to syslog facility local0
-  # log   127.0.0.1       local0
+  # log   <%= @solo %>       local0
 
   # Distribute the health checks with a bit of randomness
   spread-checks 5
@@ -141,7 +141,7 @@ listen cluster
       <% end %>
     <% else %>
       # It must be a solo.
-      server solo 127.0.0.1:8081 check inter 5000 fastinter 1000 fall 1 weight 50
+      server solo <%= @solo %>:8081 check inter 5000 fastinter 1000 fall 1 weight 50
     <% end %>
 <% end %>
 
@@ -163,14 +163,14 @@ listen cluster
 <% end -%>
 
   backend nodes-http
-     
+
       <% if @backends.any? %>
       <% @backends.each_with_index do |instance, i| %>
         server app-<%= i %> <%= instance['private_hostname'] %>:8089 check inter 5000 fastinter 1000 fall 1 weight <%= (instance['role'] == 'app_master') ? @app_master_weight : 50 %> # <%= instance['id'] %>
       <% end %>
       <% else %>
           # It must be a solo.
-          server solo 127.0.0.1:8089 check inter 5000 fastinter 1000 fall 1 weight 50
+          server solo <%= @solo %>:8089 check inter 5000 fastinter 1000 fall 1 weight 50
         <% end %>
 
  backend nodes-http2
@@ -182,9 +182,8 @@ listen cluster
       <% end %>
       <% else %>
           # It must be a solo.
-          server solo 127.0.0.1:8081 check inter 5000 fastinter 1000 fall 1 weight 50 send-proxy
+          server solo <%= @solo %>:8081 check inter 5000 fastinter 1000 fall 1 weight 50 send-proxy
         <% end %>
-    
 
 <% else %>
     <% if @certificates.count > 0 %>
@@ -205,7 +204,7 @@ listen clusterssl
         <% end %>
         <% else %>
             # It must be a solo.
-            server solo 127.0.0.1:8081 check inter 5000 fastinter 1000 fall 1 weight 50
+            server solo <%= @solo %>:8081 check inter 5000 fastinter 1000 fall 1 weight 50
           <% end %>
     <% else %>
 


### PR DESCRIPTION
#### Description of your patch
This fix allows nginx logging of client (real) IP on the first column of nginx application log.

#### Recommended Release Notes
Nginx is now correctly logging client IP on solo instances 

#### Estimated risk
Low

#### Components involved
HAproxy

#### Description of testing done
See QA instructions

#### QA Instructions
Boot solo instance, verify that /var/log/nginx/<app>.log is showing client IP on the first column
Test using SSL cert/without
Test with solo + multiple instance envs
