### PR TITLE
[FB-1918] Update Default haproxy Version

### DIFF
--- a/cookbooks/haproxy/attributes/haproxy.rb
+++ b/cookbooks/haproxy/attributes/haproxy.rb
@@ -1,2 +1,2 @@
-node.default.haproxy_version = '1.6.5'
+node.default.haproxy_version = '1.6.5-r2'
 node.default.http2 = false


### PR DESCRIPTION
Description of your patch
-------------
Update the default `haproxy` version of the stack to `1.6.5-r2`

Recommended Release Notes
-------------
The cookbooks already update haproxy, to it's latest version, therefore there is no much impact from this commit. But to maintain the consistency, if a cookbook modification is done in the future, the latest available version would be added as the default version.

Estimated risk
-------------
-

Components involved
-------------
`haproxy` cookbook

Description of testing done
-------------
1. Added the latest version to cookbooks.
2. Created a new stack release with the made changes (branch)
3. Checked for the current version

QA Instructions
-------------
1. Check the latest version on a solo environment.
2. Check the latest version on a multi-instance environment