### PR TITLE
[FB-1919] Update default OpenSSL version

### DIFF
--- a/cookbooks/openssl/attributes/openssl.rb
+++ b/cookbooks/openssl/attributes/openssl.rb
@@ -3,4 +3,4 @@ default.openssl.using_metadata = !!node.engineyard.metadata("openssl_ebuild_vers
 # Openssl version updated from 1.0.2k to 1.0.2r
 # YT-CC-1266
 # FB-655
-default.openssl.version = node.engineyard.metadata('openssl_ebuild_version','1.0.2r')
+default.openssl.version = node.engineyard.metadata('openssl_ebuild_version','1.0.2t')


### PR DESCRIPTION
Description of your patch
-------------
Update the default `openssl` version of stack-v5 to `1.0.2t`

Recommended Release Notes
-------------
Updates the default `Openssl` version to the latest available via the portage tree.

Estimated risk
-------------


Components involved
-------------
`openssl` cookbook

Description of testing done
-------------
1. Create a new `labrea` release with the branch `FB-1919-Update-OpenSSL-version`
2. Boot a new environment with the above stack release
3. Check for the current `openssl` version via `eix dev-libs/openssl`

QA Instructions
-------------
1. Check the current version in a solo environment
2. Check the current version in a multi environment
