### PR TITLE
[FB-1200] Update glibc and libidn versions to latest stable versions

### DIFF
--- a/cookbooks/db_client_libs/recipes/default.rb
+++ b/cookbooks/db_client_libs/recipes/default.rb
@@ -8,7 +8,7 @@
   #    - MySQL: /engineyard/portage/engineyard/dev-db/percona-server/*.ebuild
 install_packages=[
   {
-    :server => 'postgresql-server',   # postgresql-server or percona-server
+    :server => 'percona-server',   # postgresql-server or percona-server
     :version => '9.4.4',
     :default_slot => false,                   # postgres packages only, use true only with no_db environments, makes this package the system default
   },

--- a/cookbooks/db_client_libs/recipes/default.rb
+++ b/cookbooks/db_client_libs/recipes/default.rb
@@ -8,7 +8,7 @@
   #    - MySQL: /engineyard/portage/engineyard/dev-db/percona-server/*.ebuild
 install_packages=[
   {
-    :server => 'percona-server',   # postgresql-server or percona-server
+    :server => 'postgresql-server',   # postgresql-server or percona-server
     :version => '9.4.4',
     :default_slot => false,                   # postgres packages only, use true only with no_db environments, makes this package the system default
   },

--- a/cookbooks/security_updates/recipes/default.rb
+++ b/cookbooks/security_updates/recipes/default.rb
@@ -48,11 +48,11 @@ end
 
 # FB-1200
 package 'sys-libs/glibc' do
-  version: '2.22-r8'
+  version '2.22-r8'
 end
 
 # FB-1200
 package 'net-dns/libidn' do
-  version: '1.30-r2'
+  version '1.30-r2'
 end
 

--- a/cookbooks/security_updates/recipes/default.rb
+++ b/cookbooks/security_updates/recipes/default.rb
@@ -45,3 +45,14 @@ package 'net-misc/openssh' do
   version '7.5_p1-r3'
   notifies :restart, 'service[sshd]'
 end
+
+# FB-1200
+package 'sys-libs/glibc' do
+  version '2.25-r1'
+end
+
+# FB-1200
+package 'net-dns/libidn' do
+  version '1.32-r3'
+end
+

--- a/cookbooks/security_updates/recipes/default.rb
+++ b/cookbooks/security_updates/recipes/default.rb
@@ -48,11 +48,11 @@ end
 
 # FB-1200
 package 'sys-libs/glibc' do
-  version '2.25-r1'
+  action :upgrade
 end
 
 # FB-1200
 package 'net-dns/libidn' do
-  version '1.32-r3'
+  action :upgrade
 end
 

--- a/cookbooks/security_updates/recipes/default.rb
+++ b/cookbooks/security_updates/recipes/default.rb
@@ -48,11 +48,11 @@ end
 
 # FB-1200
 package 'sys-libs/glibc' do
-  action :upgrade
+  version: '2.22-r8'
 end
 
 # FB-1200
 package 'net-dns/libidn' do
-  action :upgrade
+  version: '1.30-r2'
 end
 


### PR DESCRIPTION
Description of your patch
-------------
Updates the `net-dns/libidn` and `sys-libs/glibc` to the latest available `stable` version upon a release.

Recommended Release Notes
-------------
Updates the current `net-dns/libidn` and `sys-libs/glibc` versions to the latest available stable version.

Estimated risk
-------------
-

Components involved
-------------
`security_updates` cookbook

Description of testing done
-------------
1. Created a new labrea stack release with the specified changes on version upgrades on `security_updates` cookbook.
2. Upgraded the current stack version, to the latest release.
3. Checked if the current versions of the 2 packages are latest.

QA Instructions
-------------
1. Boot a solo environment and check if the latest available versions of the `net-dns/libidn` and `sys-libs/glibc`  are  `1.30-r2` and `2.22-r7`.
2. Check the same with a multiple instance environment