### PR TITLE
[FB-854] Update PostgreSQL versions

### DIFF
--- a/cookbooks/postgresql/attributes/version.rb
+++ b/cookbooks/postgresql/attributes/version.rb
@@ -1,15 +1,15 @@
 case attribute.dna.engineyard.environment.db_stack_name
 when "postgres9_4"
-  default['postgresql']['latest_version'] = '9.4.22'
+  default['postgresql']['latest_version'] = '9.4.24'
   default['postgresql']['short_version'] = '9.4'
 when "postgres9_5"
-  default['postgresql']['latest_version'] = '9.5.17'
+  default['postgresql']['latest_version'] = '9.5.19'
   default['postgresql']['short_version'] = '9.5'
 when "postgres9_6"
-  default['postgresql']['latest_version'] = '9.6.13'
+  default['postgresql']['latest_version'] = '9.6.15'
   default['postgresql']['short_version'] = '9.6'
 when "postgres10"
-  default['postgresql']['latest_version'] = '10.8'
+  default['postgresql']['latest_version'] = '10.10'
   default['postgresql']['short_version'] = '10'
 end
 default['postgresql']['datadir'] = "/db/postgresql/#{node['postgresql']['short_version']}/data/"

--- a/cookbooks/postgresql/recipes/server_install.rb
+++ b/cookbooks/postgresql/recipes/server_install.rb
@@ -1,10 +1,10 @@
 postgres_version = node['postgresql']['short_version']
 
 known_ebuild_versions = %w[
-  9.4.8   9.4.11  9.4.12  9.4.22
-  9.5.3   9.5.6   9.5.7   9.5.17
-  9.6.3   9.6.13
-  10.4    10.8
+  9.4.8   9.4.11  9.4.12  9.4.22  9.4.24
+  9.5.3   9.5.6   9.5.7   9.5.17  9.5.19
+  9.6.3   9.6.13  9.6.15
+  10.4    10.8    10.10
 ]
 
 execute "dropping lock version file" do


### PR DESCRIPTION
Description of your patch
-------------
Updates the default postgreSQL versions of v9.4, v9.5, v9.6 and of v10 to `9.4.24` , `9.5.19`, `9.6.15` and `10.10` respectively.

Recommended Release Notes
-------------
Updates the default postgreSQL versions of v9.4, v9.5, v9.6 and of v10 to `9.4.24` , `9.5.19`, `9.6.15` and `10.10` respectively.

Estimated risk
-------------

Components involved
-------------
`postgresql` cookbook

Description of testing done
-------------
1. Created a new stack release via labrea with the changes done on `postgresql` cookbook.
2. Booted separate envs with the specified postgreSQL main versions.
3. Verified if the latest version available under each key-version is the default one.

QA Instructions
-------------
1. Verify the postgresql versions of each `v9.4, v9.5, v9.6 and of v10` via `solo` environments.
2. Verify the postgresql versions of each `v9.4, v9.5, v9.6 and of v10` via `multi-instance` environments.