### PR TITLE
[FB-675] Removed Encryption and Decryption from Environment Vars

### DIFF
--- a/cookbooks/env_vars/libraries/helpers.rb
+++ b/cookbooks/env_vars/libraries/helpers.rb
@@ -1,15 +1,7 @@
 require 'base64'
-require 'openssl'
 
 module EnvVars
   module Helper
-    def encrypt(value, secret)
-      MessageCipher.new(secret).encrypt(value)
-    end
-
-    def decrypt(value, secret)
-      MessageCipher.new(secret).decrypt(value)
-    end
 
     def fetch_environment_variables(app_data)
       metadata = app_data['components'].find {|component| component['key'] == 'app_metadata'}
@@ -27,99 +19,6 @@ module EnvVars
       value.gsub(/[`$"\\]/) { |x| "\\#{x}" }
     end
 
-    class MessageCipher
-      DEFAULT_DIGEST = 'SHA1'
-      DEFAULT_CIPHER = 'aes-256-cbc'
-
-      class InvalidSignature < StandardError; end
-      class InvalidMessage < StandardError; end
-
-      attr_reader :message, :secret
-
-      def initialize(secret, options = {})
-        @secret = secret
-
-        @serializer = options[:serializer] || Marshal
-        @digest = OpenSSL::Digest.const_get(options[:digest] || DEFAULT_DIGEST).new
-        @cipher = options[:cipher] || DEFAULT_CIPHER
-      end
-
-      def encrypt(message)
-        encode_and_sign(_encrypt(message))
-      end
-
-      def decrypt(message)
-        _decrypt(verify_and_decode(message))
-      end
-
-      private
-
-      def encode_and_sign(value)
-        data = encode(value)
-        "#{data}--#{sign(data)}"
-      end
-
-      def verify_and_decode(message)
-        data, signature = message.split("--")
-
-        if !data.empty? && !signature.empty? && signature == sign(data)
-          begin
-            decode(data)
-          rescue ArgumentError => argument_error
-            raise InvalidSignature if argument_error.message =~ %r{invalid base64}
-            raise
-          end
-        else
-          raise InvalidSignature
-        end
-      end
-
-      def sign(data)
-        OpenSSL::HMAC.hexdigest(@digest, secret, data)
-      end
-
-      def encode(data)
-        ::Base64.strict_encode64(data)
-      end
-
-      def decode(data)
-        ::Base64.strict_decode64(data)
-      end
-
-      def new_cipher
-        OpenSSL::Cipher::Cipher.new(@cipher)
-      end
-
-      def _encrypt(value)
-        cipher = new_cipher
-        cipher.encrypt
-        cipher.key = @secret
-
-        # Rely on OpenSSL for the initialization vector
-        iv = cipher.random_iv
-
-        encrypted_data = cipher.update(@serializer.dump(value))
-        encrypted_data << cipher.final
-
-        [encrypted_data, iv].map! { |v| encode(v) }.join('--')
-      end
-
-      def _decrypt(encrypted_message)
-        cipher = new_cipher
-        encrypted_data, iv = encrypted_message.split("--").map { |v| decode(v) }
-
-        cipher.decrypt
-        cipher.key = secret
-        cipher.iv  = iv
-
-        decrypted_data = cipher.update(encrypted_data)
-        decrypted_data << cipher.final
-
-        @serializer.load(decrypted_data)
-      rescue OpenSSLCipherError, TypeError, ArgumentError
-        raise InvalidMessage
-      end
-    end
   end
 end
 


### PR DESCRIPTION
Description of your patch
-------------
Removes code from `env_vars` helper file which were used in Encryption and Decryption scnearios

Recommended Release Notes
-------------
Removed the encryption and decryption code blocks from the helper module pf `ey-libs`, such that it doesn't affect the overall functionality of the cookbooks.

Estimated risk
-------------
Low - Nothing majorly included

Components involved
-------------
`ey-libs` env-vars `helper` module

Description of testing done
-------------

- Created a new branch with the changes made on `ey-libs` helper module.
- Created a new `labrea` release with that branch
- Changed the environment to a production stack and added a few environment variables.
- Added `environment variables` via the dashboard and changed the stack back to development stack.
- Environment-wide apply made and checked if the environment variables are working properly.

QA Instructions
-------------
Book a PHP and rails environments separately and add environment variables via the dashboard. Check `env.cloud` file to see if the values are set as expected.
