### PR TITLE
[FB-2128] Update the default Git Version to the latest available

### DIFF
--- a/cookbooks/git/attributes/git.rb
+++ b/cookbooks/git/attributes/git.rb
@@ -1,1 +1,1 @@
-default['git']['version'] = '1.7.3.5'
+default['git']['version'] = '2.7.3-r4'

--- a/cookbooks/security_updates/recipes/default.rb
+++ b/cookbooks/security_updates/recipes/default.rb
@@ -57,3 +57,7 @@ package 'net-dns/libidn' do
   version '1.30-r2'
 end
 
+# FB-2128
+package 'dev-vcs/git' do
+  version '2.7.3-r4'
+end


### PR DESCRIPTION
Description of your patch
-------------
Update the default version of `dev-vcs/git` to `2.7.3-r4`

Recommended Release Notes
-------------
Update the default version of `dev-vcs/git` to `2.7.3-r4`

Estimated risk
-------------
Low, updated through `security_updates` package. The current `git` cookbook is not referred while generating the installation

Components involved
-------------
`security_updates` cookbook

Description of testing done
-------------
1. Booted an environment (solo)
2. Edit was made to the `security_updates` cookbook to install the latest default stable version of git
3. Used `/home/ey/bin/chef-solo -j /etc/chef/dna.json -c /etc/chef/solo.rb` to run the cookbooks
4. Verified via `eix dev-vcs/git` if the latest version is installed.

QA Instructions
-------------
1. Boot a solo environment and verify if the mentioned version of git ( `2.7.3-r4`) is installed
2. Boot a non-solo environment and verify if the mentioned version of git( `2.7.3-r4`) is installed