### PR TITLE
[TEY-25, TEY-139] Support for Aurora PostgreSQL

### DIFF
--- a/cookbooks/app/recipes/prep.rb
+++ b/cookbooks/app/recipes/prep.rb
@@ -5,9 +5,9 @@ include_recipe "ey-cron"
 is_solo = ['solo'].include?(node.dna['instance_role'])
 unless is_solo   # for solo leave the db stuff to the db cookbook
   case node.engineyard.environment['db_stack_name']
-  when /postgres/
+  when /^postgres\d+/, /^aurora-postgresql\d+/
     include_recipe "postgresql::default"
-  when /mysql/, /aurora/, /mariadb/
+  when /^mysql\d+/, /^aurora\d+/, /^mariadb\d+/
     include_recipe "mysql::client"
     include_recipe "mysql::user_my.cnf"
   when "no_db"

--- a/cookbooks/ey-lib/libraries/ey-environment.rb
+++ b/cookbooks/ey-lib/libraries/ey-environment.rb
@@ -188,9 +188,9 @@ class Chef
           stack_name = @hash['db_stack_name'].gsub /[^a-z]+/, ''
           # see https://tickets.engineyard.com/issue/DATA-66 to  understand this
           case stack_name
-          when 'aurora', 'mariadb'
+          when 'aurora', 'mariadb', 'mysql'
             'mysql'
-          when 'postgres'
+          when 'postgres', 'aurorapostgresql'
             'postgresql'
           else
             stack_name

--- a/cookbooks/postgresql/attributes/version.rb
+++ b/cookbooks/postgresql/attributes/version.rb
@@ -1,14 +1,14 @@
 case attribute.dna.engineyard.environment.db_stack_name
-when "postgres9_4"
+when "postgres9_4", "aurora-postgresql9_4"
   default['postgresql']['latest_version'] = '9.4.24'
   default['postgresql']['short_version'] = '9.4'
-when "postgres9_5"
+when "postgres9_5", "aurora-postgresql9_5"
   default['postgresql']['latest_version'] = '9.5.19'
   default['postgresql']['short_version'] = '9.5'
-when "postgres9_6"
+when "postgres9_6", "aurora-postgresql9_6"
   default['postgresql']['latest_version'] = '9.6.15'
   default['postgresql']['short_version'] = '9.6'
-when "postgres10"
+when "postgres10", "aurora-postgresql10"
   default['postgresql']['latest_version'] = '10.10'
   default['postgresql']['short_version'] = '10'
 end

--- a/cookbooks/util/recipes/prep.rb
+++ b/cookbooks/util/recipes/prep.rb
@@ -5,9 +5,9 @@ include_recipe "ey-cron"
 is_solo = ['solo'].include?(node.dna['instance_role'])
 unless is_solo   # for solo leave the db stuff to the db cookbook
   case node.engineyard.environment['db_stack_name']
-  when /postgres/
+  when /^postgres\d+/, /^aurora-postgresql\d+/
     include_recipe "postgresql::default"
-  when /mysql/, /aurora/, /mariadb/
+  when /^mysql\d+/, /^aurora\d+/, /^mariadb\d+/
     include_recipe "mysql::client"
     include_recipe "mysql::user_my.cnf"
   when "no_db"


### PR DESCRIPTION
# Description of your patch
This PR adds support for Aurora PostgreSQL database engines. This includes support for Aurora PostgreSQL 10.x.

# Recommended Release Notes
Adds support for Aurora PostgreSQL.

# Estimated risk
Medium.

# Components involved
app recipes, util recipes, ey-lib libraries, postgresql recipes

# Dependencies
None.

# Description of testing done
1. Created a Aurora PostgreSQL 10.x RDS Database service
2. Created an environment (Ruby) with Amazon RDS DB provider and Aurora PostgreSQL 10.x DB engine.
3. Booted the environment with two app instances, and a redis utility instance, connected it to the RDS Database service.
4. Checked if Chef run finishes successfully and deployment succeeds.
5. Checked if the deployed application works.

# QA Instructions
Test a PHP application.
Test with RDS MySQL 5.7, PostgreSQL 9.6, and Aurora MySQL