### PR TITLE
[TEY-142] Fix logic for including recipe mysql::setup_app_users_dbs

### DIFF
--- a/cookbooks/app/recipes/build.rb
+++ b/cookbooks/app/recipes/build.rb
@@ -1,6 +1,6 @@
 include_recipe "deploy::restart"
 include_recipe "db_admin_tools"
 
-if db_host_is_rds? && node.engineyard.environment[:db_stack_name][/mysql/]
+if db_host_is_rds? && node.engineyard.environment[:db_stack_name][/^(mysql\d+|aurora\d+)/]
   include_recipe "mysql::setup_app_users_dbs"
 end


### PR DESCRIPTION
Description of your patch
-------------
This PR fixes the logic for including the recipe `mysql::setup_app_users_dbs`.

Recommended Release Notes
-------------
Fixes a bug with configuring Aurora MySQL.

Estimated risk
-------------
Low. Just updated the check for including the recipe.

Components involved
-------------
app recipes

Dependencies
-------------
None

Description of testing done
-------------
1. Booted a new environment with an Aurora MySQL 5.6 database.
2. Verified that the deploy fails because the mysql DB user wasn't set up.
3. Upgraded to a dev stack with the changes in this PR.
4. Applied and checked if Chef run is successful.
5. Checked if deployment works and app works.

QA Instructions
-------------
Test a PHP application
Test with different app servers.