### PR TITLE
[TEY-242] updates ruby version and dependencies

### DIFF
--- a/cookbooks/ey-lib/libraries/ey-environment.rb
+++ b/cookbooks/ey-lib/libraries/ey-environment.rb
@@ -143,9 +143,9 @@ class Chef
           :ruby_215   => "2.1.10",
           :ruby_220   => "2.2.10",
           :ruby_230   => "2.3.8",
-          :ruby_240   => "2.4.9",
-          :ruby_250   => "2.5.7",
-          :ruby_260   => "2.6.5",
+          :ruby_240   => "2.4.10",
+          :ruby_250   => "2.5.8",
+          :ruby_260   => "2.6.6",
         }
         if versions.has_key?(ruby_archtype.to_sym)
           version = versions[ruby_archtype.to_sym]

--- a/cookbooks/ruby/attributes/versions.rb
+++ b/cookbooks/ruby/attributes/versions.rb
@@ -56,9 +56,9 @@ elsif ruby2x?(4, ruby_version)
 elsif ruby2x?(5, ruby_version)
   default[:do_upgrade_eselect_ruby] = true
   default[:ruby_dependencies] = {
-    "dev-ruby/json"         => "2.0.3-r1",
+    "dev-ruby/json"         => "2.3.0",
     "dev-ruby/racc"         => "1.4.14-r2",
-    "dev-ruby/rake"         => "12.3.0",
+    "dev-ruby/rake"         => "12.3.3",
     "dev-ruby/rdoc"         => "6.0.3",
     "dev-ruby/rubygems"     => "2.7.9",
     "dev-ruby/did_you_mean" => "1.2.0",
@@ -76,7 +76,7 @@ elsif ruby2x?(6, ruby_version)
     "dev-ruby/bundler"      => "1.17.3",
     "dev-ruby/json"         => "2.0.3-r2",
     "dev-ruby/racc"         => "1.4.14-r3",
-    "dev-ruby/rake"         => "12.3.2",
+    "dev-ruby/rake"         => "12.3.3",
     "dev-ruby/rdoc"         => "6.0.3-r1",
     "dev-ruby/rubygems"     => "3.0.3",
     "dev-ruby/did_you_mean" => "1.3.0",

--- a/cookbooks/ruby/attributes/versions.rb
+++ b/cookbooks/ruby/attributes/versions.rb
@@ -38,7 +38,7 @@ elsif ruby2x?(3, ruby_version)
   }
 elsif ruby2x?(4, ruby_version)
   default[:ruby_dependencies] = {
-    "dev-ruby/json"         => "2.0.3",
+    "dev-ruby/json"         => "2.3.0",
     "dev-ruby/racc"         => "1.4.14-r1",
     "dev-ruby/rake"         => "12.0.0",
     "dev-ruby/rdoc"         => "5.1.0",
@@ -74,7 +74,7 @@ elsif ruby2x?(5, ruby_version)
 elsif ruby2x?(6, ruby_version)
   default[:ruby_dependencies] = {
     "dev-ruby/bundler"      => "1.17.3",
-    "dev-ruby/json"         => "2.0.3-r2",
+    "dev-ruby/json"         => "2.3.0",
     "dev-ruby/racc"         => "1.4.14-r3",
     "dev-ruby/rake"         => "12.3.3",
     "dev-ruby/rdoc"         => "6.0.3-r1",


### PR DESCRIPTION
**Description of your patch**
This PR updates the minor versions of Ruby 2.4, 2.5, and 2.6.

**Recommended Release Notes**
Updates to the latest available Ruby versions (2.4.10, 2.5.8, 2.6.6). Updates rake to 12.3.3 from 12.3.2. and JSON to 2.3.0 

**Estimated risk**
Medium. Just minor version bump which includes dependencies and security patches

**Components involved**
Ruby recipes
EngineYard Libraries (ey-lib)

**Description of testing done**
Boot new stack -> new Ruby version used
Boot new stack w/jemalloc -> new Ruby w/jemalloc version used
Boot old stack -> upgrade -> new Ruby version used
Boot old stack w/jemalloc -> upgrade -> new Ruby w/jemalloc version used

**QA Instructions**
Test different app server and DB configurations.
Test a PHP application.
Test different environment configurations.