### PR TITLE
Added custom-addtrust recipe

### DIFF
--- a/custom-cookbooks/custom-addtrust/README.md
+++ b/custom-cookbooks/custom-addtrust/README.md
@@ -1,4 +1,4 @@
-## custom-AddTrust
+## custom-addtrust
 
 This recipe removes the expired AddTrust_External_Root.crt and updates the ca-certificates. You can read more about it on [AddTrust External CA Root expiration causing SSL certificate verification failures](https://support.cloud.engineyard.com/hc/en-us/articles/360048762994-AddTrust-External-CA-Root-expiration-causing-SSL-certificate-verification-failures)
 
@@ -9,16 +9,16 @@ For simplicity, we recommend that you create the cookbooks directory at the root
 1. Edit `cookbooks/ey-custom/recipes/after-main.rb` and add
 
   ```
-  include_recipe 'custom-AddTrust'
+  include_recipe 'custom-addtrust'
   ```
 
 2. Edit `cookbooks/ey-custom/metadata.rb` and add
 
   ```
-  depends 'custom-AddTrust'
+  depends 'custom-addtrust'
   ```
 
-3. Copy `custom-cookbooks/packages/cookbooks/custom-AddTrust` to `cookbooks/`
+3. Copy `custom-cookbooks/packages/cookbooks/custom-addtrust` to `cookbooks/`
 
   ```
   cd ~ # Change this to your preferred directory. Anywhere but inside the application

--- a/custom-cookbooks/custom-addtrust/README.md
+++ b/custom-cookbooks/custom-addtrust/README.md
@@ -1,0 +1,37 @@
+## custom-AddTrust
+
+This recipe removes the expired AddTrust_External_Root.crt and updates the ca-certificates. You can read more about it on [AddTrust External CA Root expiration causing SSL certificate verification failures](https://support.cloud.engineyard.com/hc/en-us/articles/360048762994-AddTrust-External-CA-Root-expiration-causing-SSL-certificate-verification-failures)
+
+## Installation
+
+For simplicity, we recommend that you create the cookbooks directory at the root of your application. If you prefer to keep the infrastructure code separate from application code, you can create a new repository.
+
+1. Edit `cookbooks/ey-custom/recipes/after-main.rb` and add
+
+  ```
+  include_recipe 'custom-AddTrust'
+  ```
+
+2. Edit `cookbooks/ey-custom/metadata.rb` and add
+
+  ```
+  depends 'custom-AddTrust'
+  ```
+
+3. Copy `custom-cookbooks/packages/cookbooks/custom-AddTrust` to `cookbooks/`
+
+  ```
+  cd ~ # Change this to your preferred directory. Anywhere but inside the application
+
+  git clone https://github.com/engineyard/ey-cookbooks-stable-v5
+  cd ey-cookbooks-stable-v5
+  cp custom-cookbooks/packages/cookbooks/custom-AddTrust /path/to/app/cookbooks/
+  ```
+
+4. Download the ey-core gem on your local machine and upload the recipes
+
+  ```
+  gem install ey-core
+  ey-core recipes upload --environment=<nameofenvironment> --file=<pathtocookbooksfolder> --apply
+  ```
+

--- a/custom-cookbooks/custom-addtrust/metadata.rb
+++ b/custom-cookbooks/custom-addtrust/metadata.rb
@@ -1,0 +1,6 @@
+name 'custom-addtrust'
+maintainer 'Engine Yard'
+maintainer_email 'support@engineyard.com'
+version '1.0'
+source_url 'https://engineyard.com'
+issues_url 'https://support.engineyard.com'

--- a/custom-cookbooks/custom-addtrust/recipes/default.rb
+++ b/custom-cookbooks/custom-addtrust/recipes/default.rb
@@ -1,0 +1,25 @@
+ruby_block 'remove_Addtrust' do
+    not_if "/etc/ca-certificates.conf | grep \"!mozilla/AddTrust_External_Root.crt\""
+    block do
+     
+     buildarray = []
+     ischange = false
+     lines = IO.readlines('/etc/ca-certificates.conf')  
+     for line in lines
+      if (line.include? 'mozilla/AddTrust_External_Root.crt')
+        buildarray << '!mozilla/AddTrust_External_Root.crt'
+        ischange = true
+      else
+       buildarray << line
+      end
+     end
+     
+     if ischange
+      writefile = File.open("/etc/ca-certificates.conf", "w")
+      writefile.puts(buildarray)
+      writefile.close
+      system("update-ca-certificates")
+     end
+     action :run
+    end
+   end


### PR DESCRIPTION
#### Description of your patch
Added custom-addtrust recipe that removes the expired AddTrust certificate.

#### Recommended Release Notes
N/A

#### Estimated risk
Low

#### Components involved
README

#### Description of testing done
See QA instructions

#### QA Instructions

- On a V5 environment issue `head /etc/ca-certificates.conf` and check that `mozilla/AddTrust_External_Root.crt` is included

- Test a url using the expired certificate. Output would be of the following type:

```
curl https://expiredrootcertdomainname.com
curl: (60) SSL certificate problem: certificate has expired
More details here: https://curl.haxx.se/docs/sslcerts.html

curl performs SSL certificate verification by default, using a "bundle"
 of Certificate Authority (CA) public keys (CA certs). If the default
 bundle file isn't adequate, you can specify an alternate file
 using the --cacert option.
If this HTTPS server uses a certificate signed by a CA represented in
 the bundle, the certificate verification probably failed due to a
 problem with the certificate (it might be expired, or the name might
 not match the domain name in the URL).
If you'd like to turn off curl's verification of the certificate, use
 the -k (or --insecure) option.
```

- Include the recipe as per the instructions on the Readme file
- Issue `head /etc/ca-certificates.conf` and check that `mozilla/AddTrust_External_Root.crt` has been prepended with an exclamation mark (!):
`!mozilla/AddTrust_External_Root.crt`
- subsequent `curl` commands should not fail
