### PR TITLE
TEY-385 - Adds custom_nodejs recipe

### DIFF
--- a/custom-cookbooks/custom_nodejs/README.md
+++ b/custom-cookbooks/custom_nodejs/README.md
@@ -1,0 +1,5 @@
+# Custom Nodejs
+
+This example contains a `cookbooks/` directory with all the components for upgrading Nodejs beyond the platform offered versions on the v5 stack.
+
+See [cookbooks/custom_nodejs](cookbooks/custom_nodejs/README.md) for complete instructions.

--- a/custom-cookbooks/custom_nodejs/cookbooks/custom_nodejs/README.md
+++ b/custom-cookbooks/custom_nodejs/cookbooks/custom_nodejs/README.md
@@ -1,0 +1,21 @@
+# Custom Node.js
+
+This cookbook can serve as a good starting point for upgrading Node.js in your instances.
+Specifically, it gives you the tools in order to install versions of nodejs that are not present in the portage tree.
+
+** Please Note ** This recipe will setup the selected version of Node.js (the version specified in attributes) in all instances by default. If you need custom_nodejs to run only in app/util, you will need to modify the recipe. Also, since this recipe is practically installing node versions not officially supported by portage, integration is not guaranteed.  
+
+## Installation
+
+* The following instructions assume you already have a local `cookbooks` directory for your custom recipe usage, if you do not the firstly create a `cookbooks` directory.
+* Copy the full `custom_nodejs` directory from this recipe's `cookbooks` directory to your own `cookbooks` directory.
+* Copy the full `node` directory from this recipe's `cookbooks` directory to your own `cookbooks` directory. This will overlay the `node` recipe's `common.rb` and prevent the Node.js version being reverted.
+* If you already have a `cookbooks/ey-custom` directory, add `include_recipe 'custom_nodejs'` to your `ey-custom/recipes/after-main.rb`.
+* If you already have a `cookbooks/ey-custom` directory, add `depends 'custom_nodejs'` to your `ey-custom/metadata.rb`.
+* If you do not already have a `cookbooks/ey-custom` directory, copy the full `ey-custom` directory from this recipe's `cookbooks` directory to your own `cookbooks` directory.
+* Upload your recipes and run an _Apply_.
+
+## Customizations
+
+* The version of Node.js to be install can be set in `attributes/default.rb`. Please avoid installing the same versions already existing in portage (check via `eix nodejs`). You can check the available versions [here](https://nodejs.org/en/download/releases/). 
+* To revert the custom version of Node.js to the one configured on your environment's _Edit Environment_ page you must both remove/disable this recipe _and remove the `node` directory to remove the `common.rb` overlay.

--- a/custom-cookbooks/custom_nodejs/cookbooks/custom_nodejs/attributes/default.rb
+++ b/custom-cookbooks/custom_nodejs/cookbooks/custom_nodejs/attributes/default.rb
@@ -1,0 +1,2 @@
+# set the custom node version ot install
+default[:custom_node_version] = "12.18.2"

--- a/custom-cookbooks/custom_nodejs/cookbooks/custom_nodejs/files/default/nodejs-bin-generic.ebuild
+++ b/custom-cookbooks/custom_nodejs/cookbooks/custom_nodejs/files/default/nodejs-bin-generic.ebuild
@@ -1,0 +1,59 @@
+# Copyright 1999-2015 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Header: $
+
+EAPI=4
+
+inherit pax-utils versionator
+
+DESCRIPTION="Ebuild for static binary build of nodejs"
+HOMEPAGE="https://nodejs.org"
+SRC_URI="https://nodejs.org/dist/v${PV}/node-v${PV}-linux-x64.tar.gz"
+
+LICENSE="Apache-1.1 Apache-2.0 BSD BSD-2 MIT"
+SLOT="$(get_version_component_range 1-3)"
+KEYWORDS="~amd64"
+IUSE=""
+
+DEPEND="app-eselect/eselect-nodejs"
+RDEPEND="${DEPEND}"
+
+S="${WORKDIR}/node-v${PV}-linux-x64"
+INSTALL_DIR="/opt/nodejs/${PV}"
+
+src_install() {
+
+        # Installation of node modules
+        # doins is not used here since it uses a very
+        # basic install command which doen't keep binary permissions
+        # mkdir is needed as copy doesn't directly deal with the
+        # various ebuild helper functions
+        mkdir -p "${D}/${INSTALL_DIR}"
+        cp -a "${S}/lib" "${D}/${INSTALL_DIR}/"
+
+        # Install of node header files with symlinks from
+        # source node ebuild
+        insinto ${INSTALL_DIR}/include
+        doins -r include/node
+
+        dodir ${INSTALL_DIR}/include/node/deps/{v8,uv}
+        dosym . ${INSTALL_DIR}/include/node/src
+        for var in deps/{uv,v8}/include; do
+                dosym ../.. ${INSTALL_DIR}/include/node/${var}
+        done
+
+        # Man install
+        insinto ${INSTALL_DIR}/
+        doins -r share
+
+        # Node needs pax marking
+        into ${INSTALL_DIR}/
+        pax-mark -m bin/node
+        dobin bin/node
+        dosym ${INSTALL_DIR}/bin/node ${INSTALL_DIR}/bin/node-waf
+
+        # Symlink for npm + execute permissions
+        fperms 0755 ${INSTALL_DIR}/lib/node_modules/npm/bin/npm-cli.js
+        dosym ${INSTALL_DIR}/lib/node_modules/npm/bin/npm-cli.js \
+                ${INSTALL_DIR}/bin/npm
+}

--- a/custom-cookbooks/custom_nodejs/cookbooks/custom_nodejs/metadata.rb
+++ b/custom-cookbooks/custom_nodejs/cookbooks/custom_nodejs/metadata.rb
@@ -1,0 +1,1 @@
+name 'custom_nodejs'

--- a/custom-cookbooks/custom_nodejs/cookbooks/custom_nodejs/recipes/default.rb
+++ b/custom-cookbooks/custom_nodejs/cookbooks/custom_nodejs/recipes/default.rb
@@ -1,0 +1,48 @@
+version = node[:custom_node_version].strip
+
+ey_cloud_report "Install node-v#{version}" do
+  message "Installing custom node-v#{version}"
+end
+
+Chef::Log.info "Installing custom node-v#{version}"
+
+ebuild_file = "/engineyard/portage/engineyard/net-libs/nodejs-bin/nodejs-bin-#{version}.ebuild"
+
+#create the new nodejs ebuild
+cookbook_file ebuild_file do
+  source "nodejs-bin-generic.ebuild"
+  backup 0
+  mode 0644
+end
+
+#create the manifest file
+execute "ebuild-nodejs" do
+  cwd "/engineyard/portage/engineyard/net-libs/nodejs-bin/"
+  command "ebuild #{File.basename(ebuild_file)} manifest"
+end
+
+
+execute "eix-sync" do
+  command "eix-sync"
+end
+
+#inform the OS of the new package
+execute "egencache + eix-update" do
+    command "egencache --repo engineyard --update && eix-update"
+end
+
+#unmask the new node package
+enable_package "net-libs/nodejs-bin" do
+    version "#{version}"
+end
+
+#install the new node package
+package "net-libs/nodejs-bin" do
+    version version "#{version}"
+    action :install
+end
+
+#select the new node version
+execute "eselect nodejs-bin-#{version}" do
+  command "eselect nodejs set #{version}"
+end

--- a/custom-cookbooks/custom_nodejs/cookbooks/ey-custom/metadata.rb
+++ b/custom-cookbooks/custom_nodejs/cookbooks/ey-custom/metadata.rb
@@ -1,0 +1,3 @@
+name 'ey-custom'
+
+depends 'custom_nodejs'

--- a/custom-cookbooks/custom_nodejs/cookbooks/ey-custom/recipes/after-main.rb
+++ b/custom-cookbooks/custom_nodejs/cookbooks/ey-custom/recipes/after-main.rb
@@ -1,0 +1,2 @@
+include_recipe 'custom_nodejs'
+#To revert the nodejs version back to a portage provided version you must both disable this recipe and remove the cookbooks/node/recipes/common.rb overlay implemented by this recipe.

--- a/custom-cookbooks/custom_nodejs/cookbooks/node/recipes/common.rb
+++ b/custom-cookbooks/custom_nodejs/cookbooks/node/recipes/common.rb
@@ -1,0 +1,150 @@
+get_package_name = {
+  '4.4.5' => 'net-libs/nodejs',
+  '8.12.0' => 'net-libs/nodejs-bin',
+  '9.11.2' => 'net-libs/nodejs-bin',
+  '10.10.0' => 'net-libs/nodejs-bin'
+}
+get_package_name.default = 'net-libs/nodejs'
+
+unmask_package "dev-libs/libuv" do
+  version node['nodejs']['libuv']['version']
+  unmaskfile "libuv"
+end
+
+enable_package 'dev-libs/libuv' do
+  version node['nodejs']['libuv']['version']
+end
+
+directory "/mnt/node/tmp" do
+  action :delete
+  recursive true
+end
+
+directory "/opt/node" do
+  action :delete
+  recursive true
+end
+
+cookbook_file '/etc/env.d/93node' do
+  owner 'root'
+  group 'root'
+  source '93node'
+  mode 0644
+  only_if do
+    File.directory?('/opt/nodejs/current/bin')
+  end
+end
+
+execute "env-update" do
+  command "env-update"
+end
+available_nodejs_versions = node['nodejs']['available_versions'].sort {|x,y| Engineyard::Version.new(x) <=> Engineyard::Version.new(y)}
+
+nodejs_version_to_install_and_eselect = node['nodejs']['version']
+
+ # Enable all versions of node we provide
+ available_nodejs_versions.each do |nodejs_version|
+   enable_package get_package_name[nodejs_version] do
+     version nodejs_version
+   end
+ end
+
+# 0.12.x needs extra packages enabled
+if (available_nodejs_versions & %w(0.12.6 0.12.7 0.12.10)).length > 0
+  enable_package 'net-libs/http-parser' do
+    version '2.6.2'
+  end
+  enable_package 'dev-libs/libuv' do
+    version '1.8.0'
+  end
+end
+
+# # Enable and install a system node
+ unmask_package get_package_name[nodejs_version_to_install_and_eselect] do
+   version nodejs_version_to_install_and_eselect
+   unmaskfile "nodejs"
+ end
+
+# # Update the attributes
+ node.normal['nodejs']['version'] = nodejs_version_to_install_and_eselect
+ node.normal['nodejs']['available_versions'] = available_nodejs_versions
+
+
+ package get_package_name[nodejs_version_to_install_and_eselect] do
+   version nodejs_version_to_install_and_eselect
+ end
+
+# For use with custom_nodejs recipe, ensures that the following only runs for non-custom nodejs installs
+currently_installed_node = `node -v`.strip.gsub("v","")
+
+if ( node['nodejs']['available_versions'].include? currently_installed_node ) || (currently_installed_node == nil)
+
+  nodejs_version_to_eselect_trimmed = nodejs_version_to_install_and_eselect.split("-r").first
+  eselect nodejs_version_to_eselect_trimmed do
+    slot 'nodejs'
+  end
+
+  current_node_dir = "/opt/nodejs/#{node['nodejs']['version'].sub(/-r.*/, '')}"
+  link '/opt/nodejs/current' do
+    to current_node_dir
+    only_if do
+      File.directory?(current_node_dir)
+    end
+  end
+
+  extended_node_dir = "/opt/nodejs/#{node['nodejs']['version']}"
+  link extended_node_dir do
+    to current_node_dir
+    only_if do
+      extended_node_dir != current_node_dir
+    end
+  end
+
+end
+
+cookbook_file '/etc/env.d/93node' do
+  owner 'root'
+  group 'root'
+  source '93node'
+  mode 0644
+  only_if do
+    File.directory?('/opt/nodejs/current/bin')
+  end
+end
+
+execute "env-update" do
+  command "env-update"
+end
+
+# Leave a .json with the node versions we provide
+["/opt" "/opt/nodejs"].each do |dir|
+  directory dir do
+    owner 'root'
+    group 'root'
+    mode 0755
+    recursive true
+  end
+end
+
+directory "/opt/nodejs" do
+  action :create
+end
+
+managed_template "/opt/nodejs/nodejs_available_versions.json" do
+  owner 'root'
+  group 'root'
+  source "nodejs_available_versions.json.erb"
+  mode 0644
+  variables({
+    :nodejs  => node['nodejs']
+  })
+end
+
+# Install yarn. YT-CC-1132.
+package 'sys-apps/yarn' do
+  version '0.27.5'
+end
+
+if node.engineyard.environment.component?('nodejs')
+  include_recipe "node::ey_node_app_info"
+end


### PR DESCRIPTION
Description of your patch
-------------
Adds a port of the [stable-v4 custom_nodejs](https://github.com/engineyard/ey-cloud-recipes/tree/master/cookbooks/custom_nodejs) recipe to allow versions of Node.js outside of portage on the v5 stack.

Recommended Release Notes
-------------
Allows the customisation of installed Node.js version outside of those offered in the environment configuration page.

Estimated risk
-------------
Low - custom recipe only used by those requiring it.

Components involved
-------------
This recipe and an overlay of the `common.rb` in the main `node` recipe.

Description of testing done
-------------
v5 instance booted, recipe enabled, versions 10.13 and 12.18 of node set in the attributes and successfully installed. Recipe disabled but `common.rb` overlay left in place to ensure normal node installation worked successfully. Recipe and overlay removed to ensure that dashboard set version of Node is installed and is changeable via edit environment page.

QA Instructions
-------------
A new environment should be booted with the overlay in place but the recipe disabled. Then the recipe should be enabled and a custom version set, then new instances booted into the environment to ensure that new instances configure successfully.