### PR TITLE
[FB-2824] fixes nodeJS version failing on newly booted instance

### DIFF
--- a/custom-cookbooks/custom_nodejs/cookbooks/node/recipes/common.rb
+++ b/custom-cookbooks/custom_nodejs/cookbooks/node/recipes/common.rb
@@ -75,7 +75,7 @@ end
  end
 
 # For use with custom_nodejs recipe, ensures that the following only runs for non-custom nodejs installs
-currently_installed_node = `node -v`.strip.gsub("v","")
+currently_installed_node = `node -v`.strip.gsub("v","") if File.exists?("/usr/bin/node")
 
 if ( node['nodejs']['available_versions'].include? currently_installed_node ) || (currently_installed_node == nil)
 


### PR DESCRIPTION
Description of your patch
Fixes issue of instance failing to boot with custom NodeJS version

Recommended Release Notes
Fixes custom NodeJS

Estimated risk
Low - custom recipe only used by those requiring it.

Components involved
This recipe and an overlay of the common.rb in the main node recipe.

Description of testing done
v5 instance booted, recipe enabled, versions 10.13 and 12.18 of node set in the attributes and successfully installed. Recipe disabled but common.rb overlay left in place to ensure normal node installation worked successfully. Recipe and overlay removed to ensure that dashboard set version of Node is installed and is changeable via edit environment page.
booted new instance on environment and ensured it booted up successfully 

QA Instructions
A new environment should be booted with the overlay in place but the recipe disabled. Then the recipe should be enabled and a custom version set, then new instances booted into the environment to ensure that new instances configure successfully.