### PR TITLE
Sidekiq: Pass count through to yml file generator

### DIFF
--- a/cookbooks/sidekiq/recipes/setup.rb
+++ b/cookbooks/sidekiq/recipes/setup.rb
@@ -55,7 +55,7 @@ if node['sidekiq']['is_sidekiq_instance']
         mode 0644
         source "sidekiq.yml.erb"
         backup false
-        variables(node['sidekiq'])
+        variables(node['sidekiq'].merge(count: count))
         notifies :run, "execute[restart-sidekiq-for-#{app_name}]"
       end
     end


### PR DESCRIPTION
This allows us to dynamically set which queues to use in sidekiq.yml based on # of workers and the current count

```erb
---
:verbose: <%= @verbose %>
<% if @workers > 1 %>
<%# When there is more than one worker, the last one gets one thread reserved for %>
<%# low jobs and the rest of the threads divided up among the remaining jobs %>
<% if (@count + 1) < @workers %>
:concurrency: <%= (@concurrency / (@workers - 1)).ceil %>
:queues:
  - high
  - mailers
  - default
<% else %>
:concurrency: 1
:queues:
  - low
<% end %>
<% else %>
:concurrency: <%= (@concurrency / @workers).ceil %>
:queues:
  - high
  - mailers
  - default
  - low
<% end %>
```