### PR TITLE
[FB-3898] Fixes TCP issue with ENA drivers and loadbalancers using T2 instances

### DIFF
--- a/cookbooks/haproxy/recipes/default.rb
+++ b/cookbooks/haproxy/recipes/default.rb
@@ -2,6 +2,10 @@ ey_cloud_report "haproxy" do
   message 'processing haproxy'
 end
 
+execute 'fix_loadbalancers' do
+  command 'ethtool -K eth0 sg on'
+end
+
 # We do the configure first so we get the correct config.
 # The install recipe expects to be called second
 # and will likely fail on clean instances if it's put first

--- a/cookbooks/haproxy/recipes/default.rb
+++ b/cookbooks/haproxy/recipes/default.rb
@@ -3,7 +3,7 @@ ey_cloud_report "haproxy" do
 end
 
 execute 'fix_loadbalancers' do
-  command 'ethtool -K eth0 sg on'
+  command 'ethtool -K eth0 tso on sg on'
 end
 
 # We do the configure first so we get the correct config.


### PR DESCRIPTION
**Description of your patch**

Enables a setting on ethernet to ensure AWS load balancers work correctly

**Recommended Release Notes**
AWS loadbalancer fix

**Estimated risk**
Medium

**Components involved**
haproxy

**Description of testing done**
See QA instructions

**QA Instructions**

* Create an AWS load balancer 
* Set up health checks for http
* Boot a T2 instance
* Deploy an application that is accessible by http
* Try and connect by load balancer make sure it doesn't return 503
* Check load balancer health in console
