### PR TITLE
[FB-3945] Update custom-sidekiq README

### DIFF
--- a/custom-cookbooks/sidekiq/cookbooks/custom-sidekiq/README.md
+++ b/custom-cookbooks/sidekiq/cookbooks/custom-sidekiq/README.md
@@ -92,6 +92,8 @@ Sidekiq.configure_client do |config|
 end
 ``` 
 
+Note: The use of `:namespace` requires the usage of the redis-namespace gem.
+
 The reference to the Redis instance works because the Redis recipe adds a `redis-instance` entry in `/etc/hosts`.
 
 More information on setting the location of your server can be found at: 
@@ -170,7 +172,7 @@ hook similar to:
       sudo "monit -g #{config.app}_sidekiq restart all"
     end
 
-On the other hand, if you'r running Sidekiq on a dedicated utility instance, the
+On the other hand, if you're running Sidekiq on a dedicated utility instance, the
 deploy hook should be like:
 
     on_utilities("sidekiq") do

--- a/custom-cookbooks/sidekiq/cookbooks/custom-sidekiq/README.md
+++ b/custom-cookbooks/sidekiq/cookbooks/custom-sidekiq/README.md
@@ -173,7 +173,7 @@ hook similar to:
 On the other hand, if you'r running Sidekiq on a dedicated utility instance, the
 deploy hook should be like:
 
-    on_utilities :sidekiq do
+    on_utilities("sidekiq") do
       sudo "monit -g #{config.app}_sidekiq restart all"
     end
 


### PR DESCRIPTION
Description of your patch
-------------

Updates the custom-sidekiq readme to correct the way the instance name is specified in the deploy hook from a non-working symbol to a working string.
Also adds to the readme the requirement to use the redis-namespace gem.

Recommended Release Notes
-------------

None needed.

Estimated risk
-------------

Zero, is just a readme change.

Components involved
-------------

The custom_sidekiq recipe.

Description of testing done
-------------

Re-read the README.

QA Instructions
-------------

None needed.