### PR TITLE
[FB-6312] Fix New Relic Infra untar command

### DIFF
--- a/cookbooks/newrelic_infra/recipes/default.rb
+++ b/cookbooks/newrelic_infra/recipes/default.rb
@@ -41,7 +41,7 @@ execute "Extract deb file" do
 end
 
 execute "Install data.tar.gz" do
-  command "tar zxvf #{local_tar_path} -C /"
+  command "tar zxvfh #{local_tar_path} -C /"
   cwd local_work_path
   user "root"
   action :run


### PR DESCRIPTION
Description of your patch
-------------
Updates the `newrelic_infra` default recipe to follow symlinks when untarring the agent package and thus avoid replacing the `/var/run` to `/run` symlink with a directory, which would result in all PIDs being lost.

Recommended Release Notes
-------------
Fixes an issue with the New Relic Infrastructure recipe that could result in the loss of the `run` directory contents and impact the running of services for customers who upgraded the agent version.

Estimated risk
-------------
Low, makes a simple change to the extraction of an archive and only impacts those customers who manually change the version to be installed.

Components involved
-------------
The `newrelic_infra` cookbook.

Description of testing done
-------------
Manually tested a download and extraction of the package and confirmed that `-h` prevents the `/var/run` symlink being lost whilst still copying out the contents of the archive.

QA Instructions
-------------
Enable the `custom-newrelic_infra` cookbook on an environment and update https://github.com/engineyard/ey-cookbooks-stable-v5/blob/next-release/custom-cookbooks/newrelic_infra/cookbooks/custom-newrelic_infra/attributes/default.rb to a version such as `1.1.9_sysv` that includes `/var/run` in the package. Boot an instance that has `/var/run` as a symlink to `/run` and confirm that after Chef has run that this is still a symlink and that `/usr/bin/newrelic-infra -version` confirms the upgraded version is installed.
Probably also test on an instance type where `/var/run` is not a symlink, but I can't see how that would fail, as it works fine currently copying files to the other directories in the package that are not symlinks.