### PR TITLE
[FB-9088] Updates certificates and moves it to a better location

### DIFF
--- a/cookbooks/ey-base/recipes/bootstrap.rb
+++ b/cookbooks/ey-base/recipes/bootstrap.rb
@@ -139,22 +139,6 @@ execute "remove framework_env from /etc/profile" do
 end
 
 
-# TODO: move to security-updates or its own recipe
-# Upgrade ca-certificates to the newest bundle.
-enable_package "app-misc/ca-certificates" do
-  version "20140325-r1 ~amd64"
-end
-
-package "app-misc/ca-certificates" do
-  version "20140325-r1"
-  action :upgrade
-end
-
-execute "update-ca-certificates --fresh" do
- action :nothing
- subscribes :run, 'package[app-misc/ca-certificates]', :delayed
-end
-
 # all roles get these recipes
 include_recipe 'ey-cron'
 include_recipe "ey-env"

--- a/cookbooks/security_updates/recipes/default.rb
+++ b/cookbooks/security_updates/recipes/default.rb
@@ -67,3 +67,16 @@ end
 package 'dev-vcs/git' do
   version '2.7.3-r4'
 end
+
+enable_package 'app-misc/ca-certificates' do
+  version '20210119.3.66'
+end
+
+package 'app-misc/ca-certificates' do
+  version '20210119.3.66'
+end
+
+execute "update-ca-certificates --fresh" do
+ action :nothing
+ subscribes :run, 'package[app-misc/ca-certificates]', :delayed
+end


### PR DESCRIPTION
Description of your patch
-------------
1. Adds `ca-certificates` package to chef to keep certificates up to date

Recommended Release Notes
-------------
Updated system certificates

Estimated risk
-------------
Moderate/High - Is required to avoid errors with external sources using X1 LetsEncrypt

Components involved
-------------
1. `security` chef recipe 
2. `ey-base` chef recipe 

Dependencies
-------------
None

Description of testing done
-------------
* Created environment
* Booted up solo instance
* Run eix ca-certificates 
* curled letsencrypt based website



QA Instructions
-------------

* Create environment any configuratiin
* Boot up instances either solo or multi-instances
* Ensure chef runs correctly and entirely
* SSH into instance
* run eix ca-certificates
* curl / openssl connect to any website that runs a letsencrypt certificate 