### PR TITLE
[FB-9088] Updates certificates and moves it to a better location

### DIFF
--- a/cookbooks/security_updates/recipes/default.rb
+++ b/cookbooks/security_updates/recipes/default.rb
@@ -74,6 +74,7 @@ end
 
 package 'app-misc/ca-certificates' do
   version '20210119.3.66'
+  action :upgrade
 end
 
 execute "update-ca-certificates --fresh" do


### PR DESCRIPTION
Description of your patch
-------------
1. Adds `ca-certificates` package to chef to keep certificates up to date

The is an update to PR #471 due to it not updating on live running instances

Recommended Release Notes
-------------
Updated system certificates

Estimated risk
-------------
Moderate/High - Is required to avoid errors with external sources using X1 LetsEncrypt

Components involved
-------------
1. `security` chef recipe 
2. `ey-base` chef recipe 

Dependencies
-------------
None

Description of testing done
-------------
* Created environment
* Booted up solo instance
* Run eix ca-certificates 
* curled letsencrypt based website



QA Instructions
-------------

* Create environment any configuratiin
* Boot up instances either solo or multi-instances
* Ensure chef runs correctly and entirely
* SSH into instance
* run eix ca-certificates
* curl / openssl connect to any website that runs a letsencrypt certificate 