### PR TITLE
Source env.cloud in node start script

### DIFF
--- a/cookbooks/node/templates/default/build_node_app_environment.erb
+++ b/cookbooks/node/templates/default/build_node_app_environment.erb
@@ -105,6 +105,7 @@ possible_commands.each do |command|
 #!/bin/sh
 source #{config_dir}/env
 source #{config_dir}/env.custom
+source #{config_dir}/env.cloud
 cd #{current_dir}
 exec #{npm_command}
       SCRIPT


### PR DESCRIPTION
It seems that the default node start script that gets generated does not source from the environment variables set in the EY Cloud UI (just env and env.custom)

This adds `env.cloud` as a source before running the start script.